### PR TITLE
Changed status description as outlined in #547

### DIFF
--- a/commands/Migration/Status.ts
+++ b/commands/Migration/Status.ts
@@ -22,7 +22,7 @@ import MigrationsBase from './Base'
 @inject([null, null, 'Adonis/Lucid/Database'])
 export default class Status extends MigrationsBase {
   public static commandName = 'migration:status'
-  public static description = 'Drop existing tables and re-run migrations from start'
+  public static description = 'Check migrations current status'
 
   /**
    * Define custom connection


### PR DESCRIPTION
Migration status command description changed as before it was indicating it is going to re-run migrations rather than checking the status of it