### PR TITLE
Allow nested transactions when global transaction is in place

### DIFF
--- a/src/Database/index.js
+++ b/src/Database/index.js
@@ -178,12 +178,14 @@ class Database {
    * ```
    */
   beginTransaction () {
+    if (this._globalTrx) {
+      return new Promise((resolve, reject) => {
+        this._globalTrx.transaction(resolve).catch(() => {})
+      })
+    }
+
     return new Promise((resolve, reject) => {
-      this
-        .knex
-        .transaction(function (trx) {
-          resolve(trx)
-        }).catch(() => {})
+      this.knex.transaction(resolve).catch(() => {})
     })
   }
 

--- a/test/unit/database.spec.js
+++ b/test/unit/database.spec.js
@@ -127,6 +127,16 @@ test.group('Database | QueryBuilder', (group) => {
     assert.lengthOf(users, 1)
   })
 
+  test('create nested transaction (savepoint) when global transaction is in place', async (assert) => {
+    await this.database.beginGlobalTransaction()
+    await this.database.table('users').insert({ username: 'michael' })
+    const trx = await this.database.beginTransaction()
+    await trx.table('users').where({ username: 'michael' }).update({ username: 'virk' })
+    await this.database.commitGlobalTransaction()
+    const firstUser = await this.database.table('users').first()
+    assert.equal(firstUser.username, 'virk')
+  })
+
   test('destroy database connection', async (assert) => {
     await this.database.close()
     assert.plan(1)

--- a/test/unit/database.spec.js
+++ b/test/unit/database.spec.js
@@ -129,12 +129,11 @@ test.group('Database | QueryBuilder', (group) => {
 
   test('create nested transaction (savepoint) when global transaction is in place', async (assert) => {
     await this.database.beginGlobalTransaction()
-    await this.database.table('users').insert({ username: 'michael' })
     const trx = await this.database.beginTransaction()
-    await trx.table('users').where({ username: 'michael' }).update({ username: 'virk' })
-    await this.database.commitGlobalTransaction()
-    const firstUser = await this.database.table('users').first()
-    assert.equal(firstUser.username, 'virk')
+    await this.database.table('users').insert({ username: 'michael' }, trx)
+    await trx.commit()
+    await this.database.rollbackGlobalTransaction()
+    assert.isUndefined(await this.database.table('users').first())
   })
 
   test('destroy database connection', async (assert) => {


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

The fix addresses the following issue https://github.com/adonisjs/adonis-vow/issues/22.
I also had issues on my own, where I would get `Error: Test timeout, ensure "done()" is called; if returning a Promise, ensure it resolves.`  in some places.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-lucid/blob/develop/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Ideally `beginTransaction` would just be

```javascript
if (this._globalTrx) {
   return this._globalTrx.transaction()
}

return this.knex.transaction()
```

but I think the knex version first has to be updated to include this fix here https://github.com/knex/knex/pull/3393
