### PR TITLE
feat(validation): add case sensitive option for unique validation rule

### DIFF
--- a/src/Validator/index.js
+++ b/src/Validator/index.js
@@ -1,12 +1,11 @@
 'use strict'
-
 /*
- * adonis-lucid
- *
- * (c) Harminder Virk <virk@adonisjs.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
+  * adonis-lucid
+  *
+  * (c) Harminder Virk <virk@adonisjs.com>
+  *
+  * For the full copyright and license information, please view the LICENSE
+  * file that was distributed with this source code.
 */
 
 /**
@@ -37,6 +36,8 @@ class ValidatorRules {
    * email: 'unique:users' // define table
    * email: 'unique:users,user_email' // define table + field
    * email: 'unique:users,user_email,id:1' // where id !== 1
+   * email: 'unique:users,user_email,caseSensitive'
+   * email: 'unique:users,user_email,id:1,caseSensitive
    *
    * // Via new rule method
    * email: [rule('unique', ['users', 'user_email', 'id', 1])]
@@ -58,12 +59,21 @@ class ValidatorRules {
       /**
        * Extracting values of the args array
        */
-      const [ table, fieldName, ignoreKey, ignoreValue ] = args
+      const [ table, fieldName, ignoreKey, ignoreValue, caseSensitivity ] = args
+      let caseSensitivityOnThird
+      if (args.length === 3) {
+        caseSensitivityOnThird = ignoreKey
+      }
 
       /**
        * Base query to select where key=value
        */
-      const query = this.Database.table(table).where(fieldName || field, value)
+      let query = ''
+      if (caseSensitivity || caseSensitivityOnThird) {
+        query = this.Database.table(table).whereRaw(`LOWER(${fieldName || field}) = ?`, [value.toLowerCase()])
+      } else {
+        query = this.Database.table(table).where(fieldName || field, value)
+      }
 
       /**
        * If a ignore key and value is defined, then add a whereNot clause

--- a/test/unit/validation-rules.spec.js
+++ b/test/unit/validation-rules.spec.js
@@ -47,6 +47,17 @@ test.group('Validator | Unique', (group) => {
     assert.equal(result, 'validation passed')
   })
 
+  test('throw error when row is found with case sensitivity as third argument', async (assert) => {
+    assert.plan(1)
+    const validator = new Validator(this.database)
+    await this.database.table('users').insert({ username: 'foo' })
+    try {
+      await validator.unique({ username: 'Foo' }, 'username', message, ['users', 'username', 'caseSensitivity'], _.get)
+    } catch (error) {
+      assert.equal(error, 'unique validation failed')
+    }
+  })
+
   test('skip validation when data does not have field', async (assert) => {
     const validator = new Validator(this.database)
     const result = await validator.unique({}, 'email', message, ['users'], _.get)
@@ -70,5 +81,16 @@ test.group('Validator | Unique', (group) => {
     const args = ['users', 'username', 'id', 1]
     const result = await validator.unique({ username: 'foo' }, 'username', message, args, _.get)
     assert.equal(result, 'validation passed')
+  })
+
+  test('throw error on validation when row is not found with case sensitivity and when whereNot key/value pairs are passed', async (assert) => {
+    assert.plan(1)
+    const validator = new Validator(this.database)
+    await this.database.table('users').insert({ username: 'foo' })
+    try {
+      await validator.unique({ username: 'Foo' }, 'username', message, ['users', 'username', 'id', 5, 'caseSensitivity'], _.get)
+    } catch (error) {
+      assert.equal(error, 'unique validation failed')
+    }
   })
 })


### PR DESCRIPTION
## Proposed changes

As mentionned in #419, unique validation is working correctly when we talk about emails. This PR adds a `caseSensitivity` argument to the `unique` validator to allow to ensure that `foo@bar.com` !== `Foo@Bar.com`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-lucid/blob/develop/CONTRIBUTING.md) doc **dead link**
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [] I have added necessary documentation (if appropriate)

## Further comments

Please let me know if this PR is a satisfying solution or if it is not. I'll PR the documentation asap.