### PR TITLE
fix(queryBuilder): make sure withCount doesn't merge pivot table columns when call from belongsToMany eager loaded relationships

### DIFF
--- a/src/Lucid/QueryBuilder/index.js
+++ b/src/Lucid/QueryBuilder/index.js
@@ -87,7 +87,7 @@ class QueryBuilder {
     this.Model = Model
     this.connectionString = connection
 
-    const table = this.Model.prefix ? `${this.Model.prefix}${this.Model.table}` : this.Model.table
+    this.modelTable = this.Model.prefix ? `${this.Model.prefix}${this.Model.table}` : this.Model.table
 
     /**
      * Reference to database provider
@@ -97,7 +97,7 @@ class QueryBuilder {
     /**
      * Reference to query builder with pre selected table
      */
-    this.query = this.db.table(table)
+    this.query = this.db.table(this.modelTable)
 
     /**
      * SubQuery to be pulled off the query builder. For now this is
@@ -882,7 +882,7 @@ class QueryBuilder {
      * Add `*` to columns only when there are no existing columns selected
      */
     if (!_.find(this.query._statements, (statement) => statement.grouping === 'columns')) {
-      columns.push('*')
+      columns.push(`${this.modelTable}.*`)
     }
 
     columns.push(relationInstance.relatedWhere(true, this._withCountCounter).as(asStatement))

--- a/test/unit/helpers/index.js
+++ b/test/unit/helpers/index.js
@@ -206,6 +206,23 @@ module.exports = {
         table.integer('team_party_id')
         table.integer('user_party_id')
         table.timestamps()
+      }),
+      db.schema.createTable('professionals', function (table) {
+        table.increments('id')
+        table.string('name')
+        table.timestamps()
+      }),
+      db.schema.createTable('companies', function (table) {
+        table.increments('id')
+        table.string('employer')
+        table.timestamps()
+      }),
+      db.schema.createTable('company_professional', function (table) {
+        table.increments('id')
+        table.integer('company_id')
+        table.integer('professional_id')
+        table.integer('is_accepted')
+        table.timestamps()
       })
     ]))
   },
@@ -228,7 +245,10 @@ module.exports = {
       db.schema.dropTable('followers'),
       db.schema.dropTable('party_users'),
       db.schema.dropTable('teams'),
-      db.schema.dropTable('team_user')
+      db.schema.dropTable('team_user'),
+      db.schema.dropTable('professionals'),
+      db.schema.dropTable('companies'),
+      db.schema.dropTable('company_professional')
     ])
   },
 

--- a/test/unit/lucid-belongs-to.spec.js
+++ b/test/unit/lucid-belongs-to.spec.js
@@ -283,7 +283,7 @@ test.group('Relations | Belongs To', (group) => {
 
     const picture = await Picture.query().withCount('profile').first()
     assert.deepEqual(picture.$sideLoaded, { profile_count: helpers.formatNumber(1) })
-    assert.equal(pictureQuery.sql, helpers.formatQuery('select *, (select count(*) from "profiles" where "pictures"."profile_id" = "profiles"."id") as "profile_count" from "pictures" limit ?'))
+    assert.equal(pictureQuery.sql, helpers.formatQuery('select "pictures".*, (select count(*) from "profiles" where "pictures"."profile_id" = "profiles"."id") as "profile_count" from "pictures" limit ?'))
   })
 
   test('filter parent via has clause', async (assert) => {
@@ -795,7 +795,7 @@ test.group('Relations | Belongs To', (group) => {
 
     const results = await User.query().withCount('manager').fetch()
 
-    const expectedQuery = 'select *, (select count(*) from "users" as "sj_0" where "users"."manager_id" = "sj_0"."id") as "manager_count" from "users"'
+    const expectedQuery = 'select "users".*, (select count(*) from "users" as "sj_0" where "users"."manager_id" = "sj_0"."id") as "manager_count" from "users"'
 
     assert.equal(results.first().$sideLoaded.manager_count, 0)
     assert.equal(results.last().$sideLoaded.manager_count, 1)
@@ -835,7 +835,7 @@ test.group('Relations | Belongs To', (group) => {
 
     const results = await User.query().withCount('manager').withCount('lead').fetch()
 
-    const expectedQuery = 'select *, (select count(*) from "users" as "sj_0" where "users"."manager_id" = "sj_0"."id") as "manager_count", (select count(*) from "users" as "sj_1" where "users"."lead_id" = "sj_1"."id") as "lead_count" from "users"'
+    const expectedQuery = 'select "users".*, (select count(*) from "users" as "sj_0" where "users"."manager_id" = "sj_0"."id") as "manager_count", (select count(*) from "users" as "sj_1" where "users"."lead_id" = "sj_1"."id") as "lead_count" from "users"'
 
     assert.equal(results.first().$sideLoaded.manager_count, 0)
     assert.equal(results.first().$sideLoaded.lead_count, 0)
@@ -897,7 +897,7 @@ test.group('Relations | Belongs To', (group) => {
 
     await Car.query().withCount('user').fetch()
 
-    assert.equal(carQuery.sql, helpers.formatQuery('select *, (select count(*) from "users" where "cars"."user_id" = "users"."id" and "users"."deleted_at" is null) as "user_count" from "cars"'))
+    assert.equal(carQuery.sql, helpers.formatQuery('select "cars".*, (select count(*) from "users" where "cars"."user_id" = "users"."id" and "users"."deleted_at" is null) as "user_count" from "cars"'))
   })
 
   test('apply global scope on related model when called has', async (assert) => {

--- a/test/unit/lucid-has-many.spec.js
+++ b/test/unit/lucid-has-many.spec.js
@@ -475,7 +475,7 @@ test.group('Relations | Has Many', (group) => {
 
     const user = await User.query().withCount('cars').first()
     assert.deepEqual(user.$sideLoaded, { cars_count: helpers.formatNumber(2) })
-    assert.equal(userQuery.sql, helpers.formatQuery('select *, (select count(*) from "cars" where "users"."id" = "cars"."user_id") as "cars_count" from "users" limit ?'))
+    assert.equal(userQuery.sql, helpers.formatQuery('select "users".*, (select count(*) from "cars" where "users"."id" = "cars"."user_id") as "cars_count" from "users" limit ?'))
   })
 
   test('filter parent based upon child', async (assert) => {
@@ -1040,7 +1040,7 @@ test.group('Relations | Has Many', (group) => {
 
     const results = await User.query().withCount('teamMembers').fetch()
 
-    const expectedQuery = 'select *, (select count(*) from "users" as "sj_0" where "users"."id" = "sj_0"."manager_id") as "teamMembers_count" from "users"'
+    const expectedQuery = 'select "users".*, (select count(*) from "users" as "sj_0" where "users"."id" = "sj_0"."manager_id") as "teamMembers_count" from "users"'
 
     assert.equal(results.first().$sideLoaded.teamMembers_count, 2)
     assert.equal(results.rows[1].$sideLoaded.teamMembers_count, 0)
@@ -1096,7 +1096,7 @@ test.group('Relations | Has Many', (group) => {
 
     await User.query().withCount('cars').fetch()
 
-    assert.equal(userQuery.sql, helpers.formatQuery('select *, (select count(*) from "cars" where "users"."id" = "cars"."user_id" and "cars"."deleted_at" is null) as "cars_count" from "users"'))
+    assert.equal(userQuery.sql, helpers.formatQuery('select "users".*, (select count(*) from "cars" where "users"."id" = "cars"."user_id" and "cars"."deleted_at" is null) as "cars_count" from "users"'))
   })
 
   test('apply global scope on related model when called has', async (assert) => {

--- a/test/unit/lucid-relations.spec.js
+++ b/test/unit/lucid-relations.spec.js
@@ -1051,7 +1051,7 @@ test.group('Relations | HasOne', (group) => {
     assert.equal(users.size(), 2)
     assert.equal(users.first().profile_count, 1)
     assert.deepEqual(users.first().$sideLoaded, { profile_count: helpers.formatNumber(1) })
-    assert.equal(userQuery.sql, helpers.formatQuery('select *, (select count(*) from "profiles" where "users"."id" = "profiles"."user_id") as "profile_count" from "users"'))
+    assert.equal(userQuery.sql, helpers.formatQuery('select "users".*, (select count(*) from "profiles" where "users"."id" = "profiles"."user_id") as "profile_count" from "users"'))
   })
 
   test('return relation count with paginate method', async (assert) => {
@@ -1077,7 +1077,7 @@ test.group('Relations | HasOne', (group) => {
     assert.equal(users.size(), 2)
     assert.equal(users.first().profile_count, 1)
     assert.deepEqual(users.first().$sideLoaded, { profile_count: helpers.formatNumber(1) })
-    assert.equal(userQuery.sql, helpers.formatQuery('select *, (select count(*) from "profiles" where "users"."id" = "profiles"."user_id") as "profile_count" from "users" limit ?'))
+    assert.equal(userQuery.sql, helpers.formatQuery('select "users".*, (select count(*) from "profiles" where "users"."id" = "profiles"."user_id") as "profile_count" from "users" limit ?'))
   })
 
   test('return relation with paginate method', async (assert) => {
@@ -1130,7 +1130,7 @@ test.group('Relations | HasOne', (group) => {
     assert.equal(users.size(), 2)
     assert.equal(users.first().my_profile, 1)
     assert.deepEqual(users.first().$sideLoaded, { my_profile: helpers.formatNumber(1) })
-    assert.equal(userQuery.sql, helpers.formatQuery('select *, (select count(*) from "profiles" where "users"."id" = "profiles"."user_id") as "my_profile" from "users"'))
+    assert.equal(userQuery.sql, helpers.formatQuery('select "users".*, (select count(*) from "profiles" where "users"."id" = "profiles"."user_id") as "my_profile" from "users"'))
   })
 
   test('define callback with withCount', async (assert) => {
@@ -1158,7 +1158,7 @@ test.group('Relations | HasOne', (group) => {
     assert.equal(users.size(), 2)
     assert.equal(users.first().profile_count, 0)
     assert.deepEqual(users.first().$sideLoaded, { profile_count: helpers.formatNumber(0) })
-    assert.equal(userQuery.sql, helpers.formatQuery('select *, (select count(*) from "profiles" where "likes" > ? and "users"."id" = "profiles"."user_id") as "profile_count" from "users"'))
+    assert.equal(userQuery.sql, helpers.formatQuery('select "users".*, (select count(*) from "profiles" where "likes" > ? and "users"."id" = "profiles"."user_id") as "profile_count" from "users"'))
   })
 
   test('throw exception when trying to call withCount with nested relations', async (assert) => {
@@ -1216,7 +1216,7 @@ test.group('Relations | HasOne', (group) => {
     assert.equal(users.first().getRelated('profile').picture_count, helpers.formatNumber(1))
     assert.deepEqual(users.first().getRelated('profile').$sideLoaded, { picture_count: helpers.formatNumber(1) })
     assert.equal(userQuery.sql, helpers.formatQuery('select * from "users"'))
-    assert.equal(profileQuery.sql, helpers.formatQuery('select *, (select count(*) from "pictures" where "profiles"."id" = "pictures"."profile_id") as "picture_count" from "profiles" where "profiles"."user_id" in (?, ?)'))
+    assert.equal(profileQuery.sql, helpers.formatQuery('select "profiles".*, (select count(*) from "pictures" where "profiles"."id" = "pictures"."profile_id") as "picture_count" from "profiles" where "profiles"."user_id" in (?, ?)'))
   })
 
   test('eagerload when calling first', async (assert) => {
@@ -1700,7 +1700,7 @@ test.group('Relations | HasOne', (group) => {
 
     await User.query().withCount('profile').fetch()
 
-    assert.equal(userQuery.sql, helpers.formatQuery('select *, (select count(*) from "profiles" where "users"."id" = "profiles"."user_id" and "profiles"."deleted_at" is null) as "profile_count" from "users"'))
+    assert.equal(userQuery.sql, helpers.formatQuery('select "users".*, (select count(*) from "profiles" where "users"."id" = "profiles"."user_id" and "profiles"."deleted_at" is null) as "profile_count" from "users"'))
   })
 
   test('apply global scope on related model when called has', async (assert) => {


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

When calling `withCount` from within an eager loaded relationship it shouldn't merge the pivot table columns on the said eager loaded relation object.

For example, here we are fetching a user with his companies and each company will have their total count of users. 

```js
const user = User
    .query()
    .with('companies', b => b.withCount('users'))
    .first()
```

When doing so, all columns from the pivot table will get merge automatically on each company.

```js
user.toJSON().companies = [
  {
    "id": 1,
    "employer": "Name of employer",
    "created_at": null,
    "updated_at": null,
+    "company_id": 1,
+    "user_id": 2,
    "pivot": {
      "company_id": 1,
      "user_id": 2
    },
    "__meta__": {
      "users_count": 2
    }
  }
]

```

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-lucid/blob/master/CONTRIBUTING.md) doc (broken link 404)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
