### PR TITLE
WIP: Soft deletes

### DIFF
--- a/src/Lucid/Model/Traits/SoftDelete.js
+++ b/src/Lucid/Model/Traits/SoftDelete.js
@@ -1,0 +1,84 @@
+'use strict'
+
+const Database = use('Database')
+
+class SoftDelete {
+  register (Model) {
+    Model.addGlobalScope(
+      query => {
+        query.whereNull('deleted_at')
+      },
+      'soft_deletes'
+    )
+
+    Model.prototype.delete = async function ({ force = false } = {}) {
+      await this.constructor.$hooks.before.exec('delete', this)
+
+      const now = new Date()
+      const query = Database.table(this.constructor.table)
+        .where(this.constructor.primaryKey, this.primaryKeyValue)
+
+      const updatePromise = force
+        ? query.delete()
+        : query.update({ deleted_at: now })
+
+      const affected = await updatePromise
+
+      if (affected > 0) {
+        // this attribute will be marked as `dirty`
+        this.set('deleted_at', force ? null : now)
+        this.freeze()
+      }
+
+      await this.constructor.$hooks.after.exec('delete', this)
+
+      return !!affected
+    }
+
+    Model.prototype.restore = async function (trx) {
+      await this.constructor.$hooks.before.exec('restore', this)
+
+      const affected = await Database.table(this.constructor.table)
+        .transacting(trx)
+        .where(this.constructor.primaryKey, this.primaryKeyValue)
+        .update({ deleted_at: null })
+
+      if (affected > 0) {
+        this.$frozen = false
+
+        // this attribute will be marked as `dirty`
+        this.set('deleted_at', null)
+      }
+
+      await this.constructor.$hooks.after.exec('restore', this)
+
+      return !!affected
+    }
+
+    /**
+     * Assume that model is always in non-deleted state.
+     * It's easier to work this way with models state.
+     *
+     * And if you wonder if that's safe, well - not really.
+     */
+    Object.defineProperty(Model.prototype, 'isDeleted', {
+      get () {
+        return false
+      }
+    })
+
+    Object.defineProperty(Model.prototype, 'isTrashed', {
+      get () {
+        return !!this.$attributes.deleted_at
+      }
+    })
+
+    Object.defineProperty(Model.prototype, 'wasTrashed', {
+      get () {
+        return this.isAttributeDirty('deleted_at') && !this.isTrashed
+      }
+    })
+  }
+}
+
+module.exports = SoftDelete


### PR DESCRIPTION
In my recent project, I had to add support for soft deletes in models.
I thought that it could be a good starting point for #257.

I decided to create a PR to start a discussion whether this approach is correct. If yes - I can write missing parts.

For now, there's nothing much - just a trait I wrote in my project. 

---

Changed behavior:

* `delete()` by default sets `deleted_at` timestamp (trashes model); it accepts object with `force` option, when set model will be removed
* `isTrashed` attribute returns always `false` - it's a hack, should be removed
* add global scope which excludes models with `deleted_at` property set

Added behavior:

* `restore()` unsets `deleted_at` which marks model as non-trashed
* `isTrashed` property
* `wasTrashed` - returns `TRUE` if `deleted_at` changed to `null`

Things to consider:

* deleting model triggers `delete` hooks; maybe there should be `trash` hook?
  * if we decide to add `trash` hook `wasTrashed` property could be removed
* I'm not sure how `isDeleted` property should behave. I've hardcoded `false` because it allowed me to work with the models internal state. Otherwise, I should change few things in Lucid internals, can't remember what it was exactly...

TODO:

* [ ] add test suite
* [ ] add `withTrashed` query scope
* [ ] allow to define deleted column name (`static get deletedAtColumn()`)
* [ ] `softDeletes()` helper method for schema migration
