### PR TITLE
fix(Model): merge method use forIn instead of each

### DIFF
--- a/src/Lucid/Model/Base.js
+++ b/src/Lucid/Model/Base.js
@@ -312,7 +312,7 @@ class BaseModel {
    * @return {void}
    */
   merge (attributes) {
-    _.each(attributes, (value, key) => this.set(key, value))
+    _.forIn(attributes, (value, key) => this.set(key, value))
   }
 
   /**


### PR DESCRIPTION
Hey 👋 

As state in the [Lodash documentation](https://lodash.com/docs/4.17.15#forEach), collections with a `length` property will be treated as array.

We need to use `_.forIn` instead to fix the issue.

> **Note**: As with other "Collections" methods, objects with a "length" property are iterated like arrays. To avoid this behavior use _.forIn or _.forOwn for object iteration.

Closing: https://github.com/adonisjs/lucid/issues/488