### PR TITLE
Adding support for Factories

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,14 +1,5 @@
 {
   "extends": [
     "plugin:adonis/typescriptPackage"
-  ],
-  "rules": {
-    "max-len": ["error", {
-      "code": 120,
-      "comments": 120,
-      "ignoreUrls": true,
-      "ignoreTemplateLiterals": true
-    }],
-    "no-redeclare": ["off"]
-  }
+  ]
 }

--- a/adonis-typings/factory.ts
+++ b/adonis-typings/factory.ts
@@ -8,6 +8,7 @@
 */
 
 declare module '@ioc:Adonis/Lucid/Factory' {
+  import faker from 'faker'
   import { OneOrMany } from '@ioc:Adonis/Lucid/DatabaseQueryBuilder'
   import { TransactionClientContract } from '@ioc:Adonis/Lucid/Database'
   import { LucidRow, LucidModel, ModelAttributes } from '@ioc:Adonis/Lucid/Model'
@@ -98,18 +99,7 @@ declare module '@ioc:Adonis/Lucid/Factory' {
    * as well.
    */
   export interface FactoryContextContract {
-    faker: {
-      lorem: {
-        sentence (count?: number): string,
-      },
-      internet: {
-        password (): string,
-      },
-    },
-    sequence: {
-      username: string,
-      email: string,
-    },
+    faker: typeof faker,
     isStubbed: boolean,
     $trx: TransactionClientContract | undefined
   }

--- a/adonis-typings/factory.ts
+++ b/adonis-typings/factory.ts
@@ -68,6 +68,26 @@ declare module '@ioc:Adonis/Lucid/Factory' {
 
   /**
    * ------------------------------------------------------
+   *  Hooks
+   * ------------------------------------------------------
+   */
+
+  /**
+   * List of events for which a factory will trigger hooks
+   */
+  export type EventsList = 'makeStubbed' | 'create' | 'make'
+
+  /**
+   * Shape of hooks handler
+   */
+  export type HooksHandler<Model extends FactoryModelContract<LucidModel>> = (
+    factory: FactoryBuilderContract<Model>,
+    model: InstanceType<Model['model']>,
+    ctx: FactoryContextContract,
+  ) => void | Promise<void>
+
+  /**
+   * ------------------------------------------------------
    *  Runtime context
    * ------------------------------------------------------
    */
@@ -188,9 +208,10 @@ declare module '@ioc:Adonis/Lucid/Factory' {
     useCtx (ctx: FactoryContextContract): this
 
     /**
-     * Create model instance.
+     * Create model instance and stub out the persistance
+     * mechanism
      */
-    make (
+    makeStubbed (
       callback?: (
         model: InstanceType<FactoryModel['model']>,
         ctx: FactoryContextContract,
@@ -208,9 +229,10 @@ declare module '@ioc:Adonis/Lucid/Factory' {
     ): Promise<InstanceType<FactoryModel['model']>>
 
     /**
-     * Create more than one model instance
+     * Create one or more model instances and stub
+     * out the persistance mechanism.
      */
-    makeMany (
+    makeStubbedMany (
       count: number,
       callback?: (
         model: InstanceType<FactoryModel['model']>,
@@ -278,6 +300,17 @@ declare module '@ioc:Adonis/Lucid/Factory' {
       relation: K,
       callback: Relation,
     ): this & { relations: { [P in K]: Relation } }
+
+    /**
+     * Define before hooks. Only `create` event is invoked
+     * during the before lifecycle
+     */
+    before (event: 'create', handler: HooksHandler<this>): this
+
+    /**
+     * Define after hooks.
+     */
+    after (event: EventsList, handler: HooksHandler<this>): this
 
     /**
      * Build model factory. This method returns the factory builder, which can be used to

--- a/adonis-typings/factory.ts
+++ b/adonis-typings/factory.ts
@@ -1,0 +1,216 @@
+/*
+* @adonisjs/lucid
+*
+* (c) Harminder Virk <virk@adonisjs.com>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+declare module '@ioc:Adonis/Lucid/Factory' {
+  import { LucidRow, LucidModel } from '@ioc:Adonis/Lucid/Model'
+  import { TransactionClientContract } from '@ioc:Adonis/Lucid/Database'
+  import { ExtractModelRelations, RelationshipsContract, ModelRelations } from '@ioc:Adonis/Lucid/Relations'
+
+  export interface FactoryStateContract {
+    faker: any,
+    isStubbed: boolean,
+    $trx: TransactionClientContract | undefined
+  }
+
+  /**
+   * Function that create a new instance of a Lucid model with
+   * the given attributes.
+   */
+  export type NewUpModelFunction<Model extends LucidModel, Attributes extends any> = (
+    state: FactoryStateContract,
+    attributes?: Attributes,
+  ) => Promise<InstanceType<Model>> | InstanceType<Model>
+
+  /**
+   * Unwraps promise
+   */
+  export type UnwrapPromise<T> = T extends PromiseLike<infer U> ? U : T
+
+  /**
+   * Extracts the model for a factory by inspecting the ReturnType of
+   * the `newUp` method
+   */
+  export type ExtractFactoryModel<
+    T extends FactoryModelContract<LucidModel, any>
+  > = UnwrapPromise<ReturnType<T['newUp']>>
+
+  /**
+   * Extracts the attributes accepted by the newUp method of a factory
+   */
+  export type ExtractFactoryAttributes<
+    T extends FactoryModelContract<LucidModel, any>
+  > = Parameters<T['newUp']>[1]
+
+  /**
+   * Callback to define a new model state
+   */
+  export type ModelStateCallback<Model extends LucidRow> = (
+    model: Model,
+    state: FactoryStateContract,
+  ) => any | Promise<any>
+
+  /**
+  * Factory builder uses the factory model to create/make
+  * instances of lucid models
+  */
+  export interface FactoryBuilderContract<FactoryModel extends FactoryModelContract<LucidModel, any>> {
+    /**
+     * Apply pre-defined state
+     */
+    apply<K extends keyof FactoryModel['states']> (...states: K[]): this
+
+    /**
+     * Create/make relationships for explicitly defined related factories
+     */
+    with<K extends keyof FactoryModel['relations']> (
+      relation: K,
+      count?: number,
+      callback?: (
+        /**
+         * Receives the explicitly defined factory
+         */
+        factory: FactoryModel['relations'][K] extends () => FactoryBuilderContract<any>
+          ? ReturnType<FactoryModel['relations'][K]>
+          : never
+      ) => void,
+    ): this
+
+    /**
+     * Define custom set of attributes. They are passed to the `newUp` method
+     * of the factory.
+     *
+     * For `createMany` and `makeMany`, you can pass an array of attributes mapped
+     * according to the array index.
+     */
+    fill (
+      attributes: ExtractFactoryAttributes<FactoryModel> | ExtractFactoryAttributes<FactoryModel>[]
+    ): this
+
+    /**
+     * Create model instance.
+     */
+    make (
+      state?: FactoryStateContract,
+      callback?: (
+        model: ExtractFactoryModel<FactoryModel>,
+        state: FactoryStateContract,
+      ) => void
+    ): Promise<ExtractFactoryModel<FactoryModel>>
+
+    /**
+     * Create and persist model instance
+     */
+    create (
+      state?: FactoryStateContract,
+      callback?: (
+        model: ExtractFactoryModel<FactoryModel>,
+        state: FactoryStateContract,
+      ) => void
+    ): Promise<ExtractFactoryModel<FactoryModel>>
+
+    /**
+     * Create more than one model instance
+     */
+    makeMany (
+      count: number,
+      state?: FactoryStateContract,
+      callback?: (
+        model: ExtractFactoryModel<FactoryModel>,
+        state: FactoryStateContract,
+      ) => void
+    ): Promise<ExtractFactoryModel<FactoryModel>[]>
+
+    /**
+     * Create and persist more than one model instance
+     */
+    createMany (
+      count: number,
+      state?: FactoryStateContract,
+      callback?: (
+        model: ExtractFactoryModel<FactoryModel>,
+        state: FactoryStateContract,
+      ) => void
+    ): Promise<ExtractFactoryModel<FactoryModel>[]>
+  }
+
+  /**
+   * Factory model exposes the API to defined a model factory with states
+   * and relationships
+   */
+  export interface FactoryModelContract<Model extends LucidModel, Attributes extends any> {
+    /**
+     * Reference to the underlying lucid model used by the factory
+     * model
+     */
+    model: Model
+
+    /**
+     * Mainly for types support. Not used at runtime to derive any
+     * logic. Sorry, at times have to hack into typescript to
+     * get the desired output. :)
+     */
+    states: unknown
+    relations: unknown
+
+    /**
+     * Returns the callback method for the state
+     */
+    getState (state: string): ModelStateCallback<InstanceType<Model>>
+
+    /**
+     * Returns the relationship and its factory.
+     */
+    getRelation (relation: string): {
+      factory: FactoryBuilderContract<FactoryModelContract<LucidModel, any>>
+      relation: RelationshipsContract,
+    }
+
+    /**
+     * Creates an instance of lucid model by invoking callback passed
+     * to `Factory.define` method.
+     */
+    newUp: NewUpModelFunction<Model, Attributes>
+
+    /**
+     * Define custom state for the factory. When executing the factory,
+     * you can apply the pre-defined states
+     */
+    state<K extends string> (
+      state: K,
+      callback: ModelStateCallback<InstanceType<Model>>,
+    ): this & { states: { [P in K]: ModelStateCallback<InstanceType<Model>> } }
+
+    /**
+     * Define a relationship on another factory
+     */
+    related<K extends ExtractModelRelations<InstanceType<Model>>, Relation extends any> (
+      relation: K,
+      callback: Relation,
+    ): this & { relations: { [P in K]: Relation } }
+
+    /**
+     * Build model factory. This method returns the factory builder, which can be used to
+     * execute model queries
+     */
+    build (): FactoryBuilderContract<this>
+  }
+
+  /**
+   * Factory manager to define new factories
+   */
+  export interface FactoryManager {
+    define<Model extends LucidModel, Attributes extends any> (
+      model: Model,
+      callback: NewUpModelFunction<Model, Attributes>
+    ): FactoryModelContract<Model, Attributes>
+  }
+
+  const Factory: FactoryManager
+  export default Factory
+}

--- a/adonis-typings/factory.ts
+++ b/adonis-typings/factory.ts
@@ -82,6 +82,9 @@ declare module '@ioc:Adonis/Lucid/Factory' {
       lorem: {
         sentence (count?: number): string,
       },
+      internet: {
+        password (): string,
+      },
     },
     sequence: {
       username: string,
@@ -271,7 +274,7 @@ declare module '@ioc:Adonis/Lucid/Factory' {
     /**
      * Define a relationship on another factory
      */
-    related<K extends ExtractModelRelations<InstanceType<Model>>, Relation extends any> (
+    relation<K extends ExtractModelRelations<InstanceType<Model>>, Relation extends any> (
       relation: K,
       callback: Relation,
     ): this & { relations: { [P in K]: Relation } }

--- a/adonis-typings/index.ts
+++ b/adonis-typings/index.ts
@@ -5,4 +5,5 @@
 /// <reference path="./schema.ts" />
 /// <reference path="./migrator.ts" />
 /// <reference path="./relations.ts" />
+/// <reference path="./factory.ts" />
 /// <reference path="./validator.ts" />

--- a/adonis-typings/querybuilder.ts
+++ b/adonis-typings/querybuilder.ts
@@ -625,9 +625,9 @@ declare module '@ioc:Adonis/Lucid/DatabaseQueryBuilder' {
   }
 
   /**
-   * Database query builder interface. It will use the `Executable` trait
-   * and hence must be typed properly for that.
-  */
+   * Database query builder exposes the API to construct SQL query using fluent
+   * chainable API
+   */
   export interface DatabaseQueryBuilderContract <
     Result extends any = Dictionary<any, string>,
   > extends ChainableContract, ExcutableQueryBuilderContract<Result[]> {

--- a/adonis-typings/relations.ts
+++ b/adonis-typings/relations.ts
@@ -290,6 +290,8 @@ declare module '@ioc:Adonis/Lucid/Relations' {
     RelatedModel extends LucidModel,
   > extends BaseRelationContract<ParentModel, RelatedModel> {
     readonly type: 'hasOne'
+    readonly localKey: string
+    readonly foreignKey: string
 
     /**
      * Set related model as a relationship on the parent model.
@@ -342,6 +344,8 @@ declare module '@ioc:Adonis/Lucid/Relations' {
     RelatedModel extends LucidModel
   > extends BaseRelationContract<ParentModel, RelatedModel> {
     readonly type: 'hasMany'
+    readonly localKey: string
+    readonly foreignKey: string
 
     /**
      * Set related models as a relationship on the parent model
@@ -394,6 +398,8 @@ declare module '@ioc:Adonis/Lucid/Relations' {
     RelatedModel extends LucidModel
   > extends BaseRelationContract<ParentModel, RelatedModel> {
     readonly type: 'belongsTo'
+    readonly localKey: string
+    readonly foreignKey: string
 
     /**
      * Set related model as a relationship on the parent model
@@ -445,6 +451,12 @@ declare module '@ioc:Adonis/Lucid/Relations' {
     RelatedModel extends LucidModel
   > extends BaseRelationContract<ParentModel, RelatedModel> {
     type: 'manyToMany'
+
+    readonly localKey: string
+    readonly relatedKey: string
+    readonly pivotForeignKey: string
+    readonly pivotRelatedForeignKey: string
+    readonly pivotTable: string
 
     /**
      * Set related models as a relationship on the parent model
@@ -506,6 +518,10 @@ declare module '@ioc:Adonis/Lucid/Relations' {
     RelatedModel extends LucidModel
   > extends BaseRelationContract<ParentModel, RelatedModel> {
     type: 'hasManyThrough'
+    readonly localKey: string
+    readonly foreignKey: string
+    readonly throughLocalKey: string
+    readonly throughForeignKey: string
 
     /**
      * Set related models as a relationship on the parent model

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,4 +1,5 @@
 import { BaseModel, HasOne, hasOne, scope } from '@ioc:Adonis/Lucid/Orm'
+import Factory from '@ioc:Adonis/Lucid/Factory'
 
 class Profile extends BaseModel {
   public id: string
@@ -30,3 +31,24 @@ User.fetchOrCreateMany('id', [{ id: '1', username: 'virk' }])
 User.create({ id: '1', username: 'virk' })
 User.create({ id: '1', username: 'virk' })
 User.create({ id: '1' })
+
+const F = Factory.define(User, (state) => {
+  const user = new User()
+  user.username = state.faker.username
+  return user
+})
+
+const P = Factory.define(Profile, () => new Profile())
+
+const ProfileF = P
+  .state('social', () => {})
+  .build()
+
+const UserF = F
+  .state('active', (user) => {
+    user.username = 'virk'
+  })
+  .related('profile', () => ProfileF)
+  .build()
+
+UserF.with('profile', 1)

--- a/example/index.ts
+++ b/example/index.ts
@@ -50,7 +50,7 @@ const UserF = F
   .state('active', (user) => {
     user.username = 'virk'
   })
-  .related('profile', () => ProfileF)
+  .relation('profile', () => ProfileF)
   .build()
 
 UserF.with('profile', 1).merge({})

--- a/example/index.ts
+++ b/example/index.ts
@@ -33,12 +33,14 @@ User.create({ id: '1', username: 'virk' })
 User.create({ id: '1' })
 
 const F = Factory.define(User, (state) => {
-  const user = new User()
-  user.username = state.faker.username
-  return user
+  return {
+    username: state.sequence.username,
+  }
 })
 
-const P = Factory.define(Profile, () => new Profile())
+const P = Factory.define(Profile, () => {
+  return {}
+})
 
 const ProfileF = P
   .state('social', () => {})
@@ -51,4 +53,4 @@ const UserF = F
   .related('profile', () => ProfileF)
   .build()
 
-UserF.with('profile', 1)
+UserF.with('profile', 1).merge({})

--- a/example/index.ts
+++ b/example/index.ts
@@ -32,9 +32,9 @@ User.create({ id: '1', username: 'virk' })
 User.create({ id: '1', username: 'virk' })
 User.create({ id: '1' })
 
-const F = Factory.define(User, (state) => {
+const F = Factory.define(User, ({ faker }) => {
   return {
-    username: state.sequence.username,
+    username: faker.internet.userName(),
   }
 })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -833,6 +833,11 @@
       "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
       "dev": true
     },
+    "@types/faker": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/faker/-/faker-4.1.12.tgz",
+      "integrity": "sha512-0MEyzJrLLs1WaOCx9ULK6FzdCSj2EuxdSP9kvuxxdBEGujZYUOZ4vkPXdgu3dhyg/pOdn7VCatelYX7k0YShlA=="
+    },
     "@types/find-package-json": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/find-package-json/-/find-package-json-1.1.1.tgz",
@@ -3381,6 +3386,11 @@
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
+    },
+    "faker": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
+      "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8="
     },
     "fast-deep-equal": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,10 @@
   "dependencies": {
     "@poppinss/hooks": "^1.0.5",
     "@poppinss/utils": "^2.2.6",
+    "@types/faker": "^4.1.12",
     "cli-table3": "^0.6.0",
     "fast-deep-equal": "^3.1.1",
+    "faker": "^4.1.0",
     "kleur": "^3.0.3",
     "knex": "^0.21.1",
     "knex-dynamic-connection": "^1.0.5",

--- a/src/Factory/FactoryBuilder.ts
+++ b/src/Factory/FactoryBuilder.ts
@@ -14,12 +14,13 @@ import {
   FactoryBuilderContract,
 } from '@ioc:Adonis/Lucid/Factory'
 
+import { FactoryModel } from './FactoryModel'
 import { FactoryContext } from './FactoryContext'
 
 /**
  * Factory builder exposes the API to create/persist factory model instances.
  */
-export class FactoryBuilder implements FactoryBuilderContract<FactoryModelContract<LucidModel, any>> {
+export class FactoryBuilder implements FactoryBuilderContract<FactoryModelContract<LucidModel>> {
   /**
    * Relationships to setup. Do note: It is possible to load one relationship
    * twice. A practical use case is to apply different states. For example:
@@ -38,7 +39,7 @@ export class FactoryBuilder implements FactoryBuilderContract<FactoryModelContra
   private currentIndex = 0
 
   /**
-   * Custom attributes to pass to the newUp method
+   * Custom attributes to pass to model merge method
    */
   private attributes: any
 
@@ -48,15 +49,25 @@ export class FactoryBuilder implements FactoryBuilderContract<FactoryModelContra
    */
   private appliedStates: Set<string> = new Set()
 
+  /**
+   * Custom context passed using `useCtx` method. It not defined, we will
+   * create one inline inside `create` and `make` methods
+   */
   private ctx?: FactoryContextContract
 
-  constructor (private model: FactoryModelContract<LucidModel, any>) {
+  /**
+   * Instead of relying on the `FactoryModelContract`, we rely on the
+   * `FactoryModel`, since it exposes certain API's required for
+   * the runtime operations and those API's are not exposed
+   * on the interface to keep the API clean
+   */
+  constructor (public model: FactoryModel<LucidModel>) {
   }
 
   /**
    * Returns factory state
    */
-  private async getFactoryState (isStubbed: boolean) {
+  private async getCtx (isStubbed: boolean) {
     if (isStubbed === true) {
       return new FactoryContext(isStubbed, undefined)
     }
@@ -67,26 +78,62 @@ export class FactoryBuilder implements FactoryBuilderContract<FactoryModelContra
   }
 
   /**
-   * Returns attributes for a given index
+   * Returns attributes to merge for a given index
    */
-  private getAttributesForIndex (index: number) {
+  private getMergeAttributes (index: number) {
     return Array.isArray(this.attributes) ? this.attributes[index] : this.attributes
   }
 
   /**
-   * Returns the lucid model instance by invoking the `newUp` method
-   * on the Factory model.
+   * Returns a new model instance with filled attributes
    */
-  private async getModelInstance (state: FactoryContextContract) {
-    return await this.model.newUp(state, this.getAttributesForIndex(this.currentIndex))
+  private async getModelInstance (ctx: FactoryContextContract): Promise<LucidRow> {
+    const modelAttributes = await this.model.define(ctx)
+    const modelInstance = this.model.newUpModelInstance(modelAttributes, ctx)
+    this.model.mergeAttributes(modelInstance, this.getMergeAttributes(this.currentIndex), ctx)
+    return modelInstance
   }
 
   /**
    * Apply states by invoking state callback
    */
-  private async applyStates (modelInstance: LucidRow, factoryState: FactoryContextContract) {
+  private async applyStates (modelInstance: LucidRow, ctx: FactoryContextContract) {
     for (let state of this.appliedStates) {
-      await this.model.getState(state)(modelInstance, factoryState)
+      await this.model.getState(state)(modelInstance, ctx)
+    }
+  }
+
+  /**
+   * Compile factory by instantiating model instance, applying merge
+   * attributes, apply state
+   */
+  private async compile (
+    isStubbed: boolean,
+    callback?: (model: LucidRow, ctx: FactoryContextContract) => void
+  ) {
+    /**
+     * Use pre-defined ctx or create a new one
+     */
+    const ctx = this.ctx || await this.getCtx(isStubbed)
+
+    /**
+     * Newup the model instance
+     */
+    const modelInstance = await this.getModelInstance(ctx)
+
+    /**
+     * Apply state
+     */
+    this.applyStates(modelInstance, ctx)
+
+    /**
+     * Invoke custom callback (if defined)
+     */
+    typeof (callback) === 'function' && callback(modelInstance, ctx)
+
+    return {
+      modelInstance,
+      ctx,
     }
   }
 
@@ -94,24 +141,28 @@ export class FactoryBuilder implements FactoryBuilderContract<FactoryModelContra
    * Makes relationship instances. Call [[createRelation]] to
    * also persist them.
    */
-  private async makeRelations (modelInstance: LucidRow, state: FactoryContextContract) {
+  private async makeRelations (modelInstance: LucidRow, ctx: FactoryContextContract) {
     for (let { name, count, callback } of this.withRelations) {
       const relation = this.model.getRelation(name)
-      await relation.withCtx(state).make(modelInstance, callback, count)
+      await relation.useCtx(ctx).make(modelInstance, callback, count)
     }
   }
 
   /**
    * Makes and persists relationship instances
    */
-  public async createRelations (modelInstance: LucidRow, state: FactoryContextContract) {
+  public async createRelations (modelInstance: LucidRow, ctx: FactoryContextContract) {
     for (let { name, count, callback } of this.withRelations) {
       const relation = this.model.getRelation(name)
-      await relation.withCtx(state).create(modelInstance, callback, count)
+      await relation.useCtx(ctx).create(modelInstance, callback, count)
     }
   }
 
-  public withCtx (ctx: FactoryContextContract): this {
+  /**
+   * Define custom context. Usually called by the relationships
+   * to share the parent context with relationship factory
+  */
+  public useCtx (ctx: FactoryContextContract): this {
     this.ctx = ctx
     return this
   }
@@ -137,7 +188,7 @@ export class FactoryBuilder implements FactoryBuilderContract<FactoryModelContra
    * Fill custom set of attributes. They are passed down to the newUp
    * method of the factory
    */
-  public fill (attributes: any) {
+  public merge (attributes: any) {
     this.attributes = attributes
     return this
   }
@@ -146,26 +197,16 @@ export class FactoryBuilder implements FactoryBuilderContract<FactoryModelContra
    * Returns a model instance without persisting it to the database.
    * Relationships are still loaded and states are also applied.
    */
-  public async make (
-    callback?: (model: LucidRow, state: FactoryContextContract) => void,
-  ) {
-    const factoryState = this.ctx || await this.getFactoryState(true)
-
-    const modelInstance = await this.getModelInstance(factoryState)
-    this.applyStates(modelInstance, factoryState)
+  public async make (callback?: (
+    model: LucidRow,
+    ctx: FactoryContextContract,
+  ) => void) {
+    const { modelInstance, ctx } = await this.compile(true, callback)
 
     /**
-     * Invoke custom callback (if defined)
+     * Make relationships. The relationships will be not persisted
      */
-    if (typeof (callback) === 'function') {
-      callback(modelInstance, factoryState)
-    }
-
-    /**
-     * Make relationships. Since, parent model is not persisted
-     * the relationships are also not persisted
-     */
-    await this.makeRelations(modelInstance, factoryState)
+    await this.makeRelations(modelInstance, ctx)
     return modelInstance
   }
 
@@ -173,40 +214,31 @@ export class FactoryBuilder implements FactoryBuilderContract<FactoryModelContra
    * Similar to make, but also persists the model instance to the
    * database.
    */
-  public async create (
-    callback?: (model: LucidRow, state: FactoryContextContract) => void,
-  ) {
-    const factoryState = this.ctx || await this.getFactoryState(false)
-
-    const modelInstance = await this.getModelInstance(factoryState)
-    this.applyStates(modelInstance, factoryState)
+  public async create (callback?: (
+    model: LucidRow,
+    ctx: FactoryContextContract,
+  ) => void) {
+    const { modelInstance, ctx } = await this.compile(false, callback)
 
     try {
-      modelInstance.$trx = factoryState.$trx
-
       /**
-       * Invoke custom callback (if defined)
+       * Persist model instance
        */
-      if (typeof (callback) === 'function') {
-        callback(modelInstance, factoryState)
-      }
-
-      /**
-       * Persist model
-       */
+      modelInstance.$trx = ctx.$trx
       await modelInstance.save()
 
       /**
-       * Setup relationships (they are persisted too)
+       * Create relationships.
        */
-      await this.createRelations(modelInstance, factoryState)
-      if (!this.ctx && factoryState.$trx) {
-        await factoryState.$trx.commit()
+      await this.createRelations(modelInstance, ctx)
+      if (!this.ctx && ctx.$trx) {
+        await ctx.$trx.commit()
       }
+
       return modelInstance
     } catch (error) {
-      if (!this.ctx && factoryState.$trx) {
-        await factoryState.$trx.rollback()
+      if (!this.ctx && ctx.$trx) {
+        await ctx.$trx.rollback()
       }
       throw error
     }
@@ -217,7 +249,7 @@ export class FactoryBuilder implements FactoryBuilderContract<FactoryModelContra
    */
   public async makeMany (
     count: number,
-    callback?: (model: LucidRow, state: FactoryContextContract) => void,
+    callback?: (model: LucidRow, ctx: FactoryContextContract) => void,
   ) {
     let modelInstances: LucidRow[] = []
 

--- a/src/Factory/FactoryBuilder.ts
+++ b/src/Factory/FactoryBuilder.ts
@@ -1,0 +1,285 @@
+/*
+* @adonisjs/lucid
+*
+* (c) Harminder Virk <virk@adonisjs.com>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+import { LucidRow, LucidModel } from '@ioc:Adonis/Lucid/Model'
+import {
+  FactoryModelContract,
+  FactoryBuilderContract,
+} from '@ioc:Adonis/Lucid/Factory'
+
+import { HasOne } from './Relations/HasOne'
+import { HasMany } from './Relations/HasMany'
+import { FactoryState } from './FactoryState'
+import { BelongsTo } from './Relations/BelongsTo'
+import { ManyToMany } from './Relations/ManyToMany'
+
+/**
+ * Factory builder exposes the API to create/persist factory model instances.
+ */
+export class FactoryBuilder implements FactoryBuilderContract<FactoryModelContract<LucidModel, any>> {
+  /**
+   * Relationships to setup. Do note: It is possible to load one relationship
+   * twice. A practical use case is to apply different states. For example:
+   *
+   * Make user with "3 active posts" and "2 draft posts"
+   */
+  private withRelations: {
+    name: string,
+    count?: number,
+    callback?: (factory: any) => void,
+  }[] = []
+
+  /**
+   * The current index. Updated by `makeMany` and `createMany`
+   */
+  private currentIndex = 0
+
+  /**
+   * Custom attributes to pass to the newUp method
+   */
+  private attributes: any
+
+  /**
+   * States to apply. One state can be applied only once and hence
+   * a set is used.
+   */
+  private appliedStates: Set<string> = new Set()
+
+  constructor (private model: FactoryModelContract<LucidModel, any>) {
+  }
+
+  /**
+   * Returns factory state
+   */
+  private async getFactoryState (isStubbed: boolean) {
+    if (isStubbed === true) {
+      return new FactoryState(isStubbed, undefined)
+    }
+
+    const client = this.model.model.$adapter.modelConstructorClient(this.model.model)
+    const trx = await client.transaction()
+    return new FactoryState(isStubbed, trx)
+  }
+
+  /**
+   * Returns attributes for a given index
+   */
+  private getAttributesForIndex (index: number) {
+    return Array.isArray(this.attributes) ? this.attributes[index] : this.attributes
+  }
+
+  /**
+   * Returns the lucid model instance by invoking the `newUp` method
+   * on the Factory model.
+   */
+  private async getModelInstance (state: FactoryState) {
+    return await this.model.newUp(state, this.getAttributesForIndex(this.currentIndex))
+  }
+
+  /**
+   * Apply states by invoking state callback
+   */
+  private async applyStates (modelInstance: LucidRow, factoryState: FactoryState) {
+    for (let state of this.appliedStates) {
+      await this.model.getState(state)(modelInstance, factoryState)
+    }
+  }
+
+  /**
+   * Makes relationship instances. Call [[createRelation]] to
+   * also persist them.
+   */
+  private async makeRelations (modelInstance: LucidRow, state: FactoryState) {
+    for (let { name, count, callback } of this.withRelations) {
+      const { factory, relation } = this.model.getRelation(name)
+
+      if (typeof (callback) === 'function') {
+        callback(factory)
+      }
+
+      switch (relation.type) {
+        case 'belongsTo':
+          await new BelongsTo(relation).make(modelInstance, state, factory)
+          break
+        case 'hasOne':
+          await new HasOne(relation).make(modelInstance, state, factory)
+          break
+        case 'hasMany':
+          await new HasMany(relation).make(modelInstance, state, factory, count)
+          break
+        case 'manyToMany':
+          await new ManyToMany(relation).make(modelInstance, state, factory, count)
+          break
+      }
+    }
+  }
+
+  /**
+   * Makes and persists relationship instances
+   */
+  public async createRelations (modelInstance: LucidRow, state: FactoryState) {
+    for (let { name, count, callback } of this.withRelations) {
+      const { factory, relation } = this.model.getRelation(name)
+      if (typeof (callback) === 'function') {
+        callback(factory)
+      }
+
+      switch (relation.type) {
+        case 'belongsTo':
+          await new BelongsTo(relation).create(modelInstance, state, factory)
+          break
+        case 'hasOne':
+          await new HasOne(relation).create(modelInstance, state, factory)
+          break
+        case 'hasMany':
+          await new HasMany(relation).create(modelInstance, state, factory, count)
+          break
+        case 'manyToMany':
+          await new ManyToMany(relation).create(modelInstance, state, factory, count)
+          break
+      }
+    }
+  }
+
+  /**
+   * Load relationship
+   */
+  public with (relation: string, count?: number, callback?: (factory: never) => void): this {
+    this.withRelations.push({ name: relation, count, callback })
+    return this
+  }
+
+  /**
+   * Apply one or more states. Multiple calls to apply a single
+   * state will be ignored
+   */
+  public apply (...states: string[]): this {
+    states.forEach((state) => this.appliedStates.add(state))
+    return this
+  }
+
+  /**
+   * Fill custom set of attributes. They are passed down to the newUp
+   * method of the factory
+   */
+  public fill (attributes: any) {
+    this.attributes = attributes
+    return this
+  }
+
+  /**
+   * Returns a model instance without persisting it to the database.
+   * Relationships are still loaded and states are also applied.
+   */
+  public async make (
+    state?: FactoryState,
+    callback?: (model: LucidRow, state: FactoryState) => void,
+  ) {
+    const factoryState = state || await this.getFactoryState(true)
+
+    const modelInstance = await this.getModelInstance(factoryState)
+    this.applyStates(modelInstance, factoryState)
+
+    /**
+     * Invoke custom callback (if defined)
+     */
+    if (typeof (callback) === 'function') {
+      callback(modelInstance, factoryState)
+    }
+
+    /**
+     * Make relationships. Since, parent model is not persisted
+     * the relationships are also not persisted
+     */
+    await this.makeRelations(modelInstance, factoryState)
+    return modelInstance
+  }
+
+  /**
+   * Similar to make, but also persists the model instance to the
+   * database.
+   */
+  public async create (
+    state?: FactoryState,
+    callback?: (model: LucidRow, state: FactoryState) => void,
+  ) {
+    const factoryState = state || await this.getFactoryState(false)
+
+    const modelInstance = await this.getModelInstance(factoryState)
+    this.applyStates(modelInstance, factoryState)
+
+    try {
+      modelInstance.$trx = factoryState.$trx
+
+      /**
+       * Invoke custom callback (if defined)
+       */
+      if (typeof (callback) === 'function') {
+        callback(modelInstance, factoryState)
+      }
+
+      /**
+       * Persist model
+       */
+      await modelInstance.save()
+
+      /**
+       * Setup relationships (they are persisted too)
+       */
+      await this.createRelations(modelInstance, factoryState)
+      if (!state && factoryState.$trx) {
+        await factoryState.$trx.commit()
+      }
+      return modelInstance
+    } catch (error) {
+      if (!state && factoryState.$trx) {
+        await factoryState.$trx.rollback()
+      }
+      throw error
+    }
+  }
+
+  /**
+   * Create many of factory model instances
+   */
+  public async makeMany (
+    count: number,
+    state?: FactoryState,
+    callback?: (model: LucidRow, state: FactoryState) => void,
+  ) {
+    let modelInstances: LucidRow[] = []
+
+    const counter = new Array(count).fill(0).map((_, i) => i)
+    for (let index of counter) {
+      this.currentIndex = index
+      modelInstances.push(await this.make(state, callback))
+    }
+
+    return modelInstances
+  }
+
+  /**
+   * Create and persist many of factory model instances
+   */
+  public async createMany (
+    count: number,
+    state?: FactoryState,
+    callback?: (model: LucidRow, state: FactoryState) => void,
+  ) {
+    let modelInstances: LucidRow[] = []
+
+    const counter = new Array(count).fill(0).map((_, i) => i)
+    for (let index of counter) {
+      this.currentIndex = index
+      modelInstances.push(await this.create(state, callback))
+    }
+
+    return modelInstances
+  }
+}

--- a/src/Factory/FactoryContext.ts
+++ b/src/Factory/FactoryContext.ts
@@ -7,11 +7,12 @@
  * file that was distributed with this source code.
 */
 
+import faker from 'faker'
 import { FactoryContextContract } from '@ioc:Adonis/Lucid/Factory'
 import { TransactionClientContract } from '@ioc:Adonis/Lucid/Database'
 
 export class FactoryContext implements FactoryContextContract {
-  public faker = {}
+  public faker = faker
 
   constructor (
     public isStubbed: boolean,

--- a/src/Factory/FactoryContext.ts
+++ b/src/Factory/FactoryContext.ts
@@ -11,7 +11,18 @@ import { FactoryContextContract } from '@ioc:Adonis/Lucid/Factory'
 import { TransactionClientContract } from '@ioc:Adonis/Lucid/Database'
 
 export class FactoryContext implements FactoryContextContract {
-  public faker: any = {}
+  public faker = {
+    lorem: {
+      sentence (_?: number): string {
+        return ''
+      },
+    },
+  }
+
+  public sequence = {
+    username: 'string',
+    email: 'string',
+  }
 
   constructor (
     public isStubbed: boolean,

--- a/src/Factory/FactoryContext.ts
+++ b/src/Factory/FactoryContext.ts
@@ -7,10 +7,10 @@
  * file that was distributed with this source code.
 */
 
-import { FactoryStateContract } from '@ioc:Adonis/Lucid/Factory'
+import { FactoryContextContract } from '@ioc:Adonis/Lucid/Factory'
 import { TransactionClientContract } from '@ioc:Adonis/Lucid/Database'
 
-export class FactoryState implements FactoryStateContract {
+export class FactoryContext implements FactoryContextContract {
   public faker: any = {}
 
   constructor (

--- a/src/Factory/FactoryContext.ts
+++ b/src/Factory/FactoryContext.ts
@@ -17,6 +17,11 @@ export class FactoryContext implements FactoryContextContract {
         return ''
       },
     },
+    internet: {
+      password () {
+        return ''
+      },
+    },
   }
 
   public sequence = {

--- a/src/Factory/FactoryContext.ts
+++ b/src/Factory/FactoryContext.ts
@@ -11,23 +11,7 @@ import { FactoryContextContract } from '@ioc:Adonis/Lucid/Factory'
 import { TransactionClientContract } from '@ioc:Adonis/Lucid/Database'
 
 export class FactoryContext implements FactoryContextContract {
-  public faker = {
-    lorem: {
-      sentence (_?: number): string {
-        return ''
-      },
-    },
-    internet: {
-      password () {
-        return ''
-      },
-    },
-  }
-
-  public sequence = {
-    username: 'string',
-    email: 'string',
-  }
+  public faker = {}
 
   constructor (
     public isStubbed: boolean,

--- a/src/Factory/FactoryModel.ts
+++ b/src/Factory/FactoryModel.ts
@@ -1,0 +1,114 @@
+/*
+ * @adonisjs/lucid
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+*/
+
+import { LucidRow, LucidModel } from '@ioc:Adonis/Lucid/Model'
+import { ExtractModelRelations, RelationshipsContract } from '@ioc:Adonis/Lucid/Relations'
+
+import {
+  NewUpModelFunction,
+  ModelStateCallback,
+  FactoryModelContract,
+  FactoryBuilderContract,
+} from '@ioc:Adonis/Lucid/Factory'
+
+import { FactoryBuilder } from './FactoryBuilder'
+
+/**
+ * Factory model exposes the API to define a model factory with custom
+ * states and relationships
+ */
+export class FactoryModel implements FactoryModelContract<LucidModel, any> {
+  /**
+   * A collection of factory states
+   */
+  public states: { [key: string]: ModelStateCallback<LucidRow> } = {}
+
+  /**
+   * A collection of factory relations
+   */
+  public relations: {
+    [relation: string]: () => FactoryBuilderContract<FactoryModelContract<LucidModel, any>>
+  } = {}
+
+  constructor (
+    public model: LucidModel,
+    public newUp: NewUpModelFunction<LucidModel, any>,
+  ) {
+  }
+
+  /**
+   * Returns state callback defined on the model factory. Raises an
+   * exception, when state is not registered
+   */
+  public getState (state: string): ModelStateCallback<LucidRow> {
+    const stateCallback = this.states[state]
+    if (!stateCallback) {
+      throw new Error(`Cannot apply undefined state "${state}". Double check the model factory`)
+    }
+
+    return stateCallback
+  }
+
+  /**
+   * Returns the pre-registered relationship factory function, along with
+   * the original model relation.
+   */
+  public getRelation (relation: string): {
+    factory: FactoryBuilderContract<FactoryModelContract<LucidModel, any>>
+    relation: RelationshipsContract,
+  } {
+    const relationship = this.relations[relation]
+    if (!relationship) {
+      throw new Error(`Cannot setup undefined relationship "${relation}". Double check the model factory`)
+    }
+
+    const modelRelation = this.model.$getRelation(relation)!
+    const relationshipFactory = relationship()
+
+    return {
+      factory: relationshipFactory,
+      relation: modelRelation,
+    }
+  }
+
+  /**
+   * Define custom state for the factory. When executing the factory,
+   * you can apply the pre-defined states
+   */
+  public state (state: string, callback: ModelStateCallback<LucidRow>): any {
+    this.states[state] = callback
+    return this
+  }
+
+  /**
+   * Define a relationship on another factory
+   */
+  public related<K extends ExtractModelRelations<LucidRow>> (
+    relation: K,
+    callback: any,
+  ): any {
+    if (!this.model.$getRelation(relation)) {
+      throw new Error([
+        `Cannot define "${relation}" relationship.`,
+        `The relationship must exist on the "${this.model.name}" model first`,
+      ].join(' '))
+    }
+
+    this.relations[relation as unknown as string] = callback
+    return this
+  }
+
+  /**
+   * Build factory model and return factory builder. The builder is then
+   * used to make/create model instances
+   */
+  public build () {
+    return new FactoryBuilder(this)
+  }
+}

--- a/src/Factory/FactoryModel.ts
+++ b/src/Factory/FactoryModel.ts
@@ -105,7 +105,7 @@ export class FactoryModel<Model extends LucidModel> implements FactoryModelContr
   /**
    * Define a relationship on another factory
    */
-  public related<K extends ExtractModelRelations<InstanceType<Model>>> (
+  public relation<K extends ExtractModelRelations<InstanceType<Model>>> (
     relation: Extract<K, string>,
     callback: any,
   ): any {

--- a/src/Factory/FactoryModel.ts
+++ b/src/Factory/FactoryModel.ts
@@ -7,10 +7,13 @@
  * file that was distributed with this source code.
 */
 
+import { Hooks } from '@poppinss/hooks'
 import { LucidRow, LucidModel } from '@ioc:Adonis/Lucid/Model'
 import { ExtractModelRelations, RelationshipsContract } from '@ioc:Adonis/Lucid/Relations'
 
 import {
+  EventsList,
+  HooksHandler,
   StateCallback,
   MergeCallback,
   NewUpCallback,
@@ -64,7 +67,34 @@ export class FactoryModel<Model extends LucidModel> implements FactoryModelContr
    */
   public relations: { [relation: string]: FactoryRelationContract } = {}
 
+  /**
+   * A set of registered hooks
+   */
+  public hooks = new Hooks()
+
   constructor (public model: Model, public define: DefineCallback<LucidModel>) {
+  }
+
+  /**
+   * Register a before event hook
+   */
+  public before (
+    event: EventsList,
+    handler: HooksHandler<FactoryModelContract<Model>>,
+  ): this {
+    this.hooks.add('before', event, handler)
+    return this
+  }
+
+  /**
+   * Register an after event hook
+   */
+  public after (
+    event: EventsList,
+    handler: HooksHandler<FactoryModelContract<Model>>,
+  ): this {
+    this.hooks.add('after', event, handler)
+    return this
   }
 
   /**

--- a/src/Factory/FactoryState.ts
+++ b/src/Factory/FactoryState.ts
@@ -1,0 +1,21 @@
+/*
+ * @adonisjs/lucid
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+*/
+
+import { FactoryStateContract } from '@ioc:Adonis/Lucid/Factory'
+import { TransactionClientContract } from '@ioc:Adonis/Lucid/Database'
+
+export class FactoryState implements FactoryStateContract {
+  public faker: any = {}
+
+  constructor (
+    public isStubbed: boolean,
+    public $trx: TransactionClientContract | undefined
+  ) {
+  }
+}

--- a/src/Factory/Relations/Base.ts
+++ b/src/Factory/Relations/Base.ts
@@ -1,0 +1,50 @@
+/*
+* @adonisjs/lucid
+*
+* (c) Harminder Virk <virk@adonisjs.com>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+import { LucidModel } from '@ioc:Adonis/Lucid/Model'
+import {
+  RelationCallback,
+  FactoryModelContract,
+  FactoryContextContract,
+  FactoryBuilderContract,
+} from '@ioc:Adonis/Lucid/Factory'
+
+/**
+ * Base relation to be extended by other factory relations
+ */
+export abstract class BaseRelation {
+  protected ctx: FactoryContextContract
+
+  constructor (
+    private factory: () => FactoryBuilderContract<FactoryModelContract<LucidModel>>
+  ) {
+  }
+
+  /**
+   * Instantiates the relationship factory
+   */
+  protected compile (callback?: RelationCallback) {
+    const factory = this.factory()
+    if (typeof (callback) === 'function') {
+      callback(factory)
+    }
+
+    factory.useCtx(this.ctx)
+    return factory
+  }
+
+  /**
+   * Use custom ctx. This must always be called by the factory, otherwise
+   * `make` and `create` calls will fail.
+   */
+  public useCtx (ctx: FactoryContextContract): this {
+    this.ctx = ctx
+    return this
+  }
+}

--- a/src/Factory/Relations/Base.ts
+++ b/src/Factory/Relations/Base.ts
@@ -12,7 +12,7 @@ import {
   RelationCallback,
   FactoryModelContract,
   FactoryContextContract,
-  FactoryBuilderContract,
+  FactoryBuilderQueryContract,
 } from '@ioc:Adonis/Lucid/Factory'
 
 /**
@@ -22,7 +22,7 @@ export abstract class BaseRelation {
   protected ctx: FactoryContextContract
 
   constructor (
-    private factory: () => FactoryBuilderContract<FactoryModelContract<LucidModel>>
+    private factory: () => FactoryBuilderQueryContract<FactoryModelContract<LucidModel>>
   ) {
   }
 
@@ -30,7 +30,7 @@ export abstract class BaseRelation {
    * Instantiates the relationship factory
    */
   protected compile (callback?: RelationCallback) {
-    const factory = this.factory()
+    const factory = this.factory().query()
     if (typeof (callback) === 'function') {
       callback(factory)
     }

--- a/src/Factory/Relations/BelongsTo.ts
+++ b/src/Factory/Relations/BelongsTo.ts
@@ -11,30 +11,49 @@ import { LucidModel, LucidRow } from '@ioc:Adonis/Lucid/Model'
 import { BelongsToRelationContract } from '@ioc:Adonis/Lucid/Relations'
 import {
   FactoryModelContract,
-  FactoryStateContract,
+  FactoryContextContract,
   FactoryBuilderContract,
+  FactoryRelationContract,
 } from '@ioc:Adonis/Lucid/Factory'
 
-export class BelongsTo {
-  constructor (private relation: BelongsToRelationContract<LucidModel, LucidModel>) {
+export class BelongsTo implements FactoryRelationContract {
+  private ctx: FactoryContextContract
+
+  constructor (
+    public relation: BelongsToRelationContract<LucidModel, LucidModel>,
+    private factory: () => FactoryBuilderContract<FactoryModelContract<LucidModel, any>>
+  ) {
     this.relation.boot()
+  }
+
+  public withCtx (ctx: FactoryContextContract): this {
+    this.ctx = ctx
+    return this
   }
 
   public async make (
     parent: LucidRow,
-    state: FactoryStateContract,
-    factory: FactoryBuilderContract<any>,
+    callback?: (factory: FactoryBuilderContract<FactoryModelContract<LucidModel, any>>) => void,
   ) {
-    const instance = await factory.make(state)
+    const factory = this.factory()
+    if (typeof (callback) === 'function') {
+      callback(factory)
+    }
+
+    const instance = await factory.withCtx(this.ctx).make()
     parent.$setRelated(this.relation.relationName, instance)
   }
 
   public async create (
     parent: LucidRow,
-    state: FactoryStateContract,
-    factory: FactoryBuilderContract<FactoryModelContract<LucidModel, any>>,
+    callback?: (factory: FactoryBuilderContract<FactoryModelContract<LucidModel, any>>) => void,
   ) {
-    const related = await factory.create(state)
+    const factory = this.factory()
+    if (typeof (callback) === 'function') {
+      callback(factory)
+    }
+
+    const related = await factory.withCtx(this.ctx).create()
     this.relation.hydrateForPersistance(parent, related)
     parent.$setRelated(this.relation.relationName, related)
   }

--- a/src/Factory/Relations/BelongsTo.ts
+++ b/src/Factory/Relations/BelongsTo.ts
@@ -12,8 +12,8 @@ import { BelongsToRelationContract } from '@ioc:Adonis/Lucid/Relations'
 import {
   RelationCallback,
   FactoryModelContract,
-  FactoryBuilderContract,
   FactoryRelationContract,
+  FactoryBuilderQueryContract,
 } from '@ioc:Adonis/Lucid/Factory'
 
 import { BaseRelation } from './Base'
@@ -24,7 +24,7 @@ import { BaseRelation } from './Base'
 export class BelongsTo extends BaseRelation implements FactoryRelationContract {
   constructor (
     public relation: BelongsToRelationContract<LucidModel, LucidModel>,
-    factory: () => FactoryBuilderContract<FactoryModelContract<LucidModel>>
+    factory: () => FactoryBuilderQueryContract<FactoryModelContract<LucidModel>>
   ) {
     super(factory)
     this.relation.boot()

--- a/src/Factory/Relations/BelongsTo.ts
+++ b/src/Factory/Relations/BelongsTo.ts
@@ -35,7 +35,8 @@ export class BelongsTo extends BaseRelation implements FactoryRelationContract {
    */
   public async make (parent: LucidRow, callback?: RelationCallback) {
     const factory = this.compile(callback)
-    const related = await factory.make()
+    const related = await factory.makeStubbed()
+    this.relation.hydrateForPersistance(parent, related)
     parent.$setRelated(this.relation.relationName, related)
   }
 

--- a/src/Factory/Relations/BelongsTo.ts
+++ b/src/Factory/Relations/BelongsTo.ts
@@ -1,0 +1,41 @@
+/*
+* @adonisjs/lucid
+*
+* (c) Harminder Virk <virk@adonisjs.com>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+import { LucidModel, LucidRow } from '@ioc:Adonis/Lucid/Model'
+import { BelongsToRelationContract } from '@ioc:Adonis/Lucid/Relations'
+import {
+  FactoryModelContract,
+  FactoryStateContract,
+  FactoryBuilderContract,
+} from '@ioc:Adonis/Lucid/Factory'
+
+export class BelongsTo {
+  constructor (private relation: BelongsToRelationContract<LucidModel, LucidModel>) {
+    this.relation.boot()
+  }
+
+  public async make (
+    parent: LucidRow,
+    state: FactoryStateContract,
+    factory: FactoryBuilderContract<any>,
+  ) {
+    const instance = await factory.make(state)
+    parent.$setRelated(this.relation.relationName, instance)
+  }
+
+  public async create (
+    parent: LucidRow,
+    state: FactoryStateContract,
+    factory: FactoryBuilderContract<FactoryModelContract<LucidModel, any>>,
+  ) {
+    const related = await factory.create(state)
+    this.relation.hydrateForPersistance(parent, related)
+    parent.$setRelated(this.relation.relationName, related)
+  }
+}

--- a/src/Factory/Relations/BelongsTo.ts
+++ b/src/Factory/Relations/BelongsTo.ts
@@ -10,50 +10,42 @@
 import { LucidModel, LucidRow } from '@ioc:Adonis/Lucid/Model'
 import { BelongsToRelationContract } from '@ioc:Adonis/Lucid/Relations'
 import {
+  RelationCallback,
   FactoryModelContract,
-  FactoryContextContract,
   FactoryBuilderContract,
   FactoryRelationContract,
 } from '@ioc:Adonis/Lucid/Factory'
 
-export class BelongsTo implements FactoryRelationContract {
-  private ctx: FactoryContextContract
+import { BaseRelation } from './Base'
 
+/**
+ * A belongs to factory relation
+ */
+export class BelongsTo extends BaseRelation implements FactoryRelationContract {
   constructor (
     public relation: BelongsToRelationContract<LucidModel, LucidModel>,
-    private factory: () => FactoryBuilderContract<FactoryModelContract<LucidModel, any>>
+    factory: () => FactoryBuilderContract<FactoryModelContract<LucidModel>>
   ) {
+    super(factory)
     this.relation.boot()
   }
 
-  public withCtx (ctx: FactoryContextContract): this {
-    this.ctx = ctx
-    return this
+  /**
+   * Make relationship and set it on the parent model instance
+   */
+  public async make (parent: LucidRow, callback?: RelationCallback) {
+    const factory = this.compile(callback)
+    const related = await factory.make()
+    parent.$setRelated(this.relation.relationName, related)
   }
 
-  public async make (
-    parent: LucidRow,
-    callback?: (factory: FactoryBuilderContract<FactoryModelContract<LucidModel, any>>) => void,
-  ) {
-    const factory = this.factory()
-    if (typeof (callback) === 'function') {
-      callback(factory)
-    }
+  /**
+   * Persist relationship and set it on the parent model instance
+   */
+  public async create (parent: LucidRow, callback?: RelationCallback) {
+    const factory = this.compile(callback)
+    const related = await factory.create()
 
-    const instance = await factory.withCtx(this.ctx).make()
-    parent.$setRelated(this.relation.relationName, instance)
-  }
-
-  public async create (
-    parent: LucidRow,
-    callback?: (factory: FactoryBuilderContract<FactoryModelContract<LucidModel, any>>) => void,
-  ) {
-    const factory = this.factory()
-    if (typeof (callback) === 'function') {
-      callback(factory)
-    }
-
-    const related = await factory.withCtx(this.ctx).create()
     this.relation.hydrateForPersistance(parent, related)
     parent.$setRelated(this.relation.relationName, related)
   }

--- a/src/Factory/Relations/HasMany.ts
+++ b/src/Factory/Relations/HasMany.ts
@@ -12,8 +12,8 @@ import { HasManyRelationContract } from '@ioc:Adonis/Lucid/Relations'
 import {
   RelationCallback,
   FactoryModelContract,
-  FactoryBuilderContract,
   FactoryRelationContract,
+  FactoryBuilderQueryContract,
 } from '@ioc:Adonis/Lucid/Factory'
 
 import { BaseRelation } from './Base'
@@ -24,7 +24,7 @@ import { BaseRelation } from './Base'
 export class HasMany extends BaseRelation implements FactoryRelationContract {
   constructor (
     public relation: HasManyRelationContract<LucidModel, LucidModel>,
-    factory: () => FactoryBuilderContract<FactoryModelContract<LucidModel>>
+    factory: () => FactoryBuilderQueryContract<FactoryModelContract<LucidModel>>
   ) {
     super(factory)
     this.relation.boot()

--- a/src/Factory/Relations/HasMany.ts
+++ b/src/Factory/Relations/HasMany.ts
@@ -1,0 +1,44 @@
+/*
+* @adonisjs/lucid
+*
+* (c) Harminder Virk <virk@adonisjs.com>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+import { LucidModel, LucidRow } from '@ioc:Adonis/Lucid/Model'
+import { HasManyRelationContract } from '@ioc:Adonis/Lucid/Relations'
+import {
+  FactoryBuilderContract,
+  FactoryModelContract,
+  FactoryStateContract,
+} from '@ioc:Adonis/Lucid/Factory'
+
+export class HasMany {
+  constructor (private relation: HasManyRelationContract<LucidModel, LucidModel>) {
+    this.relation.boot()
+  }
+
+  public async make (
+    parent: LucidRow,
+    state: FactoryStateContract,
+    factory: FactoryBuilderContract<any>,
+    count?: number,
+  ) {
+    const instances = await factory.makeMany(count || 1, state)
+    parent.$setRelated(this.relation.relationName, instances)
+  }
+
+  public async create (
+    parent: LucidRow,
+    state: FactoryStateContract,
+    factory: FactoryBuilderContract<FactoryModelContract<LucidModel, any>>,
+    count?: number,
+  ) {
+    const customAttributes = {}
+    this.relation.hydrateForPersistance(parent, customAttributes)
+    const instance = await factory.createMany(count || 1, state, (related) => related.merge(customAttributes))
+    parent.$setRelated(this.relation.relationName, instance)
+  }
+}

--- a/src/Factory/Relations/HasMany.ts
+++ b/src/Factory/Relations/HasMany.ts
@@ -10,57 +10,44 @@
 import { LucidModel, LucidRow } from '@ioc:Adonis/Lucid/Model'
 import { HasManyRelationContract } from '@ioc:Adonis/Lucid/Relations'
 import {
+  RelationCallback,
   FactoryModelContract,
-  FactoryContextContract,
   FactoryBuilderContract,
   FactoryRelationContract,
 } from '@ioc:Adonis/Lucid/Factory'
 
-export class HasMany implements FactoryRelationContract {
-  private ctx: FactoryContextContract
+import { BaseRelation } from './Base'
 
+/**
+ * Has many to factory relation
+ */
+export class HasMany extends BaseRelation implements FactoryRelationContract {
   constructor (
     public relation: HasManyRelationContract<LucidModel, LucidModel>,
-    private factory: () => FactoryBuilderContract<FactoryModelContract<LucidModel, any>>
+    factory: () => FactoryBuilderContract<FactoryModelContract<LucidModel>>
   ) {
+    super(factory)
     this.relation.boot()
   }
 
-  public withCtx (ctx: FactoryContextContract): this {
-    this.ctx = ctx
-    return this
-  }
-
-  public async make (
-    parent: LucidRow,
-    callback?: (factory: FactoryBuilderContract<FactoryModelContract<LucidModel, any>>) => void,
-    count?: number,
-  ) {
-    const factory = this.factory()
-    if (typeof (callback) === 'function') {
-      callback(factory)
-    }
-
-    const instances = await this.factory().withCtx(this.ctx).makeMany(count || 1)
+  /**
+   * Make relationship and set it on the parent model instance
+   */
+  public async make (parent: LucidRow, callback?: RelationCallback, count?: number) {
+    const factory = this.compile(callback)
+    const instances = await factory.makeMany(count || 1)
     parent.$setRelated(this.relation.relationName, instances)
   }
 
-  public async create (
-    parent: LucidRow,
-    callback?: (factory: FactoryBuilderContract<FactoryModelContract<LucidModel, any>>) => void,
-    count?: number,
-  ) {
-    const factory = this.factory()
-    if (typeof (callback) === 'function') {
-      callback(factory)
-    }
+  /**
+   * Persist relationship and set it on the parent model instance
+   */
+  public async create (parent: LucidRow, callback?: RelationCallback, count?: number) {
+    const factory = this.compile(callback)
 
     const customAttributes = {}
     this.relation.hydrateForPersistance(parent, customAttributes)
-
-    const instance = await factory
-      .withCtx(this.ctx)
-      .createMany(count || 1, (related) => related.merge(customAttributes))
+    const instance = await factory.createMany(count || 1, (related) => related.merge(customAttributes))
 
     parent.$setRelated(this.relation.relationName, instance)
   }

--- a/src/Factory/Relations/HasMany.ts
+++ b/src/Factory/Relations/HasMany.ts
@@ -35,7 +35,13 @@ export class HasMany extends BaseRelation implements FactoryRelationContract {
    */
   public async make (parent: LucidRow, callback?: RelationCallback, count?: number) {
     const factory = this.compile(callback)
-    const instances = await factory.makeMany(count || 1)
+
+    const customAttributes = {}
+    this.relation.hydrateForPersistance(parent, customAttributes)
+    const instances = await factory.makeStubbedMany(count || 1, (related) => {
+      related.merge(customAttributes)
+    })
+
     parent.$setRelated(this.relation.relationName, instances)
   }
 
@@ -47,7 +53,10 @@ export class HasMany extends BaseRelation implements FactoryRelationContract {
 
     const customAttributes = {}
     this.relation.hydrateForPersistance(parent, customAttributes)
-    const instance = await factory.createMany(count || 1, (related) => related.merge(customAttributes))
+
+    const instance = await factory.createMany(count || 1, (related) => {
+      related.merge(customAttributes)
+    })
 
     parent.$setRelated(this.relation.relationName, instance)
   }

--- a/src/Factory/Relations/HasOne.ts
+++ b/src/Factory/Relations/HasOne.ts
@@ -1,0 +1,42 @@
+/*
+* @adonisjs/lucid
+*
+* (c) Harminder Virk <virk@adonisjs.com>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+import { LucidModel, LucidRow } from '@ioc:Adonis/Lucid/Model'
+import { HasOneRelationContract } from '@ioc:Adonis/Lucid/Relations'
+import {
+  FactoryStateContract,
+  FactoryModelContract,
+  FactoryBuilderContract,
+} from '@ioc:Adonis/Lucid/Factory'
+
+export class HasOne {
+  constructor (private relation: HasOneRelationContract<LucidModel, LucidModel>) {
+    this.relation.boot()
+  }
+
+  public async make (
+    parent: LucidRow,
+    state: FactoryStateContract,
+    factory: FactoryBuilderContract<any>,
+  ) {
+    const instance = await factory.make(state)
+    parent.$setRelated(this.relation.relationName, instance)
+  }
+
+  public async create (
+    parent: LucidRow,
+    state: FactoryStateContract,
+    factory: FactoryBuilderContract<FactoryModelContract<LucidModel, any>>,
+  ) {
+    const customAttributes = {}
+    this.relation.hydrateForPersistance(parent, customAttributes)
+    const instance = await factory.create(state, (related) => related.merge(customAttributes))
+    parent.$setRelated(this.relation.relationName, instance)
+  }
+}

--- a/src/Factory/Relations/HasOne.ts
+++ b/src/Factory/Relations/HasOne.ts
@@ -35,7 +35,10 @@ export class HasOne extends BaseRelation implements FactoryRelationContract {
    */
   public async make (parent: LucidRow, callback?: RelationCallback) {
     const factory = this.compile(callback)
-    const instance = await factory.make()
+    const customAttributes = {}
+    this.relation.hydrateForPersistance(parent, customAttributes)
+
+    const instance = await factory.makeStubbed((related) => related.merge(customAttributes))
     parent.$setRelated(this.relation.relationName, instance)
   }
 

--- a/src/Factory/Relations/HasOne.ts
+++ b/src/Factory/Relations/HasOne.ts
@@ -12,8 +12,8 @@ import { HasOneRelationContract } from '@ioc:Adonis/Lucid/Relations'
 import {
   RelationCallback,
   FactoryModelContract,
-  FactoryBuilderContract,
   FactoryRelationContract,
+  FactoryBuilderQueryContract,
 } from '@ioc:Adonis/Lucid/Factory'
 
 import { BaseRelation } from './Base'
@@ -24,7 +24,7 @@ import { BaseRelation } from './Base'
 export class HasOne extends BaseRelation implements FactoryRelationContract {
   constructor (
     public relation: HasOneRelationContract<LucidModel, LucidModel>,
-    factory: () => FactoryBuilderContract<FactoryModelContract<LucidModel>>
+    factory: () => FactoryBuilderQueryContract<FactoryModelContract<LucidModel>>
   ) {
     super(factory)
     this.relation.boot()

--- a/src/Factory/Relations/ManyToMany.ts
+++ b/src/Factory/Relations/ManyToMany.ts
@@ -73,6 +73,7 @@ export class ManyToMany implements FactoryRelationContract {
       pivotAttributes[pivotRelatedKey] = pivotRelatedValue
     })
 
+    console.log(pivotAttributes)
     await this.relation.client(parent, this.ctx.$trx!).attach(pivotAttributes)
     parent.$setRelated(this.relation.relationName, instances)
   }

--- a/src/Factory/Relations/ManyToMany.ts
+++ b/src/Factory/Relations/ManyToMany.ts
@@ -12,8 +12,8 @@ import { LucidModel, LucidRow, ModelObject } from '@ioc:Adonis/Lucid/Model'
 import {
   RelationCallback,
   FactoryModelContract,
-  FactoryBuilderContract,
   FactoryRelationContract,
+  FactoryBuilderQueryContract,
 } from '@ioc:Adonis/Lucid/Factory'
 
 import { BaseRelation } from './Base'
@@ -24,7 +24,7 @@ import { BaseRelation } from './Base'
 export class ManyToMany extends BaseRelation implements FactoryRelationContract {
   constructor (
     public relation: ManyToManyRelationContract<LucidModel, LucidModel>,
-    factory: () => FactoryBuilderContract<FactoryModelContract<LucidModel>>
+    factory: () => FactoryBuilderQueryContract<FactoryModelContract<LucidModel>>
   ) {
     super(factory)
     this.relation.boot()

--- a/src/Factory/Relations/ManyToMany.ts
+++ b/src/Factory/Relations/ManyToMany.ts
@@ -1,0 +1,58 @@
+/*
+* @adonisjs/lucid
+*
+* (c) Harminder Virk <virk@adonisjs.com>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+import { LucidModel, LucidRow } from '@ioc:Adonis/Lucid/Model'
+import { ManyToManyRelationContract } from '@ioc:Adonis/Lucid/Relations'
+import {
+  FactoryStateContract,
+  FactoryModelContract,
+  FactoryBuilderContract,
+} from '@ioc:Adonis/Lucid/Factory'
+
+export class ManyToMany {
+  constructor (private relation: ManyToManyRelationContract<LucidModel, LucidModel>) {
+    this.relation.boot()
+  }
+
+  public async make (
+    parent: LucidRow,
+    state: FactoryStateContract,
+    factory: FactoryBuilderContract<any>,
+    count?: number,
+  ) {
+    const instances = await factory.makeMany(count || 1, state)
+    parent.$setRelated(this.relation.relationName, instances)
+  }
+
+  public async create (
+    parent: LucidRow,
+    state: FactoryStateContract,
+    factory: FactoryBuilderContract<FactoryModelContract<LucidModel, any>>,
+    count?: number,
+  ) {
+    const customAttributes = {}
+    const pivotAttributes: any = {}
+
+    const instances = await factory.createMany(count || 1, state, (related) => {
+      related.merge(customAttributes)
+    })
+
+    const [pivotKey, pivotValue] = this.relation.getPivotPair(parent)
+
+    instances.forEach((related) => {
+      const [pivotRelatedKey, pivotRelatedValue] = this.relation.getPivotRelatedPair(related)
+      related.$extras[pivotKey] = pivotValue
+      related.$extras[pivotRelatedKey] = pivotRelatedValue
+      pivotAttributes[pivotRelatedKey] = pivotRelatedValue
+    })
+
+    await this.relation.client(parent, state.$trx!).attach(pivotAttributes)
+    parent.$setRelated(this.relation.relationName, instances)
+  }
+}

--- a/src/Factory/Relations/ManyToMany.ts
+++ b/src/Factory/Relations/ManyToMany.ts
@@ -70,10 +70,9 @@ export class ManyToMany implements FactoryRelationContract {
       const [pivotRelatedKey, pivotRelatedValue] = this.relation.getPivotRelatedPair(related)
       related.$extras[pivotKey] = pivotValue
       related.$extras[pivotRelatedKey] = pivotRelatedValue
-      pivotAttributes[pivotRelatedKey] = pivotRelatedValue
+      pivotAttributes[pivotRelatedValue] = {}
     })
 
-    console.log(pivotAttributes)
     await this.relation.client(parent, this.ctx.$trx!).attach(pivotAttributes)
     parent.$setRelated(this.relation.relationName, instances)
   }

--- a/src/Factory/index.ts
+++ b/src/Factory/index.ts
@@ -1,0 +1,41 @@
+/*
+ * @adonisjs/lucid
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+*/
+
+import { LucidModel, LucidRow } from '@ioc:Adonis/Lucid/Model'
+import { FactoryManagerContract, DefineCallback, StubIdCallback } from '@ioc:Adonis/Lucid/Factory'
+import { FactoryModel } from './FactoryModel'
+
+/**
+ * Factory manager exposes the API to register factories.
+ */
+export class FactoryManager implements FactoryManagerContract {
+  private stubCounter = 1
+  private stubIdCallback: StubIdCallback = (counter) => counter
+
+  /**
+   * Returns the next id
+   */
+  public getNextId (model: LucidRow) {
+    return this.stubIdCallback(this.stubCounter++, model)
+  }
+
+  /**
+   * Define a factory model
+   */
+  public define<Model extends LucidModel> (model: Model, callback: DefineCallback<Model>) {
+    return new FactoryModel(model, callback, this)
+  }
+
+  /**
+   * Define custom callback to generate stub ids
+   */
+  public stubId (callback: StubIdCallback) {
+    this.stubIdCallback = callback
+  }
+}

--- a/src/Orm/Relations/HasOne/index.ts
+++ b/src/Orm/Relations/HasOne/index.ts
@@ -34,9 +34,15 @@ export class HasOne implements HasOneRelationContract<LucidModel, LucidModel> {
     : this.options.serializeAs
 
   /**
-   * Available after boot is invoked
+   * Local key is reference to the primary key in the self table
+   * @note: Available after boot is invoked
    */
   public localKey: string
+
+  /**
+   * Foreign key is reference to the foreign key in the related table
+   * @note: Available after boot is invoked
+   */
   public foreignKey: string
 
   /**

--- a/test-helpers/index.ts
+++ b/test-helpers/index.ts
@@ -41,7 +41,7 @@ import {
 import { ApplicationContract } from '@ioc:Adonis/Core/Application'
 import { SchemaConstructorContract } from '@ioc:Adonis/Lucid/Schema'
 import { MigratorContract, MigratorOptions } from '@ioc:Adonis/Lucid/Migrator'
-import { FactoryModelContract, NewUpModelFunction } from '@ioc:Adonis/Lucid/Factory'
+import { FactoryModelContract, DefineCallback } from '@ioc:Adonis/Lucid/Factory'
 
 import { Schema } from '../src/Schema'
 import { Migrator } from '../src/Migrator'
@@ -382,10 +382,10 @@ export function getBaseModel (adapter: AdapterContract, container?: IocContract)
  */
 export function getFactoryModel () {
   return FactoryModel as unknown as {
-    new<Model extends LucidModel, Attributes extends any> (
+    new<Model extends LucidModel> (
       model: Model,
-      callback: NewUpModelFunction<Model, Attributes>
-    ): FactoryModelContract<Model, Attributes>
+      callback: DefineCallback<Model>
+    ): FactoryModelContract<Model>
   }
 }
 

--- a/test-helpers/index.ts
+++ b/test-helpers/index.ts
@@ -41,7 +41,7 @@ import {
 import { ApplicationContract } from '@ioc:Adonis/Core/Application'
 import { SchemaConstructorContract } from '@ioc:Adonis/Lucid/Schema'
 import { MigratorContract, MigratorOptions } from '@ioc:Adonis/Lucid/Migrator'
-import { FactoryModelContract, DefineCallback } from '@ioc:Adonis/Lucid/Factory'
+import { FactoryModelContract, DefineCallback, FactoryManagerContract } from '@ioc:Adonis/Lucid/Factory'
 
 import { Schema } from '../src/Schema'
 import { Migrator } from '../src/Migrator'
@@ -384,7 +384,8 @@ export function getFactoryModel () {
   return FactoryModel as unknown as {
     new<Model extends LucidModel> (
       model: Model,
-      callback: DefineCallback<Model>
+      callback: DefineCallback<Model>,
+      manager: FactoryManagerContract,
     ): FactoryModelContract<Model>
   }
 }

--- a/test-helpers/index.ts
+++ b/test-helpers/index.ts
@@ -41,6 +41,7 @@ import {
 import { ApplicationContract } from '@ioc:Adonis/Core/Application'
 import { SchemaConstructorContract } from '@ioc:Adonis/Lucid/Schema'
 import { MigratorContract, MigratorOptions } from '@ioc:Adonis/Lucid/Migrator'
+import { FactoryModelContract, NewUpModelFunction } from '@ioc:Adonis/Lucid/Factory'
 
 import { Schema } from '../src/Schema'
 import { Migrator } from '../src/Migrator'
@@ -48,6 +49,7 @@ import { Adapter } from '../src/Orm/Adapter'
 import { BaseModel } from '../src/Orm/BaseModel'
 import { QueryClient } from '../src/QueryClient'
 import { Database } from '../src/Database/index'
+import { FactoryModel } from '../src/Factory/FactoryModel'
 import { RawQueryBuilder } from '../src/Database/QueryBuilder/Raw'
 import { InsertQueryBuilder } from '../src/Database/QueryBuilder/Insert'
 import { DatabaseQueryBuilder } from '../src/Database/QueryBuilder/Database'
@@ -373,6 +375,18 @@ export function getBaseModel (adapter: AdapterContract, container?: IocContract)
   BaseModel.$adapter = adapter
   BaseModel.$container = container || new Ioc()
   return BaseModel as unknown as LucidModel
+}
+
+/**
+ * Returns the factory model
+ */
+export function getFactoryModel () {
+  return FactoryModel as unknown as {
+    new<Model extends LucidModel, Attributes extends any> (
+      model: Model,
+      callback: NewUpModelFunction<Model, Attributes>
+    ): FactoryModelContract<Model, Attributes>
+  }
 }
 
 /**

--- a/test/database/query-builder.spec.ts
+++ b/test/database/query-builder.spec.ts
@@ -340,6 +340,32 @@ test.group('Query Builder | select', (group) => {
     assert.deepEqual(bindings, knexBindings)
     await connection.disconnect()
   })
+
+  test('chain select calls', async (assert) => {
+    const connection = new Connection('primary', getConfig(), getLogger())
+    connection.connect()
+
+    const db = getQueryBuilder(getQueryClient(connection))
+    const db1 = getQueryBuilder(getQueryClient(connection))
+
+    const { sql, bindings } = db
+      .from('users')
+      .select('*')
+      .select(db1.from('addresses').count('* as total').as('addresses_total'))
+      .toSQL()
+
+    const { sql: knexSql, bindings: knexBindings } = connection.client!
+      .from('users')
+      .select(
+        '*',
+        connection.client!.from('addresses').count('* as total').as('addresses_total')
+      )
+      .toSQL()
+
+    assert.equal(sql, knexSql)
+    assert.deepEqual(bindings, knexBindings)
+    await connection.disconnect()
+  })
 })
 
 test.group('Query Builder | where', (group) => {

--- a/test/factory/belongs-to-spec.ts
+++ b/test/factory/belongs-to-spec.ts
@@ -72,8 +72,8 @@ test.group('Factory | BelongTo | make', (group) => {
       profile.displayName = 'virk'
       return profile
     })
-    .related('user', () => factory)
-    .build()
+      .related('user', () => factory)
+      .build()
 
     const factory = new FactoryModel(User, () => new User()).build()
 
@@ -113,8 +113,8 @@ test.group('Factory | BelongTo | make', (group) => {
       profile.displayName = 'virk'
       return profile
     })
-    .related('user', () => factory)
-    .build()
+      .related('user', () => factory)
+      .build()
 
     const factory = new FactoryModel(User, (_, attributes?: any) => {
       const user = new User()
@@ -122,7 +122,7 @@ test.group('Factory | BelongTo | make', (group) => {
       return user
     }).build()
 
-    const profile = await profileFactory.with('user', 1, (factory) => (factory.fill({ points: 10 }))).make()
+    const profile = await profileFactory.with('user', 1, (related) => related.fill({ points: 10 })).make()
     assert.isFalse(profile.$isPersisted)
     assert.instanceOf(profile.user, User)
     assert.isFalse(profile.user.$isPersisted)
@@ -176,8 +176,8 @@ test.group('Factory | BelongTo | create', (group) => {
       profile.displayName = 'virk'
       return profile
     })
-    .related('user', () => factory)
-    .build()
+      .related('user', () => factory)
+      .build()
 
     const factory = new FactoryModel(User, () => new User()).build()
 
@@ -217,8 +217,8 @@ test.group('Factory | BelongTo | create', (group) => {
       profile.displayName = 'virk'
       return profile
     })
-    .related('user', () => factory)
-    .build()
+      .related('user', () => factory)
+      .build()
 
     const factory = new FactoryModel(User, (_, attributes?: any) => {
       const user = new User()
@@ -226,7 +226,7 @@ test.group('Factory | BelongTo | create', (group) => {
       return user
     }).build()
 
-    const profile = await profileFactory.with('user', 1, (factory) => (factory.fill({ points: 10 }))).create()
+    const profile = await profileFactory.with('user', 1, (related) => related.fill({ points: 10 })).create()
     assert.isTrue(profile.$isPersisted)
     assert.instanceOf(profile.user, User)
     assert.isTrue(profile.user.$isPersisted)
@@ -263,8 +263,8 @@ test.group('Factory | BelongTo | create', (group) => {
       profile.displayName = 'virk'
       return profile
     })
-    .related('user', () => factory)
-    .build()
+      .related('user', () => factory)
+      .build()
 
     const factory = new FactoryModel(User, (_, attributes?: any) => {
       const user = new User()
@@ -272,7 +272,7 @@ test.group('Factory | BelongTo | create', (group) => {
       return user
     }).build()
 
-    const profile = await profileFactory.with('user', 1, (factory) => (factory.fill({ points: 10 }))).create()
+    const profile = await profileFactory.with('user', 1, (related) => related.fill({ points: 10 })).create()
     assert.isTrue(profile.$isPersisted)
     assert.instanceOf(profile.user, User)
     assert.isTrue(profile.user.$isPersisted)
@@ -311,8 +311,8 @@ test.group('Factory | BelongTo | create', (group) => {
       profile.displayName = 'Virk'
       return profile
     })
-    .related('user', () => factory)
-    .build()
+      .related('user', () => factory)
+      .build()
 
     /**
      * Creating user in advance, so that the `user` relationship

--- a/test/factory/belongs-to-spec.ts
+++ b/test/factory/belongs-to-spec.ts
@@ -11,6 +11,7 @@
 
 import test from 'japa'
 import { BelongsTo } from '@ioc:Adonis/Lucid/Relations'
+import { FactoryManager } from '../../src/Factory/index'
 import { column, belongsTo } from '../../src/Orm/Decorators'
 
 import {
@@ -26,6 +27,7 @@ import {
 let db: ReturnType<typeof getDb>
 let BaseModel: ReturnType<typeof getBaseModel>
 const FactoryModel = getFactoryModel()
+const factoryManager = new FactoryManager()
 
 test.group('Factory | BelongTo | make', (group) => {
   group.before(async () => {
@@ -74,13 +76,13 @@ test.group('Factory | BelongTo | make', (group) => {
       return {
         displayName: 'virk',
       }
-    })
+    }, factoryManager)
       .relation('user', () => factory)
       .build()
 
     const factory = new FactoryModel(User, () => {
       return {}
-    }).build()
+    }, factoryManager).build()
 
     const profile = await profileFactory.with('user').makeStubbed()
     assert.exists(profile.id)
@@ -123,7 +125,7 @@ test.group('Factory | BelongTo | make', (group) => {
       return {
         displayName: 'virk',
       }
-    })
+    }, factoryManager)
       .relation('user', () => factory)
       .build()
 
@@ -131,7 +133,7 @@ test.group('Factory | BelongTo | make', (group) => {
       return {
         points: 0,
       }
-    }).build()
+    }, factoryManager).build()
 
     const profile = await profileFactory
       .with('user', 1, (related) => related.merge({ points: 10 }))
@@ -179,7 +181,7 @@ test.group('Factory | BelongTo | make', (group) => {
       return {
         displayName: 'virk',
       }
-    })
+    }, factoryManager)
       .relation('user', () => factory)
       .build()
 
@@ -187,7 +189,7 @@ test.group('Factory | BelongTo | make', (group) => {
       return {
         points: 0,
       }
-    })
+    }, factoryManager)
       .after('make', (_, user) => {
         user.id = 100
       })
@@ -253,13 +255,13 @@ test.group('Factory | BelongTo | create', (group) => {
       return {
         displayName: 'virk',
       }
-    })
+    }, factoryManager)
       .relation('user', () => factory)
       .build()
 
     const factory = new FactoryModel(User, () => {
       return {}
-    }).build()
+    }, factoryManager).build()
 
     const profile = await profileFactory.with('user').create()
 
@@ -297,7 +299,7 @@ test.group('Factory | BelongTo | create', (group) => {
       return {
         displayName: 'virk',
       }
-    })
+    }, factoryManager)
       .relation('user', () => factory)
       .build()
 
@@ -305,7 +307,7 @@ test.group('Factory | BelongTo | create', (group) => {
       return {
         points: 0,
       }
-    }).build()
+    }, factoryManager).build()
 
     const profile = await profileFactory
       .with('user', 1, (related) => related.merge({ points: 10 }))
@@ -346,7 +348,7 @@ test.group('Factory | BelongTo | create', (group) => {
       return {
         displayName: 'virk',
       }
-    })
+    }, factoryManager)
       .relation('user', () => factory)
       .build()
 
@@ -354,7 +356,7 @@ test.group('Factory | BelongTo | create', (group) => {
       return {
         points: 0,
       }
-    }).build()
+    }, factoryManager).build()
 
     const profile = await profileFactory
       .with('user', 1, (related) => related.merge({ points: 10 }))
@@ -397,7 +399,7 @@ test.group('Factory | BelongTo | create', (group) => {
       return {
         displayName: 'virk',
       }
-    })
+    }, factoryManager)
       .relation('user', () => factory)
       .build()
 
@@ -414,7 +416,7 @@ test.group('Factory | BelongTo | create', (group) => {
       return {
         username: 'virk',
       }
-    }).build()
+    }, factoryManager).build()
 
     try {
       await profileFactory.with('user').create()

--- a/test/factory/belongs-to-spec.ts
+++ b/test/factory/belongs-to-spec.ts
@@ -72,7 +72,7 @@ test.group('Factory | BelongTo | make', (group) => {
         displayName: 'virk',
       }
     })
-      .related('user', () => factory)
+      .relation('user', () => factory)
       .build()
 
     const factory = new FactoryModel(User, () => {
@@ -115,7 +115,7 @@ test.group('Factory | BelongTo | make', (group) => {
         displayName: 'virk',
       }
     })
-      .related('user', () => factory)
+      .relation('user', () => factory)
       .build()
 
     const factory = new FactoryModel(User, () => {
@@ -178,7 +178,7 @@ test.group('Factory | BelongTo | create', (group) => {
         displayName: 'virk',
       }
     })
-      .related('user', () => factory)
+      .relation('user', () => factory)
       .build()
 
     const factory = new FactoryModel(User, () => {
@@ -221,7 +221,7 @@ test.group('Factory | BelongTo | create', (group) => {
         displayName: 'virk',
       }
     })
-      .related('user', () => factory)
+      .relation('user', () => factory)
       .build()
 
     const factory = new FactoryModel(User, () => {
@@ -267,7 +267,7 @@ test.group('Factory | BelongTo | create', (group) => {
         displayName: 'virk',
       }
     })
-      .related('user', () => factory)
+      .relation('user', () => factory)
       .build()
 
     const factory = new FactoryModel(User, () => {
@@ -315,7 +315,7 @@ test.group('Factory | BelongTo | create', (group) => {
         displayName: 'virk',
       }
     })
-      .related('user', () => factory)
+      .relation('user', () => factory)
       .build()
 
     /**

--- a/test/factory/belongs-to-spec.ts
+++ b/test/factory/belongs-to-spec.ts
@@ -68,14 +68,16 @@ test.group('Factory | BelongTo | make', (group) => {
     }
 
     const profileFactory = new FactoryModel(Profile, () => {
-      const profile = new Profile()
-      profile.displayName = 'virk'
-      return profile
+      return {
+        displayName: 'virk',
+      }
     })
       .related('user', () => factory)
       .build()
 
-    const factory = new FactoryModel(User, () => new User()).build()
+    const factory = new FactoryModel(User, () => {
+      return {}
+    }).build()
 
     const profile = await profileFactory.with('user').make()
     assert.isFalse(profile.$isPersisted)
@@ -109,20 +111,20 @@ test.group('Factory | BelongTo | make', (group) => {
     }
 
     const profileFactory = new FactoryModel(Profile, () => {
-      const profile = new Profile()
-      profile.displayName = 'virk'
-      return profile
+      return {
+        displayName: 'virk',
+      }
     })
       .related('user', () => factory)
       .build()
 
-    const factory = new FactoryModel(User, (_, attributes?: any) => {
-      const user = new User()
-      user.points = attributes?.points || 0
-      return user
+    const factory = new FactoryModel(User, () => {
+      return {
+        points: 0,
+      }
     }).build()
 
-    const profile = await profileFactory.with('user', 1, (related) => related.fill({ points: 10 })).make()
+    const profile = await profileFactory.with('user', 1, (related) => related.merge({ points: 10 })).make()
     assert.isFalse(profile.$isPersisted)
     assert.instanceOf(profile.user, User)
     assert.isFalse(profile.user.$isPersisted)
@@ -172,14 +174,16 @@ test.group('Factory | BelongTo | create', (group) => {
     }
 
     const profileFactory = new FactoryModel(Profile, () => {
-      const profile = new Profile()
-      profile.displayName = 'virk'
-      return profile
+      return {
+        displayName: 'virk',
+      }
     })
       .related('user', () => factory)
       .build()
 
-    const factory = new FactoryModel(User, () => new User()).build()
+    const factory = new FactoryModel(User, () => {
+      return {}
+    }).build()
 
     const profile = await profileFactory.with('user').create()
     assert.isTrue(profile.$isPersisted)
@@ -213,20 +217,20 @@ test.group('Factory | BelongTo | create', (group) => {
     }
 
     const profileFactory = new FactoryModel(Profile, () => {
-      const profile = new Profile()
-      profile.displayName = 'virk'
-      return profile
+      return {
+        displayName: 'virk',
+      }
     })
       .related('user', () => factory)
       .build()
 
-    const factory = new FactoryModel(User, (_, attributes?: any) => {
-      const user = new User()
-      user.points = attributes?.points || 0
-      return user
+    const factory = new FactoryModel(User, () => {
+      return {
+        points: 0,
+      }
     }).build()
 
-    const profile = await profileFactory.with('user', 1, (related) => related.fill({ points: 10 })).create()
+    const profile = await profileFactory.with('user', 1, (related) => related.merge({ points: 10 })).create()
     assert.isTrue(profile.$isPersisted)
     assert.instanceOf(profile.user, User)
     assert.isTrue(profile.user.$isPersisted)
@@ -259,20 +263,20 @@ test.group('Factory | BelongTo | create', (group) => {
     }
 
     const profileFactory = new FactoryModel(Profile, () => {
-      const profile = new Profile()
-      profile.displayName = 'virk'
-      return profile
+      return {
+        displayName: 'virk',
+      }
     })
       .related('user', () => factory)
       .build()
 
-    const factory = new FactoryModel(User, (_, attributes?: any) => {
-      const user = new User()
-      user.points = attributes?.points || 0
-      return user
+    const factory = new FactoryModel(User, () => {
+      return {
+        points: 0,
+      }
     }).build()
 
-    const profile = await profileFactory.with('user', 1, (related) => related.fill({ points: 10 })).create()
+    const profile = await profileFactory.with('user', 1, (related) => related.merge({ points: 10 })).create()
     assert.isTrue(profile.$isPersisted)
     assert.instanceOf(profile.user, User)
     assert.isTrue(profile.user.$isPersisted)
@@ -307,9 +311,9 @@ test.group('Factory | BelongTo | create', (group) => {
     }
 
     const profileFactory = new FactoryModel(Profile, () => {
-      const profile = new Profile()
-      profile.displayName = 'Virk'
-      return profile
+      return {
+        displayName: 'virk',
+      }
     })
       .related('user', () => factory)
       .build()
@@ -324,9 +328,9 @@ test.group('Factory | BelongTo | create', (group) => {
     await db.table('users').insert({ username: 'virk' })
 
     const factory = new FactoryModel(User, () => {
-      const user = new User()
-      user.username = 'virk'
-      return user
+      return {
+        username: 'virk',
+      }
     }).build()
 
     try {

--- a/test/factory/belongs-to-spec.ts
+++ b/test/factory/belongs-to-spec.ts
@@ -1,0 +1,344 @@
+/*
+* @adonisjs/lucid
+*
+* (c) Harminder Virk <virk@adonisjs.com>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+/// <reference path="../../adonis-typings/index.ts" />
+
+import test from 'japa'
+import { BelongsTo } from '@ioc:Adonis/Lucid/Relations'
+import { column, belongsTo } from '../../src/Orm/Decorators'
+
+import {
+  setup,
+  getDb,
+  cleanup,
+  ormAdapter,
+  resetTables,
+  getBaseModel,
+  getFactoryModel,
+} from '../../test-helpers'
+
+let db: ReturnType<typeof getDb>
+let BaseModel: ReturnType<typeof getBaseModel>
+const FactoryModel = getFactoryModel()
+
+test.group('Factory | BelongTo | make', (group) => {
+  group.before(async () => {
+    db = getDb()
+    BaseModel = getBaseModel(ormAdapter(db))
+    await setup()
+  })
+
+  group.after(async () => {
+    await cleanup()
+    await db.manager.closeAll()
+  })
+
+  group.afterEach(async () => {
+    await resetTables()
+  })
+
+  test('make model with relationship', async (assert) => {
+    class Profile extends BaseModel {
+      @column()
+      public userId: number
+
+      @column()
+      public displayName: string
+
+      @belongsTo(() => User)
+      public user: BelongsTo<typeof User>
+    }
+    Profile.boot()
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number = 0
+    }
+
+    const profileFactory = new FactoryModel(Profile, () => {
+      const profile = new Profile()
+      profile.displayName = 'virk'
+      return profile
+    })
+    .related('user', () => factory)
+    .build()
+
+    const factory = new FactoryModel(User, () => new User()).build()
+
+    const profile = await profileFactory.with('user').make()
+    assert.isFalse(profile.$isPersisted)
+    assert.instanceOf(profile.user, User)
+    assert.isFalse(profile.user.$isPersisted)
+    assert.equal(profile.user.id, profile.userId)
+  })
+
+  test('pass custom attributes to the relationship', async (assert) => {
+    class Profile extends BaseModel {
+      @column()
+      public userId: number
+
+      @column()
+      public displayName: string
+
+      @belongsTo(() => User)
+      public user: BelongsTo<typeof User>
+    }
+    Profile.boot()
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number = 0
+    }
+
+    const profileFactory = new FactoryModel(Profile, () => {
+      const profile = new Profile()
+      profile.displayName = 'virk'
+      return profile
+    })
+    .related('user', () => factory)
+    .build()
+
+    const factory = new FactoryModel(User, (_, attributes?: any) => {
+      const user = new User()
+      user.points = attributes?.points || 0
+      return user
+    }).build()
+
+    const profile = await profileFactory.with('user', 1, (factory) => (factory.fill({ points: 10 }))).make()
+    assert.isFalse(profile.$isPersisted)
+    assert.instanceOf(profile.user, User)
+    assert.isFalse(profile.user.$isPersisted)
+    assert.equal(profile.user.id, profile.userId)
+    assert.equal(profile.user.points, 10)
+  })
+})
+
+test.group('Factory | BelongTo | create', (group) => {
+  group.before(async () => {
+    db = getDb()
+    BaseModel = getBaseModel(ormAdapter(db))
+    await setup()
+  })
+
+  group.after(async () => {
+    await cleanup()
+    await db.manager.closeAll()
+  })
+
+  group.afterEach(async () => {
+    await resetTables()
+  })
+
+  test('create model with relationship', async (assert) => {
+    class Profile extends BaseModel {
+      @column()
+      public userId: number
+
+      @column()
+      public displayName: string
+
+      @belongsTo(() => User)
+      public user: BelongsTo<typeof User>
+    }
+    Profile.boot()
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number = 0
+    }
+
+    const profileFactory = new FactoryModel(Profile, () => {
+      const profile = new Profile()
+      profile.displayName = 'virk'
+      return profile
+    })
+    .related('user', () => factory)
+    .build()
+
+    const factory = new FactoryModel(User, () => new User()).build()
+
+    const profile = await profileFactory.with('user').create()
+    assert.isTrue(profile.$isPersisted)
+    assert.instanceOf(profile.user, User)
+    assert.isTrue(profile.user.$isPersisted)
+    assert.equal(profile.user.id, profile.userId)
+  })
+
+  test('pass custom attributes to the relationship', async (assert) => {
+    class Profile extends BaseModel {
+      @column()
+      public userId: number
+
+      @column()
+      public displayName: string
+
+      @belongsTo(() => User)
+      public user: BelongsTo<typeof User>
+    }
+    Profile.boot()
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number = 0
+    }
+
+    const profileFactory = new FactoryModel(Profile, () => {
+      const profile = new Profile()
+      profile.displayName = 'virk'
+      return profile
+    })
+    .related('user', () => factory)
+    .build()
+
+    const factory = new FactoryModel(User, (_, attributes?: any) => {
+      const user = new User()
+      user.points = attributes?.points || 0
+      return user
+    }).build()
+
+    const profile = await profileFactory.with('user', 1, (factory) => (factory.fill({ points: 10 }))).create()
+    assert.isTrue(profile.$isPersisted)
+    assert.instanceOf(profile.user, User)
+    assert.isTrue(profile.user.$isPersisted)
+    assert.equal(profile.user.id, profile.userId)
+    assert.equal(profile.user.points, 10)
+  })
+
+  test('create model with custom foreign key', async (assert) => {
+    class Profile extends BaseModel {
+      @column({ columnName: 'user_id' })
+      public authorId: number
+
+      @column()
+      public displayName: string
+
+      @belongsTo(() => User, { foreignKey: 'authorId' })
+      public user: BelongsTo<typeof User>
+    }
+    Profile.boot()
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number = 0
+    }
+
+    const profileFactory = new FactoryModel(Profile, () => {
+      const profile = new Profile()
+      profile.displayName = 'virk'
+      return profile
+    })
+    .related('user', () => factory)
+    .build()
+
+    const factory = new FactoryModel(User, (_, attributes?: any) => {
+      const user = new User()
+      user.points = attributes?.points || 0
+      return user
+    }).build()
+
+    const profile = await profileFactory.with('user', 1, (factory) => (factory.fill({ points: 10 }))).create()
+    assert.isTrue(profile.$isPersisted)
+    assert.instanceOf(profile.user, User)
+    assert.isTrue(profile.user.$isPersisted)
+    assert.equal(profile.user.id, profile.authorId)
+    assert.equal(profile.user.points, 10)
+  })
+
+  test('rollback changes on error', async (assert) => {
+    assert.plan(3)
+
+    class Profile extends BaseModel {
+      @column()
+      public userId: number
+
+      @column()
+      public displayName: string
+
+      @belongsTo(() => User)
+      public user: BelongsTo<typeof User>
+    }
+    Profile.boot()
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number = 0
+    }
+
+    const profileFactory = new FactoryModel(Profile, () => {
+      const profile = new Profile()
+      profile.displayName = 'Virk'
+      return profile
+    })
+    .related('user', () => factory)
+    .build()
+
+    /**
+     * Creating user in advance, so that the `user` relationship
+     * create call raises a unique constraint exception.
+     *
+     * After the exception, we except the profile insert to be
+     * rolled back as well.
+     */
+    await db.table('users').insert({ username: 'virk' })
+
+    const factory = new FactoryModel(User, () => {
+      const user = new User()
+      user.username = 'virk'
+      return user
+    }).build()
+
+    try {
+      await profileFactory.with('user').create()
+    } catch (error) {
+      assert.exists(error)
+    }
+
+    const profiles = await db.from('profiles').exec()
+    const users = await db.from('users').exec()
+
+    assert.lengthOf(profiles, 0)
+    assert.lengthOf(users, 1) // one user still exists from the setup insert call
+  })
+})

--- a/test/factory/factory-builder.spec.ts
+++ b/test/factory/factory-builder.spec.ts
@@ -11,6 +11,7 @@
 
 import test from 'japa'
 import { column } from '../../src/Orm/Decorators'
+import { FactoryManager } from '../../src/Factory/index'
 import { FactoryContext } from '../../src/Factory/FactoryContext'
 import { FactoryBuilder } from '../../src/Factory/FactoryBuilder'
 
@@ -27,6 +28,7 @@ import {
 let db: ReturnType<typeof getDb>
 let BaseModel: ReturnType<typeof getBaseModel>
 const FactoryModel = getFactoryModel()
+const factoryManager = new FactoryManager()
 
 test.group('Factory | Factory Builder | make', (group) => {
   group.before(async () => {
@@ -58,7 +60,7 @@ test.group('Factory | Factory Builder | make', (group) => {
 
     const factory = new FactoryModel(User, () => {
       return {}
-    })
+    }, factoryManager)
       .state('withPoints', (user) => user.points = 10)
       .build()
 
@@ -82,7 +84,7 @@ test.group('Factory | Factory Builder | make', (group) => {
 
     const factory = new FactoryModel(User, () => {
       return {}
-    })
+    }, factoryManager)
       .state('withPoints', (user) => {
         user.points += 10
       })
@@ -110,7 +112,7 @@ test.group('Factory | Factory Builder | make', (group) => {
       return {
         username: 'virk',
       }
-    }).build()
+    }, factoryManager).build()
 
     const user = await factory.merge({ username: 'nikk' }).makeStubbed()
     assert.equal(user.username, 'nikk')
@@ -134,7 +136,7 @@ test.group('Factory | Factory Builder | make', (group) => {
       return {
         username: 'virk',
       }
-    })
+    }, factoryManager)
       .merge(() => {})
       .build()
 
@@ -160,7 +162,7 @@ test.group('Factory | Factory Builder | make', (group) => {
       return {
         username: 'virk',
       }
-    })
+    }, factoryManager)
       .newUp((attributes) => {
         const user = new User()
         user.fill(attributes)
@@ -193,7 +195,7 @@ test.group('Factory | Factory Builder | make', (group) => {
       return {
         username: 'virk',
       }
-    }).build()
+    }, factoryManager).build()
 
     const user = await factory.merge([{ username: 'nikk' }, { username: 'romain' }]).makeStubbed()
     assert.equal(user.username, 'nikk')
@@ -219,7 +221,7 @@ test.group('Factory | Factory Builder | make', (group) => {
       return {
         username: 'virk',
       }
-    })
+    }, factoryManager)
       .after('make', (_, user, ctx) => {
         assert.instanceOf(_, FactoryBuilder)
         assert.instanceOf(user, User)
@@ -251,7 +253,7 @@ test.group('Factory | Factory Builder | make', (group) => {
       return {
         username: 'virk',
       }
-    })
+    }, factoryManager)
       .after('makeStubbed', (_, user, ctx) => {
         assert.instanceOf(_, FactoryBuilder)
         assert.instanceOf(user, User)
@@ -283,7 +285,7 @@ test.group('Factory | Factory Builder | make', (group) => {
       return {
         username: 'virk',
       }
-    })
+    }, factoryManager)
       .after('make', (_, user, ctx) => {
         if (ctx.isStubbed) {
           user.id = 100
@@ -328,7 +330,7 @@ test.group('Factory | Factory Builder | makeMany', (group) => {
 
     const factory = new FactoryModel(User, () => {
       return {}
-    })
+    }, factoryManager)
       .state('withPoints', (user) => user.points = 10)
       .build()
 
@@ -357,7 +359,7 @@ test.group('Factory | Factory Builder | makeMany', (group) => {
 
     const factory = new FactoryModel(User, () => {
       return {}
-    })
+    }, factoryManager)
       .state('withPoints', (user) => user.points += 10)
       .build()
 
@@ -389,7 +391,7 @@ test.group('Factory | Factory Builder | makeMany', (group) => {
       return {
         username: 'virk',
       }
-    }).build()
+    }, factoryManager).build()
 
     const users = await factory.merge({ username: 'nikk' }).makeStubbedMany(2)
     assert.lengthOf(users, 2)
@@ -419,7 +421,7 @@ test.group('Factory | Factory Builder | makeMany', (group) => {
       return {
         username: 'virk',
       }
-    }).build()
+    }, factoryManager).build()
 
     const users = await factory.merge([{ username: 'nikk' }, { username: 'romain' }]).makeStubbedMany(2)
     assert.lengthOf(users, 2)
@@ -449,7 +451,7 @@ test.group('Factory | Factory Builder | makeMany', (group) => {
 
     const factory = new FactoryModel(User, () => {
       return {}
-    })
+    }, factoryManager)
       .after('makeStubbed', (_, user, ctx) => {
         assert.instanceOf(_, FactoryBuilder)
         assert.instanceOf(user, User)
@@ -486,7 +488,7 @@ test.group('Factory | Factory Builder | makeMany', (group) => {
 
     const factory = new FactoryModel(User, () => {
       return {}
-    })
+    }, factoryManager)
       .after('make', (_, user, ctx) => {
         assert.instanceOf(_, FactoryBuilder)
         assert.instanceOf(user, User)
@@ -538,7 +540,7 @@ test.group('Factory | Factory Builder | create', (group) => {
 
     const factory = new FactoryModel(User, () => {
       return {}
-    })
+    }, factoryManager)
       .state('withPoints', (user) => user.points = 10)
       .build()
 
@@ -561,7 +563,7 @@ test.group('Factory | Factory Builder | create', (group) => {
 
     const factory = new FactoryModel(User, () => {
       return {}
-    })
+    }, factoryManager)
       .state('withPoints', (user) => user.points += 10)
       .build()
 
@@ -586,7 +588,7 @@ test.group('Factory | Factory Builder | create', (group) => {
       return {
         username: 'virk',
       }
-    }).build()
+    }, factoryManager).build()
 
     const user = await factory.merge({ username: 'nikk' }).create()
     assert.equal(user.username, 'nikk')
@@ -609,7 +611,7 @@ test.group('Factory | Factory Builder | create', (group) => {
       return {
         username: 'virk',
       }
-    }).build()
+    }, factoryManager).build()
 
     const user = await factory.merge([{ username: 'nikk' }, { username: 'romain' }]).create()
     assert.equal(user.username, 'nikk')
@@ -632,7 +634,7 @@ test.group('Factory | Factory Builder | create', (group) => {
 
     const factory = new FactoryModel(User, () => {
       return {}
-    })
+    }, factoryManager)
       .before('create', (_, user) => {
         assert.isFalse(user.$isPersisted)
       })
@@ -664,7 +666,7 @@ test.group('Factory | Factory Builder | create', (group) => {
 
     const factory = new FactoryModel(User, () => {
       return {}
-    })
+    }, factoryManager)
       .before('create', (_, user) => {
         stack.push('beforeCreate')
         assert.isFalse(user.$isPersisted)
@@ -717,7 +719,7 @@ test.group('Factory | Factory Builder | createMany', (group) => {
 
     const factory = new FactoryModel(User, () => {
       return {}
-    })
+    }, factoryManager)
       .state('withPoints', (user) => user.points = 10)
       .build()
 
@@ -743,7 +745,7 @@ test.group('Factory | Factory Builder | createMany', (group) => {
 
     const factory = new FactoryModel(User, () => {
       return {}
-    })
+    }, factoryManager)
       .state('withPoints', (user) => user.points += 10)
       .build()
 
@@ -772,7 +774,7 @@ test.group('Factory | Factory Builder | createMany', (group) => {
         username: `u-${new Date().getTime()}`,
         points: 0,
       }
-    }).build()
+    }, factoryManager).build()
 
     const users = await factory.merge({ points: 10 }).createMany(2)
     assert.lengthOf(users, 2)
@@ -798,7 +800,7 @@ test.group('Factory | Factory Builder | createMany', (group) => {
       return {
         username: 'virk',
       }
-    }).build()
+    }, factoryManager).build()
 
     const users = await factory.merge([{ username: 'nikk' }, { username: 'romain' }]).createMany(2)
     assert.lengthOf(users, 2)

--- a/test/factory/factory-builder.spec.ts
+++ b/test/factory/factory-builder.spec.ts
@@ -1,0 +1,473 @@
+/*
+* @adonisjs/lucid
+*
+* (c) Harminder Virk <virk@adonisjs.com>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+/// <reference path="../../adonis-typings/index.ts" />
+
+import { ModelAttributes } from '@ioc:Adonis/Lucid/Model'
+import test from 'japa'
+import { column } from '../../src/Orm/Decorators'
+
+import {
+  setup,
+  getDb,
+  cleanup,
+  ormAdapter,
+  resetTables,
+  getBaseModel,
+  getFactoryModel,
+} from '../../test-helpers'
+
+let db: ReturnType<typeof getDb>
+let BaseModel: ReturnType<typeof getBaseModel>
+const FactoryModel = getFactoryModel()
+
+test.group('Factory | Factory Builder | make', (group) => {
+  group.before(async () => {
+    db = getDb()
+    BaseModel = getBaseModel(ormAdapter(db))
+    await setup()
+  })
+
+  group.after(async () => {
+    await cleanup()
+    await db.manager.closeAll()
+  })
+
+  group.afterEach(async () => {
+    await resetTables()
+  })
+
+  test('apply factory model state', async (assert) => {
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number
+    }
+
+    const factory = new FactoryModel(User, () => new User())
+      .state('withPoints', (user) => user.points = 10)
+      .build()
+
+    const user = await factory.apply('withPoints').make()
+    assert.equal(user.points, 10)
+    assert.isFalse(user.$isPersisted)
+  })
+
+  test('applying a state twice must be a noop', async (assert) => {
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number = 0
+    }
+
+    const factory = new FactoryModel(User, () => new User())
+      .state('withPoints', (user) => user.points += 10)
+      .build()
+
+    const user = await factory.apply('withPoints').apply('withPoints').make()
+    assert.equal(user.points, 10)
+    assert.isFalse(user.$isPersisted)
+  })
+
+  test('define custom attributes accepted by the newUp method', async (assert) => {
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number
+    }
+
+    const factory = new FactoryModel(User, (_, attributes?: Partial<ModelAttributes<User>>) => {
+      const user = new User()
+      user.username = attributes?.username || 'virk'
+      return user
+    }).build()
+
+    const user = await factory.fill({ username: 'nikk' }).make()
+    assert.equal(user.username, 'nikk')
+    assert.isFalse(user.$isPersisted)
+  })
+
+  test('use 0 index elements when attributes are defined as an array', async (assert) => {
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number
+    }
+
+    const factory = new FactoryModel(User, (_, attributes?: Partial<ModelAttributes<User>>) => {
+      const user = new User()
+      user.username = attributes?.username || 'virk'
+      return user
+    }).build()
+
+    const user = await factory.fill([{ username: 'nikk' }, { username: 'romain' }]).make()
+    assert.equal(user.username, 'nikk')
+    assert.isFalse(user.$isPersisted)
+  })
+})
+
+test.group('Factory | Factory Builder | makeMany', (group) => {
+  group.before(async () => {
+    db = getDb()
+    BaseModel = getBaseModel(ormAdapter(db))
+    await setup()
+  })
+
+  group.after(async () => {
+    await cleanup()
+    await db.manager.closeAll()
+  })
+
+  group.afterEach(async () => {
+    await resetTables()
+  })
+
+  test('apply factory model state', async (assert) => {
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number
+    }
+
+    const factory = new FactoryModel(User, () => new User())
+      .state('withPoints', (user) => user.points = 10)
+      .build()
+
+    const users = await factory.apply('withPoints').makeMany(2)
+    assert.lengthOf(users, 2)
+    assert.equal(users[0].points, 10)
+    assert.isFalse(users[0].$isPersisted)
+    assert.equal(users[1].points, 10)
+    assert.isFalse(users[1].$isPersisted)
+  })
+
+  test('applying a state twice must be a noop', async (assert) => {
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number = 0
+    }
+
+    const factory = new FactoryModel(User, () => new User())
+      .state('withPoints', (user) => user.points += 10)
+      .build()
+
+    const users = await factory.apply('withPoints').apply('withPoints').makeMany(2)
+    assert.lengthOf(users, 2)
+    assert.equal(users[0].points, 10)
+    assert.isFalse(users[0].$isPersisted)
+    assert.equal(users[1].points, 10)
+    assert.isFalse(users[1].$isPersisted)
+  })
+
+  test('define custom attributes accepted by the newUp method', async (assert) => {
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number
+    }
+
+    const factory = new FactoryModel(User, (_, attributes?: Partial<ModelAttributes<User>>) => {
+      const user = new User()
+      user.username = attributes?.username || 'virk'
+      return user
+    }).build()
+
+    const users = await factory.fill({ username: 'nikk' }).makeMany(2)
+    assert.lengthOf(users, 2)
+    assert.equal(users[0].username, 'nikk')
+    assert.isFalse(users[0].$isPersisted)
+    assert.equal(users[1].username, 'nikk')
+    assert.isFalse(users[1].$isPersisted)
+  })
+
+  test('define index specific attributes for makeMany', async (assert) => {
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number
+    }
+
+    const factory = new FactoryModel(User, (_, attributes?: Partial<ModelAttributes<User>>) => {
+      const user = new User()
+      user.username = attributes?.username || 'virk'
+      return user
+    }).build()
+
+    const users = await factory.fill([{ username: 'nikk' }, { username: 'romain' }]).makeMany(2)
+    assert.lengthOf(users, 2)
+    assert.equal(users[0].username, 'nikk')
+    assert.isFalse(users[0].$isPersisted)
+    assert.equal(users[1].username, 'romain')
+    assert.isFalse(users[1].$isPersisted)
+  })
+})
+
+test.group('Factory | Factory Builder | create', (group) => {
+  group.before(async () => {
+    db = getDb()
+    BaseModel = getBaseModel(ormAdapter(db))
+    await setup()
+  })
+
+  group.after(async () => {
+    await cleanup()
+    await db.manager.closeAll()
+  })
+
+  group.afterEach(async () => {
+    await resetTables()
+  })
+
+  test('apply factory model state', async (assert) => {
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number
+    }
+
+    const factory = new FactoryModel(User, () => new User())
+      .state('withPoints', (user) => user.points = 10)
+      .build()
+
+    const user = await factory.apply('withPoints').create()
+    assert.equal(user.points, 10)
+    assert.isTrue(user.$isPersisted)
+  })
+
+  test('applying a state twice must be a noop', async (assert) => {
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number = 0
+    }
+
+    const factory = new FactoryModel(User, () => new User())
+      .state('withPoints', (user) => user.points += 10)
+      .build()
+
+    const user = await factory.apply('withPoints').apply('withPoints').create()
+    assert.equal(user.points, 10)
+    assert.isTrue(user.$isPersisted)
+  })
+
+  test('define custom attributes accepted by the newUp method', async (assert) => {
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number
+    }
+
+    const factory = new FactoryModel(User, (_, attributes?: Partial<ModelAttributes<User>>) => {
+      const user = new User()
+      user.username = attributes?.username || 'virk'
+      return user
+    }).build()
+
+    const user = await factory.fill({ username: 'nikk' }).create()
+    assert.equal(user.username, 'nikk')
+    assert.isTrue(user.$isPersisted)
+  })
+
+  test('use index 0 elements when attributes are defined as an array', async (assert) => {
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number
+    }
+
+    const factory = new FactoryModel(User, (_, attributes?: Partial<ModelAttributes<User>>) => {
+      const user = new User()
+      user.username = attributes?.username || 'virk'
+      return user
+    }).build()
+
+    const user = await factory.fill([{ username: 'nikk' }, { username: 'romain' }]).create()
+    assert.equal(user.username, 'nikk')
+    assert.isTrue(user.$isPersisted)
+  })
+})
+
+test.group('Factory | Factory Builder | createMany', (group) => {
+  group.before(async () => {
+    db = getDb()
+    BaseModel = getBaseModel(ormAdapter(db))
+    await setup()
+  })
+
+  group.after(async () => {
+    await cleanup()
+    await db.manager.closeAll()
+  })
+
+  group.afterEach(async () => {
+    await resetTables()
+  })
+
+  test('apply factory model state', async (assert) => {
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number
+    }
+
+    const factory = new FactoryModel(User, () => new User())
+      .state('withPoints', (user) => user.points = 10)
+      .build()
+
+    const users = await factory.apply('withPoints').createMany(2)
+    assert.lengthOf(users, 2)
+    assert.equal(users[0].points, 10)
+    assert.isTrue(users[0].$isPersisted)
+    assert.equal(users[1].points, 10)
+    assert.isTrue(users[1].$isPersisted)
+  })
+
+  test('applying a state twice must be a noop', async (assert) => {
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number = 0
+    }
+
+    const factory = new FactoryModel(User, () => new User())
+      .state('withPoints', (user) => user.points += 10)
+      .build()
+
+    const users = await factory.apply('withPoints').apply('withPoints').createMany(2)
+    assert.lengthOf(users, 2)
+    assert.equal(users[0].points, 10)
+    assert.isTrue(users[0].$isPersisted)
+    assert.equal(users[1].points, 10)
+    assert.isTrue(users[1].$isPersisted)
+  })
+
+  test('define custom attributes accepted by the newUp method', async (assert) => {
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number
+    }
+
+    const factory = new FactoryModel(User, (_, attributes?: Partial<ModelAttributes<User>>) => {
+      const user = new User()
+      user.username = attributes?.username || `u-${new Date().getTime()}`
+      user.points = attributes?.points || 0
+      return user
+    }).build()
+
+    const users = await factory.fill({ points: 10 }).createMany(2)
+    assert.lengthOf(users, 2)
+    assert.equal(users[0].points, 10)
+    assert.isTrue(users[0].$isPersisted)
+    assert.equal(users[1].points, 10)
+    assert.isTrue(users[1].$isPersisted)
+  })
+
+  test('define index specific attributes for makeMany', async (assert) => {
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number
+    }
+
+    const factory = new FactoryModel(User, (_, attributes?: Partial<ModelAttributes<User>>) => {
+      const user = new User()
+      user.username = attributes?.username || 'virk'
+      return user
+    }).build()
+
+    const users = await factory.fill([{ username: 'nikk' }, { username: 'romain' }]).createMany(2)
+    assert.lengthOf(users, 2)
+    assert.equal(users[0].username, 'nikk')
+    assert.isTrue(users[0].$isPersisted)
+    assert.equal(users[1].username, 'romain')
+    assert.isTrue(users[1].$isPersisted)
+  })
+})

--- a/test/factory/factory-model.spec.ts
+++ b/test/factory/factory-model.spec.ts
@@ -13,6 +13,7 @@ import test from 'japa'
 
 import { HasOne } from '@ioc:Adonis/Lucid/Orm'
 import { column, hasOne } from '../../src/Orm/Decorators'
+import { FactoryModel } from '../../src/Factory/FactoryModel'
 import { HasOne as FactoryHasOne } from '../../src/Factory/Relations/HasOne'
 
 import {
@@ -22,12 +23,10 @@ import {
   ormAdapter,
   resetTables,
   getBaseModel,
-  getFactoryModel,
 } from '../../test-helpers'
 
 let db: ReturnType<typeof getDb>
 let BaseModel: ReturnType<typeof getBaseModel>
-const FactoryModel = getFactoryModel()
 
 test.group('Factory | Factory Model', (group) => {
   group.before(async () => {
@@ -211,7 +210,9 @@ test.group('Factory | Factory Model', (group) => {
       public profile: HasOne<typeof Profile>
     }
 
-    const factory = new FactoryModel(User, () => new User()).build()
+    const factory = new FactoryModel(User, () => {
+      return {}
+    }).build()
     const user = await factory.make()
     assert.instanceOf(user, User)
   })

--- a/test/factory/factory-model.spec.ts
+++ b/test/factory/factory-model.spec.ts
@@ -91,7 +91,7 @@ test.group('Factory | Factory Model', (group) => {
     User.boot()
 
     function relatedFn () {}
-    const factory = new FactoryModel(User, () => new User()).related('profile', relatedFn)
+    const factory = new FactoryModel(User, () => new User()).relation('profile', relatedFn)
     assert.property(factory.relations, 'profile')
     assert.instanceOf(factory.relations.profile, FactoryHasOne)
   })
@@ -150,7 +150,7 @@ test.group('Factory | Factory Model', (group) => {
       return profileFactory
     }
 
-    const factory = new FactoryModel(User, () => new User()).related('profile', relatedFn)
+    const factory = new FactoryModel(User, () => new User()).relation('profile', relatedFn)
     assert.instanceOf(factory.getRelation('profile'), FactoryHasOne)
     assert.deepEqual(factory.getRelation('profile').relation, User.$getRelation('profile')!)
   })
@@ -187,7 +187,7 @@ test.group('Factory | Factory Model', (group) => {
       public username: string
     }
 
-    const factory = () => new FactoryModel(User, () => new User()).related('profile' as any, () => {})
+    const factory = () => new FactoryModel(User, () => new User()).relation('profile' as any, () => {})
     assert.throw(
       factory,
       'Cannot define "profile" relationship. The relationship must exist on the "User" model first'

--- a/test/factory/factory-model.spec.ts
+++ b/test/factory/factory-model.spec.ts
@@ -1,0 +1,212 @@
+/*
+* @adonisjs/lucid
+*
+* (c) Harminder Virk <virk@adonisjs.com>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+/// <reference path="../../adonis-typings/index.ts" />
+
+import test from 'japa'
+
+import { HasOne } from '@ioc:Adonis/Lucid/Orm'
+import { column, hasOne } from '../../src/Orm/Decorators'
+
+import {
+  setup,
+  getDb,
+  cleanup,
+  ormAdapter,
+  resetTables,
+  getBaseModel,
+  getFactoryModel,
+} from '../../test-helpers'
+
+let db: ReturnType<typeof getDb>
+let BaseModel: ReturnType<typeof getBaseModel>
+const FactoryModel = getFactoryModel()
+
+test.group('Factory | Factory Model', (group) => {
+  group.before(async () => {
+    db = getDb()
+    BaseModel = getBaseModel(ormAdapter(db))
+    await setup()
+  })
+
+  group.after(async () => {
+    await cleanup()
+    await db.manager.closeAll()
+  })
+
+  group.afterEach(async () => {
+    await resetTables()
+  })
+
+  test('define model factory', async (assert) => {
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+    }
+
+    const factory = new FactoryModel(User, () => new User())
+    assert.instanceOf(factory, FactoryModel)
+  })
+
+  test('define factory state', async (assert) => {
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+    }
+
+    function stateFn () {}
+    const factory = new FactoryModel(User, () => new User()).state('active', stateFn)
+    assert.deepEqual(factory.states, { active: stateFn })
+  })
+
+  test('define factory relation', async (assert) => {
+    class Profile extends BaseModel {
+    }
+    Profile.boot()
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @hasOne(() => Profile)
+      public profile: HasOne<typeof Profile>
+    }
+
+    function relatedFn () {}
+    const factory = new FactoryModel(User, () => new User()).related('profile', relatedFn)
+    assert.deepEqual(factory.relations, { profile: relatedFn })
+  })
+
+  test('get pre-registered state', async (assert) => {
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+    }
+
+    function stateFn () {}
+    const factory = new FactoryModel(User, () => new User()).state('active', stateFn)
+    assert.deepEqual(factory.getState('active'), stateFn)
+  })
+
+  test('raise exception when state is not registered', async (assert) => {
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+    }
+
+    const factory = new FactoryModel(User, () => new User())
+    assert.throw(
+      () => factory.getState('active'),
+      'Cannot apply undefined state \"active\". Double check the model factory',
+    )
+  })
+
+  test('get pre-registered relationship', async (assert) => {
+    class Profile extends BaseModel {
+    }
+    Profile.boot()
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @hasOne(() => Profile)
+      public profile: HasOne<typeof Profile>
+    }
+
+    const profileFactory = new FactoryModel(Profile, () => new Profile()).build()
+    function relatedFn () {
+      return profileFactory
+    }
+
+    const factory = new FactoryModel(User, () => new User()).related('profile', relatedFn)
+    assert.deepEqual(factory.getRelation('profile'), {
+      factory: profileFactory,
+      relation: User.$getRelation('profile')!,
+    })
+  })
+
+  test('raise exception when relation is not defined', async (assert) => {
+    class Profile extends BaseModel {
+    }
+    Profile.boot()
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @hasOne(() => Profile)
+      public profile: HasOne<typeof Profile>
+    }
+
+    const factory = new FactoryModel(User, () => new User())
+    assert.throw(
+      () => factory.getRelation('profile'),
+      'Cannot setup undefined relationship \"profile\". Double check the model factory'
+    )
+  })
+
+  test('do not allow registering relationships not defined on the model', async (assert) => {
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+    }
+
+    const factory = () => new FactoryModel(User, () => new User()).related('profile' as any, () => {})
+    assert.throw(
+      factory,
+      'Cannot define "profile" relationship. The relationship must exist on the "User" model first'
+    )
+  })
+
+  test('build factory', async (assert) => {
+    class Profile extends BaseModel {
+    }
+    Profile.boot()
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @hasOne(() => Profile)
+      public profile: HasOne<typeof Profile>
+    }
+
+    const factory = new FactoryModel(User, () => new User()).build()
+    const user = await factory.make()
+    assert.instanceOf(user, User)
+  })
+})

--- a/test/factory/factory-model.spec.ts
+++ b/test/factory/factory-model.spec.ts
@@ -13,6 +13,7 @@ import test from 'japa'
 
 import { HasOne } from '@ioc:Adonis/Lucid/Orm'
 import { column, hasOne } from '../../src/Orm/Decorators'
+import { FactoryManager } from '../../src/Factory/index'
 import { FactoryModel } from '../../src/Factory/FactoryModel'
 import { HasOne as FactoryHasOne } from '../../src/Factory/Relations/HasOne'
 
@@ -27,6 +28,7 @@ import {
 
 let db: ReturnType<typeof getDb>
 let BaseModel: ReturnType<typeof getBaseModel>
+const factoryManager = new FactoryManager()
 
 test.group('Factory | Factory Model', (group) => {
   group.before(async () => {
@@ -53,7 +55,7 @@ test.group('Factory | Factory Model', (group) => {
       public username: string
     }
 
-    const factory = new FactoryModel(User, () => new User())
+    const factory = new FactoryModel(User, () => new User(), factoryManager)
     assert.instanceOf(factory, FactoryModel)
   })
 
@@ -67,7 +69,7 @@ test.group('Factory | Factory Model', (group) => {
     }
 
     function stateFn () {}
-    const factory = new FactoryModel(User, () => new User()).state('active', stateFn)
+    const factory = new FactoryModel(User, () => new User(), factoryManager).state('active', stateFn)
     assert.deepEqual(factory.states, { active: stateFn })
   })
 
@@ -91,7 +93,7 @@ test.group('Factory | Factory Model', (group) => {
     User.boot()
 
     function relatedFn () {}
-    const factory = new FactoryModel(User, () => new User()).relation('profile', relatedFn)
+    const factory = new FactoryModel(User, () => new User(), factoryManager).relation('profile', relatedFn)
     assert.property(factory.relations, 'profile')
     assert.instanceOf(factory.relations.profile, FactoryHasOne)
   })
@@ -106,7 +108,7 @@ test.group('Factory | Factory Model', (group) => {
     }
 
     function stateFn () {}
-    const factory = new FactoryModel(User, () => new User()).state('active', stateFn)
+    const factory = new FactoryModel(User, () => new User(), factoryManager).state('active', stateFn)
     assert.deepEqual(factory.getState('active'), stateFn)
   })
 
@@ -119,7 +121,7 @@ test.group('Factory | Factory Model', (group) => {
       public username: string
     }
 
-    const factory = new FactoryModel(User, () => new User())
+    const factory = new FactoryModel(User, () => new User(), factoryManager)
     assert.throw(
       () => factory.getState('active'),
       'Cannot apply undefined state \"active\". Double check the model factory',
@@ -145,12 +147,12 @@ test.group('Factory | Factory Model', (group) => {
     }
     User.boot()
 
-    const profileFactory = new FactoryModel(Profile, () => new Profile()).build()
+    const profileFactory = new FactoryModel(Profile, () => new Profile(), factoryManager).build()
     function relatedFn () {
       return profileFactory
     }
 
-    const factory = new FactoryModel(User, () => new User()).relation('profile', relatedFn)
+    const factory = new FactoryModel(User, () => new User(), factoryManager).relation('profile', relatedFn)
     assert.instanceOf(factory.getRelation('profile'), FactoryHasOne)
     assert.deepEqual(factory.getRelation('profile').relation, User.$getRelation('profile')!)
   })
@@ -171,7 +173,7 @@ test.group('Factory | Factory Model', (group) => {
       public profile: HasOne<typeof Profile>
     }
 
-    const factory = new FactoryModel(User, () => new User())
+    const factory = new FactoryModel(User, () => new User(), factoryManager)
     assert.throw(
       () => factory.getRelation('profile'),
       'Cannot setup undefined relationship \"profile\". Double check the model factory'
@@ -187,7 +189,7 @@ test.group('Factory | Factory Model', (group) => {
       public username: string
     }
 
-    const factory = () => new FactoryModel(User, () => new User()).relation('profile' as any, () => {})
+    const factory = () => new FactoryModel(User, () => new User(), factoryManager).relation('profile' as any, () => {})
     assert.throw(
       factory,
       'Cannot define "profile" relationship. The relationship must exist on the "User" model first'
@@ -212,7 +214,8 @@ test.group('Factory | Factory Model', (group) => {
 
     const factory = new FactoryModel(User, () => {
       return {}
-    }).build()
+    }, factoryManager).build()
+
     const user = await factory.make()
     assert.instanceOf(user, User)
   })

--- a/test/factory/factory-model.spec.ts
+++ b/test/factory/factory-model.spec.ts
@@ -13,6 +13,7 @@ import test from 'japa'
 
 import { HasOne } from '@ioc:Adonis/Lucid/Orm'
 import { column, hasOne } from '../../src/Orm/Decorators'
+import { HasOne as FactoryHasOne } from '../../src/Factory/Relations/HasOne'
 
 import {
   setup,
@@ -73,6 +74,8 @@ test.group('Factory | Factory Model', (group) => {
 
   test('define factory relation', async (assert) => {
     class Profile extends BaseModel {
+      @column()
+      public userId: number
     }
     Profile.boot()
 
@@ -86,10 +89,12 @@ test.group('Factory | Factory Model', (group) => {
       @hasOne(() => Profile)
       public profile: HasOne<typeof Profile>
     }
+    User.boot()
 
     function relatedFn () {}
     const factory = new FactoryModel(User, () => new User()).related('profile', relatedFn)
-    assert.deepEqual(factory.relations, { profile: relatedFn })
+    assert.property(factory.relations, 'profile')
+    assert.instanceOf(factory.relations.profile, FactoryHasOne)
   })
 
   test('get pre-registered state', async (assert) => {
@@ -124,6 +129,8 @@ test.group('Factory | Factory Model', (group) => {
 
   test('get pre-registered relationship', async (assert) => {
     class Profile extends BaseModel {
+      @column()
+      public userId: number
     }
     Profile.boot()
 
@@ -137,6 +144,7 @@ test.group('Factory | Factory Model', (group) => {
       @hasOne(() => Profile)
       public profile: HasOne<typeof Profile>
     }
+    User.boot()
 
     const profileFactory = new FactoryModel(Profile, () => new Profile()).build()
     function relatedFn () {
@@ -144,10 +152,8 @@ test.group('Factory | Factory Model', (group) => {
     }
 
     const factory = new FactoryModel(User, () => new User()).related('profile', relatedFn)
-    assert.deepEqual(factory.getRelation('profile'), {
-      factory: profileFactory,
-      relation: User.$getRelation('profile')!,
-    })
+    assert.instanceOf(factory.getRelation('profile'), FactoryHasOne)
+    assert.deepEqual(factory.getRelation('profile').relation, User.$getRelation('profile')!)
   })
 
   test('raise exception when relation is not defined', async (assert) => {

--- a/test/factory/has-many.spec.ts
+++ b/test/factory/has-many.spec.ts
@@ -120,7 +120,7 @@ test.group('Factory | HasMany | make', (group) => {
       .related('posts', () => postFactory)
       .build()
 
-    const user = await factory.with('posts', 1, (factory) => factory.fill({ title: 'Lucid 101' })).make()
+    const user = await factory.with('posts', 1, (related) => related.fill({ title: 'Lucid 101' })).make()
 
     assert.isFalse(user.$isPersisted)
     assert.lengthOf(user.posts, 1)
@@ -164,7 +164,7 @@ test.group('Factory | HasMany | make', (group) => {
       .related('posts', () => postFactory)
       .build()
 
-    const user = await factory.with('posts', 2, (factory) => factory.fill({ title: 'Lucid 101' })).make()
+    const user = await factory.with('posts', 2, (related) => related.fill({ title: 'Lucid 101' })).make()
 
     assert.isFalse(user.$isPersisted)
     assert.lengthOf(user.posts, 2)
@@ -272,7 +272,7 @@ test.group('Factory | HasMany | create', (group) => {
       .build()
 
     const user = await factory
-      .with('posts', 1, (factory) => factory.fill({ title: 'Lucid 101' }))
+      .with('posts', 1, (related) => related.fill({ title: 'Lucid 101' }))
       .create()
 
     assert.isTrue(user.$isPersisted)
@@ -318,7 +318,7 @@ test.group('Factory | HasMany | create', (group) => {
       .build()
 
     const user = await factory
-      .with('posts', 2, (factory) => factory.fill({ title: 'Lucid 101' }))
+      .with('posts', 2, (related) => related.fill({ title: 'Lucid 101' }))
       .create()
 
     assert.isTrue(user.$isPersisted)
@@ -368,7 +368,7 @@ test.group('Factory | HasMany | create', (group) => {
       .build()
 
     const user = await factory
-      .with('posts', 1, (factory) => factory.fill({ title: 'Lucid 101' }))
+      .with('posts', 1, (related) => related.fill({ title: 'Lucid 101' }))
       .create()
 
     assert.isTrue(user.$isPersisted)

--- a/test/factory/has-many.spec.ts
+++ b/test/factory/has-many.spec.ts
@@ -46,6 +46,9 @@ test.group('Factory | HasMany | make', (group) => {
   test('make model with relationship', async (assert) => {
     class Post extends BaseModel {
       @column()
+      public id: number
+
+      @column()
       public userId: number
 
       @column()
@@ -79,11 +82,14 @@ test.group('Factory | HasMany | make', (group) => {
       .relation('posts', () => postFactory)
       .build()
 
-    const user = await factory.with('posts').make()
+    const user = await factory.with('posts').makeStubbed()
 
     assert.isFalse(user.$isPersisted)
+    assert.exists(user.id)
     assert.lengthOf(user.posts, 1)
+
     assert.instanceOf(user.posts[0], Post)
+    assert.exists(user.posts[0].id)
     assert.isFalse(user.posts[0].$isPersisted)
     assert.equal(user.posts[0].userId, user.id)
   })
@@ -126,7 +132,7 @@ test.group('Factory | HasMany | make', (group) => {
 
     const user = await factory
       .with('posts', 1, (related) => related.merge({ title: 'Lucid 101' }))
-      .make()
+      .makeStubbed()
 
     assert.isFalse(user.$isPersisted)
     assert.lengthOf(user.posts, 1)
@@ -174,7 +180,7 @@ test.group('Factory | HasMany | make', (group) => {
 
     const user = await factory
       .with('posts', 2, (related) => related.merge({ title: 'Lucid 101' }))
-      .make()
+      .makeStubbed()
 
     assert.isFalse(user.$isPersisted)
     assert.lengthOf(user.posts, 2)

--- a/test/factory/has-many.spec.ts
+++ b/test/factory/has-many.spec.ts
@@ -68,12 +68,14 @@ test.group('Factory | HasMany | make', (group) => {
     }
 
     const postFactory = new FactoryModel(Post, () => {
-      const post = new Post()
-      post.title = 'Adonis 101'
-      return post
+      return {
+        title: 'Adonis 101',
+      }
     }).build()
 
-    const factory = new FactoryModel(User, () => new User())
+    const factory = new FactoryModel(User, () => {
+      return {}
+    })
       .related('posts', () => postFactory)
       .build()
 
@@ -110,17 +112,21 @@ test.group('Factory | HasMany | make', (group) => {
       public posts: HasMany<typeof Post>
     }
 
-    const postFactory = new FactoryModel(Post, (_, attributes?: any) => {
-      const post = new Post()
-      post.title = attributes?.title || 'Adonis 101'
-      return post
+    const postFactory = new FactoryModel(Post, () => {
+      return {
+        title: 'Adonis 101',
+      }
     }).build()
 
-    const factory = new FactoryModel(User, () => new User())
+    const factory = new FactoryModel(User, () => {
+      return {}
+    })
       .related('posts', () => postFactory)
       .build()
 
-    const user = await factory.with('posts', 1, (related) => related.fill({ title: 'Lucid 101' })).make()
+    const user = await factory
+      .with('posts', 1, (related) => related.merge({ title: 'Lucid 101' }))
+      .make()
 
     assert.isFalse(user.$isPersisted)
     assert.lengthOf(user.posts, 1)
@@ -154,17 +160,21 @@ test.group('Factory | HasMany | make', (group) => {
       public posts: HasMany<typeof Post>
     }
 
-    const postFactory = new FactoryModel(Post, (_, attributes?: any) => {
-      const post = new Post()
-      post.title = attributes?.title || 'Adonis 101'
-      return post
+    const postFactory = new FactoryModel(Post, () => {
+      return {
+        title: 'Adonis 101',
+      }
     }).build()
 
-    const factory = new FactoryModel(User, () => new User())
+    const factory = new FactoryModel(User, () => {
+      return {}
+    })
       .related('posts', () => postFactory)
       .build()
 
-    const user = await factory.with('posts', 2, (related) => related.fill({ title: 'Lucid 101' })).make()
+    const user = await factory
+      .with('posts', 2, (related) => related.merge({ title: 'Lucid 101' }))
+      .make()
 
     assert.isFalse(user.$isPersisted)
     assert.lengthOf(user.posts, 2)
@@ -219,12 +229,14 @@ test.group('Factory | HasMany | create', (group) => {
     }
 
     const postFactory = new FactoryModel(Post, () => {
-      const post = new Post()
-      post.title = 'Adonis 101'
-      return post
+      return {
+        title: 'Adonis 101',
+      }
     }).build()
 
-    const factory = new FactoryModel(User, () => new User())
+    const factory = new FactoryModel(User, () => {
+      return {}
+    })
       .related('posts', () => postFactory)
       .build()
 
@@ -261,18 +273,20 @@ test.group('Factory | HasMany | create', (group) => {
       public posts: HasMany<typeof Post>
     }
 
-    const postFactory = new FactoryModel(Post, (_, attributes?: any) => {
-      const post = new Post()
-      post.title = attributes?.title || 'Adonis 101'
-      return post
+    const postFactory = new FactoryModel(Post, () => {
+      return {
+        title: 'Adonis 101',
+      }
     }).build()
 
-    const factory = new FactoryModel(User, () => new User())
+    const factory = new FactoryModel(User, () => {
+      return {}
+    })
       .related('posts', () => postFactory)
       .build()
 
     const user = await factory
-      .with('posts', 1, (related) => related.fill({ title: 'Lucid 101' }))
+      .with('posts', 1, (related) => related.merge({ title: 'Lucid 101' }))
       .create()
 
     assert.isTrue(user.$isPersisted)
@@ -307,18 +321,20 @@ test.group('Factory | HasMany | create', (group) => {
       public posts: HasMany<typeof Post>
     }
 
-    const postFactory = new FactoryModel(Post, (_, attributes?: any) => {
-      const post = new Post()
-      post.title = attributes?.title || 'Adonis 101'
-      return post
+    const postFactory = new FactoryModel(Post, () => {
+      return {
+        title: 'Adonis 101',
+      }
     }).build()
 
-    const factory = new FactoryModel(User, () => new User())
+    const factory = new FactoryModel(User, () => {
+      return {}
+    })
       .related('posts', () => postFactory)
       .build()
 
     const user = await factory
-      .with('posts', 2, (related) => related.fill({ title: 'Lucid 101' }))
+      .with('posts', 2, (related) => related.merge({ title: 'Lucid 101' }))
       .create()
 
     assert.isTrue(user.$isPersisted)
@@ -357,18 +373,20 @@ test.group('Factory | HasMany | create', (group) => {
       public posts: HasMany<typeof Post>
     }
 
-    const postFactory = new FactoryModel(Post, (_, attributes?: any) => {
-      const post = new Post()
-      post.title = attributes?.title || 'Adonis 101'
-      return post
+    const postFactory = new FactoryModel(Post, () => {
+      return {
+        title: 'Adonis 101',
+      }
     }).build()
 
-    const factory = new FactoryModel(User, () => new User())
+    const factory = new FactoryModel(User, () => {
+      return {}
+    })
       .related('posts', () => postFactory)
       .build()
 
     const user = await factory
-      .with('posts', 1, (related) => related.fill({ title: 'Lucid 101' }))
+      .with('posts', 1, (related) => related.merge({ title: 'Lucid 101' }))
       .create()
 
     assert.isTrue(user.$isPersisted)
@@ -406,11 +424,12 @@ test.group('Factory | HasMany | create', (group) => {
     }
 
     const postFactory = new FactoryModel(Post, () => {
-      const post = new Post()
-      return post
+      return {}
     }).build()
 
-    const factory = new FactoryModel(User, () => new User())
+    const factory = new FactoryModel(User, () => {
+      return {}
+    })
       .related('posts', () => postFactory)
       .build()
 

--- a/test/factory/has-many.spec.ts
+++ b/test/factory/has-many.spec.ts
@@ -1,0 +1,429 @@
+/*
+* @adonisjs/lucid
+*
+* (c) Harminder Virk <virk@adonisjs.com>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+/// <reference path="../../adonis-typings/index.ts" />
+
+import test from 'japa'
+import { HasMany } from '@ioc:Adonis/Lucid/Relations'
+import { column, hasMany } from '../../src/Orm/Decorators'
+
+import {
+  setup,
+  getDb,
+  cleanup,
+  ormAdapter,
+  resetTables,
+  getBaseModel,
+  getFactoryModel,
+} from '../../test-helpers'
+
+let db: ReturnType<typeof getDb>
+let BaseModel: ReturnType<typeof getBaseModel>
+const FactoryModel = getFactoryModel()
+
+test.group('Factory | HasMany | make', (group) => {
+  group.before(async () => {
+    db = getDb()
+    BaseModel = getBaseModel(ormAdapter(db))
+    await setup()
+  })
+
+  group.after(async () => {
+    await cleanup()
+    await db.manager.closeAll()
+  })
+
+  group.afterEach(async () => {
+    await resetTables()
+  })
+
+  test('make model with relationship', async (assert) => {
+    class Post extends BaseModel {
+      @column()
+      public userId: number
+
+      @column()
+      public title: string
+    }
+    Post.boot()
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number = 0
+
+      @hasMany(() => Post)
+      public posts: HasMany<typeof Post>
+    }
+
+    const postFactory = new FactoryModel(Post, () => {
+      const post = new Post()
+      post.title = 'Adonis 101'
+      return post
+    }).build()
+
+    const factory = new FactoryModel(User, () => new User())
+      .related('posts', () => postFactory)
+      .build()
+
+    const user = await factory.with('posts').make()
+
+    assert.isFalse(user.$isPersisted)
+    assert.lengthOf(user.posts, 1)
+    assert.instanceOf(user.posts[0], Post)
+    assert.isFalse(user.posts[0].$isPersisted)
+    assert.equal(user.posts[0].userId, user.id)
+  })
+
+  test('pass custom attributes to relationship', async (assert) => {
+    class Post extends BaseModel {
+      @column()
+      public userId: number
+
+      @column()
+      public title: string
+    }
+    Post.boot()
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number = 0
+
+      @hasMany(() => Post)
+      public posts: HasMany<typeof Post>
+    }
+
+    const postFactory = new FactoryModel(Post, (_, attributes?: any) => {
+      const post = new Post()
+      post.title = attributes?.title || 'Adonis 101'
+      return post
+    }).build()
+
+    const factory = new FactoryModel(User, () => new User())
+      .related('posts', () => postFactory)
+      .build()
+
+    const user = await factory.with('posts', 1, (factory) => factory.fill({ title: 'Lucid 101' })).make()
+
+    assert.isFalse(user.$isPersisted)
+    assert.lengthOf(user.posts, 1)
+    assert.instanceOf(user.posts[0], Post)
+    assert.isFalse(user.posts[0].$isPersisted)
+    assert.equal(user.posts[0].userId, user.id)
+    assert.equal(user.posts[0].title, 'Lucid 101')
+  })
+
+  test('make many relationship', async (assert) => {
+    class Post extends BaseModel {
+      @column()
+      public userId: number
+
+      @column()
+      public title: string
+    }
+    Post.boot()
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number = 0
+
+      @hasMany(() => Post)
+      public posts: HasMany<typeof Post>
+    }
+
+    const postFactory = new FactoryModel(Post, (_, attributes?: any) => {
+      const post = new Post()
+      post.title = attributes?.title || 'Adonis 101'
+      return post
+    }).build()
+
+    const factory = new FactoryModel(User, () => new User())
+      .related('posts', () => postFactory)
+      .build()
+
+    const user = await factory.with('posts', 2, (factory) => factory.fill({ title: 'Lucid 101' })).make()
+
+    assert.isFalse(user.$isPersisted)
+    assert.lengthOf(user.posts, 2)
+    assert.instanceOf(user.posts[0], Post)
+    assert.isFalse(user.posts[0].$isPersisted)
+    assert.isFalse(user.posts[1].$isPersisted)
+    assert.equal(user.posts[0].userId, user.id)
+    assert.equal(user.posts[1].userId, user.id)
+    assert.equal(user.posts[0].title, 'Lucid 101')
+    assert.equal(user.posts[1].title, 'Lucid 101')
+  })
+})
+
+test.group('Factory | HasMany | create', (group) => {
+  group.before(async () => {
+    db = getDb()
+    BaseModel = getBaseModel(ormAdapter(db))
+    await setup()
+  })
+
+  group.after(async () => {
+    await cleanup()
+    await db.manager.closeAll()
+  })
+
+  group.afterEach(async () => {
+    await resetTables()
+  })
+
+  test('create model with relationship', async (assert) => {
+    class Post extends BaseModel {
+      @column()
+      public userId: number
+
+      @column()
+      public title: string
+    }
+    Post.boot()
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number = 0
+
+      @hasMany(() => Post)
+      public posts: HasMany<typeof Post>
+    }
+
+    const postFactory = new FactoryModel(Post, () => {
+      const post = new Post()
+      post.title = 'Adonis 101'
+      return post
+    }).build()
+
+    const factory = new FactoryModel(User, () => new User())
+      .related('posts', () => postFactory)
+      .build()
+
+    const user = await factory.with('posts').create()
+
+    assert.isTrue(user.$isPersisted)
+    assert.lengthOf(user.posts, 1)
+    assert.instanceOf(user.posts[0], Post)
+    assert.isTrue(user.posts[0].$isPersisted)
+    assert.equal(user.posts[0].userId, user.id)
+  })
+
+  test('pass custom attributes to relationship', async (assert) => {
+    class Post extends BaseModel {
+      @column()
+      public userId: number
+
+      @column()
+      public title: string
+    }
+    Post.boot()
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number = 0
+
+      @hasMany(() => Post)
+      public posts: HasMany<typeof Post>
+    }
+
+    const postFactory = new FactoryModel(Post, (_, attributes?: any) => {
+      const post = new Post()
+      post.title = attributes?.title || 'Adonis 101'
+      return post
+    }).build()
+
+    const factory = new FactoryModel(User, () => new User())
+      .related('posts', () => postFactory)
+      .build()
+
+    const user = await factory
+      .with('posts', 1, (factory) => factory.fill({ title: 'Lucid 101' }))
+      .create()
+
+    assert.isTrue(user.$isPersisted)
+    assert.lengthOf(user.posts, 1)
+    assert.instanceOf(user.posts[0], Post)
+    assert.isTrue(user.posts[0].$isPersisted)
+    assert.equal(user.posts[0].userId, user.id)
+    assert.equal(user.posts[0].title, 'Lucid 101')
+  })
+
+  test('create many relationship', async (assert) => {
+    class Post extends BaseModel {
+      @column()
+      public userId: number
+
+      @column()
+      public title: string
+    }
+    Post.boot()
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number = 0
+
+      @hasMany(() => Post)
+      public posts: HasMany<typeof Post>
+    }
+
+    const postFactory = new FactoryModel(Post, (_, attributes?: any) => {
+      const post = new Post()
+      post.title = attributes?.title || 'Adonis 101'
+      return post
+    }).build()
+
+    const factory = new FactoryModel(User, () => new User())
+      .related('posts', () => postFactory)
+      .build()
+
+    const user = await factory
+      .with('posts', 2, (factory) => factory.fill({ title: 'Lucid 101' }))
+      .create()
+
+    assert.isTrue(user.$isPersisted)
+    assert.lengthOf(user.posts, 2)
+    assert.instanceOf(user.posts[0], Post)
+    assert.isTrue(user.posts[0].$isPersisted)
+    assert.equal(user.posts[0].userId, user.id)
+    assert.equal(user.posts[0].title, 'Lucid 101')
+    assert.instanceOf(user.posts[1], Post)
+    assert.isTrue(user.posts[1].$isPersisted)
+    assert.equal(user.posts[1].userId, user.id)
+    assert.equal(user.posts[1].title, 'Lucid 101')
+  })
+
+  test('create relationship with custom foreign key', async (assert) => {
+    class Post extends BaseModel {
+      @column({ columnName: 'user_id' })
+      public authorId: number
+
+      @column()
+      public title: string
+    }
+    Post.boot()
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number = 0
+
+      @hasMany(() => Post, { foreignKey: 'authorId' })
+      public posts: HasMany<typeof Post>
+    }
+
+    const postFactory = new FactoryModel(Post, (_, attributes?: any) => {
+      const post = new Post()
+      post.title = attributes?.title || 'Adonis 101'
+      return post
+    }).build()
+
+    const factory = new FactoryModel(User, () => new User())
+      .related('posts', () => postFactory)
+      .build()
+
+    const user = await factory
+      .with('posts', 1, (factory) => factory.fill({ title: 'Lucid 101' }))
+      .create()
+
+    assert.isTrue(user.$isPersisted)
+    assert.lengthOf(user.posts, 1)
+    assert.instanceOf(user.posts[0], Post)
+    assert.isTrue(user.posts[0].$isPersisted)
+    assert.equal(user.posts[0].authorId, user.id)
+    assert.equal(user.posts[0].title, 'Lucid 101')
+  })
+
+  test('rollback changes on error', async (assert) => {
+    assert.plan(3)
+
+    class Post extends BaseModel {
+      @column()
+      public userId: number
+
+      @column()
+      public title: string
+    }
+    Post.boot()
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number = 0
+
+      @hasMany(() => Post)
+      public posts: HasMany<typeof Post>
+    }
+
+    const postFactory = new FactoryModel(Post, () => {
+      const post = new Post()
+      return post
+    }).build()
+
+    const factory = new FactoryModel(User, () => new User())
+      .related('posts', () => postFactory)
+      .build()
+
+    try {
+      await factory.with('posts').create()
+    } catch (error) {
+      assert.exists(error)
+    }
+
+    const users = await db.from('users').exec()
+    const posts = await db.from('posts').exec()
+
+    assert.lengthOf(users, 0)
+    assert.lengthOf(posts, 0)
+  })
+})

--- a/test/factory/has-many.spec.ts
+++ b/test/factory/has-many.spec.ts
@@ -11,6 +11,7 @@
 
 import test from 'japa'
 import { HasMany } from '@ioc:Adonis/Lucid/Relations'
+import { FactoryManager } from '../../src/Factory/index'
 import { column, hasMany } from '../../src/Orm/Decorators'
 
 import {
@@ -26,6 +27,7 @@ import {
 let db: ReturnType<typeof getDb>
 let BaseModel: ReturnType<typeof getBaseModel>
 const FactoryModel = getFactoryModel()
+const factoryManager = new FactoryManager()
 
 test.group('Factory | HasMany | make', (group) => {
   group.before(async () => {
@@ -74,11 +76,11 @@ test.group('Factory | HasMany | make', (group) => {
       return {
         title: 'Adonis 101',
       }
-    }).build()
+    }, factoryManager).build()
 
     const factory = new FactoryModel(User, () => {
       return {}
-    })
+    }, factoryManager)
       .relation('posts', () => postFactory)
       .build()
 
@@ -122,11 +124,11 @@ test.group('Factory | HasMany | make', (group) => {
       return {
         title: 'Adonis 101',
       }
-    }).build()
+    }, factoryManager).build()
 
     const factory = new FactoryModel(User, () => {
       return {}
-    })
+    }, factoryManager)
       .relation('posts', () => postFactory)
       .build()
 
@@ -170,11 +172,11 @@ test.group('Factory | HasMany | make', (group) => {
       return {
         title: 'Adonis 101',
       }
-    }).build()
+    }, factoryManager).build()
 
     const factory = new FactoryModel(User, () => {
       return {}
-    })
+    }, factoryManager)
       .relation('posts', () => postFactory)
       .build()
 
@@ -238,11 +240,11 @@ test.group('Factory | HasMany | create', (group) => {
       return {
         title: 'Adonis 101',
       }
-    }).build()
+    }, factoryManager).build()
 
     const factory = new FactoryModel(User, () => {
       return {}
-    })
+    }, factoryManager)
       .relation('posts', () => postFactory)
       .build()
 
@@ -283,11 +285,11 @@ test.group('Factory | HasMany | create', (group) => {
       return {
         title: 'Adonis 101',
       }
-    }).build()
+    }, factoryManager).build()
 
     const factory = new FactoryModel(User, () => {
       return {}
-    })
+    }, factoryManager)
       .relation('posts', () => postFactory)
       .build()
 
@@ -331,11 +333,11 @@ test.group('Factory | HasMany | create', (group) => {
       return {
         title: 'Adonis 101',
       }
-    }).build()
+    }, factoryManager).build()
 
     const factory = new FactoryModel(User, () => {
       return {}
-    })
+    }, factoryManager)
       .relation('posts', () => postFactory)
       .build()
 
@@ -383,11 +385,11 @@ test.group('Factory | HasMany | create', (group) => {
       return {
         title: 'Adonis 101',
       }
-    }).build()
+    }, factoryManager).build()
 
     const factory = new FactoryModel(User, () => {
       return {}
-    })
+    }, factoryManager)
       .relation('posts', () => postFactory)
       .build()
 
@@ -431,11 +433,11 @@ test.group('Factory | HasMany | create', (group) => {
 
     const postFactory = new FactoryModel(Post, () => {
       return {}
-    }).build()
+    }, factoryManager).build()
 
     const factory = new FactoryModel(User, () => {
       return {}
-    })
+    }, factoryManager)
       .relation('posts', () => postFactory)
       .build()
 

--- a/test/factory/has-many.spec.ts
+++ b/test/factory/has-many.spec.ts
@@ -76,7 +76,7 @@ test.group('Factory | HasMany | make', (group) => {
     const factory = new FactoryModel(User, () => {
       return {}
     })
-      .related('posts', () => postFactory)
+      .relation('posts', () => postFactory)
       .build()
 
     const user = await factory.with('posts').make()
@@ -121,7 +121,7 @@ test.group('Factory | HasMany | make', (group) => {
     const factory = new FactoryModel(User, () => {
       return {}
     })
-      .related('posts', () => postFactory)
+      .relation('posts', () => postFactory)
       .build()
 
     const user = await factory
@@ -169,7 +169,7 @@ test.group('Factory | HasMany | make', (group) => {
     const factory = new FactoryModel(User, () => {
       return {}
     })
-      .related('posts', () => postFactory)
+      .relation('posts', () => postFactory)
       .build()
 
     const user = await factory
@@ -237,7 +237,7 @@ test.group('Factory | HasMany | create', (group) => {
     const factory = new FactoryModel(User, () => {
       return {}
     })
-      .related('posts', () => postFactory)
+      .relation('posts', () => postFactory)
       .build()
 
     const user = await factory.with('posts').create()
@@ -282,7 +282,7 @@ test.group('Factory | HasMany | create', (group) => {
     const factory = new FactoryModel(User, () => {
       return {}
     })
-      .related('posts', () => postFactory)
+      .relation('posts', () => postFactory)
       .build()
 
     const user = await factory
@@ -330,7 +330,7 @@ test.group('Factory | HasMany | create', (group) => {
     const factory = new FactoryModel(User, () => {
       return {}
     })
-      .related('posts', () => postFactory)
+      .relation('posts', () => postFactory)
       .build()
 
     const user = await factory
@@ -382,7 +382,7 @@ test.group('Factory | HasMany | create', (group) => {
     const factory = new FactoryModel(User, () => {
       return {}
     })
-      .related('posts', () => postFactory)
+      .relation('posts', () => postFactory)
       .build()
 
     const user = await factory
@@ -430,7 +430,7 @@ test.group('Factory | HasMany | create', (group) => {
     const factory = new FactoryModel(User, () => {
       return {}
     })
-      .related('posts', () => postFactory)
+      .relation('posts', () => postFactory)
       .build()
 
     try {

--- a/test/factory/has-one.spec.ts
+++ b/test/factory/has-one.spec.ts
@@ -120,7 +120,7 @@ test.group('Factory | HasOne | make', (group) => {
       .build()
 
     const user = await factory
-      .with('profile', 1, (factory) => factory.fill({ displayName: 'Romain' }))
+      .with('profile', 1, (related) => related.fill({ displayName: 'Romain' }))
       .make()
 
     assert.isFalse(user.$isPersisted)
@@ -224,7 +224,7 @@ test.group('Factory | HasOne | create', (group) => {
       .build()
 
     const user = await factory
-      .with('profile', 1, (factory) => factory.fill({ displayName: 'Romain' }))
+      .with('profile', 1, (related) => related.fill({ displayName: 'Romain' }))
       .create()
 
     assert.isTrue(user.$isPersisted)

--- a/test/factory/has-one.spec.ts
+++ b/test/factory/has-one.spec.ts
@@ -1,0 +1,326 @@
+/*
+* @adonisjs/lucid
+*
+* (c) Harminder Virk <virk@adonisjs.com>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+/// <reference path="../../adonis-typings/index.ts" />
+
+import test from 'japa'
+import { HasOne } from '@ioc:Adonis/Lucid/Relations'
+import { column, hasOne } from '../../src/Orm/Decorators'
+
+import {
+  setup,
+  getDb,
+  cleanup,
+  ormAdapter,
+  resetTables,
+  getBaseModel,
+  getFactoryModel,
+} from '../../test-helpers'
+
+let db: ReturnType<typeof getDb>
+let BaseModel: ReturnType<typeof getBaseModel>
+const FactoryModel = getFactoryModel()
+
+test.group('Factory | HasOne | make', (group) => {
+  group.before(async () => {
+    db = getDb()
+    BaseModel = getBaseModel(ormAdapter(db))
+    await setup()
+  })
+
+  group.after(async () => {
+    await cleanup()
+    await db.manager.closeAll()
+  })
+
+  group.afterEach(async () => {
+    await resetTables()
+  })
+
+  test('make model with relationship', async (assert) => {
+    class Profile extends BaseModel {
+      @column()
+      public userId: number
+
+      @column()
+      public displayName: string
+    }
+    Profile.boot()
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number = 0
+
+      @hasOne(() => Profile)
+      public profile: HasOne<typeof Profile>
+    }
+
+    const profileFactory = new FactoryModel(Profile, () => {
+      const profile = new Profile()
+      profile.displayName = 'virk'
+      return profile
+    }).build()
+
+    const factory = new FactoryModel(User, () => new User())
+      .related('profile', () => profileFactory)
+      .build()
+
+    const user = await factory.with('profile').make()
+
+    assert.isFalse(user.$isPersisted)
+    assert.instanceOf(user.profile, Profile)
+    assert.isFalse(user.profile.$isPersisted)
+    assert.equal(user.profile.userId, user.id)
+  })
+
+  test('pass custom attributes to relationship', async (assert) => {
+    class Profile extends BaseModel {
+      @column()
+      public userId: number
+
+      @column()
+      public displayName: string
+    }
+    Profile.boot()
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number = 0
+
+      @hasOne(() => Profile)
+      public profile: HasOne<typeof Profile>
+    }
+
+    const profileFactory = new FactoryModel(Profile, (_, attributes?: any) => {
+      const profile = new Profile()
+      profile.displayName = attributes?.displayName || 'virk'
+      return profile
+    }).build()
+
+    const factory = new FactoryModel(User, () => new User())
+      .related('profile', () => profileFactory)
+      .build()
+
+    const user = await factory
+      .with('profile', 1, (factory) => factory.fill({ displayName: 'Romain' }))
+      .make()
+
+    assert.isFalse(user.$isPersisted)
+    assert.instanceOf(user.profile, Profile)
+    assert.isFalse(user.profile.$isPersisted)
+    assert.equal(user.profile.displayName, 'Romain')
+    assert.equal(user.profile.userId, user.id)
+  })
+})
+
+test.group('Factory | HasOne | create', (group) => {
+  group.before(async () => {
+    db = getDb()
+    BaseModel = getBaseModel(ormAdapter(db))
+    await setup()
+  })
+
+  group.after(async () => {
+    await cleanup()
+    await db.manager.closeAll()
+  })
+
+  group.afterEach(async () => {
+    await resetTables()
+  })
+
+  test('create model with relationship', async (assert) => {
+    class Profile extends BaseModel {
+      @column()
+      public userId: number
+
+      @column()
+      public displayName: string
+    }
+    Profile.boot()
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number = 0
+
+      @hasOne(() => Profile)
+      public profile: HasOne<typeof Profile>
+    }
+
+    const profileFactory = new FactoryModel(Profile, () => {
+      const profile = new Profile()
+      profile.displayName = 'virk'
+      return profile
+    }).build()
+
+    const factory = new FactoryModel(User, () => new User())
+      .related('profile', () => profileFactory)
+      .build()
+
+    const user = await factory.with('profile').create()
+
+    assert.isTrue(user.$isPersisted)
+    assert.instanceOf(user.profile, Profile)
+    assert.isTrue(user.profile.$isPersisted)
+    assert.equal(user.profile.userId, user.id)
+  })
+
+  test('pass custom attributes to relationship', async (assert) => {
+    class Profile extends BaseModel {
+      @column()
+      public userId: number
+
+      @column()
+      public displayName: string
+    }
+    Profile.boot()
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number = 0
+
+      @hasOne(() => Profile)
+      public profile: HasOne<typeof Profile>
+    }
+
+    const profileFactory = new FactoryModel(Profile, (_, attributes?: any) => {
+      const profile = new Profile()
+      profile.displayName = attributes?.displayName || 'virk'
+      return profile
+    }).build()
+
+    const factory = new FactoryModel(User, () => new User())
+      .related('profile', () => profileFactory)
+      .build()
+
+    const user = await factory
+      .with('profile', 1, (factory) => factory.fill({ displayName: 'Romain' }))
+      .create()
+
+    assert.isTrue(user.$isPersisted)
+    assert.instanceOf(user.profile, Profile)
+    assert.isTrue(user.profile.$isPersisted)
+    assert.equal(user.profile.displayName, 'Romain')
+    assert.equal(user.profile.userId, user.id)
+  })
+
+  test('create model with custom foreign key', async (assert) => {
+    class Profile extends BaseModel {
+      @column({ columnName: 'user_id' })
+      public authorId: number
+
+      @column()
+      public displayName: string
+    }
+    Profile.boot()
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number = 0
+
+      @hasOne(() => Profile, { foreignKey: 'authorId' })
+      public profile: HasOne<typeof Profile>
+    }
+
+    const profileFactory = new FactoryModel(Profile, () => {
+      const profile = new Profile()
+      profile.displayName = 'virk'
+      return profile
+    }).build()
+
+    const factory = new FactoryModel(User, () => new User())
+      .related('profile', () => profileFactory)
+      .build()
+
+    const user = await factory.with('profile').create()
+
+    assert.isTrue(user.$isPersisted)
+    assert.instanceOf(user.profile, Profile)
+    assert.isTrue(user.profile.$isPersisted)
+    assert.equal(user.profile.authorId, user.id)
+  })
+
+  test('rollback changes on error', async (assert) => {
+    assert.plan(3)
+
+    class Profile extends BaseModel {
+      @column()
+      public userId: number
+
+      @column()
+      public displayName: string
+    }
+    Profile.boot()
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number = 0
+
+      @hasOne(() => Profile)
+      public profile: HasOne<typeof Profile>
+    }
+
+    const profileFactory = new FactoryModel(Profile, () => {
+      const profile = new Profile()
+      return profile
+    }).build()
+
+    const factory = new FactoryModel(User, () => new User())
+      .related('profile', () => profileFactory)
+      .build()
+
+    try {
+      await factory.with('profile').create()
+    } catch (error) {
+      assert.exists(error)
+    }
+
+    const users = await db.from('users').exec()
+    const profiles = await db.from('profiles').exec()
+
+    assert.lengthOf(users, 0)
+    assert.lengthOf(profiles, 0)
+  })
+})

--- a/test/factory/has-one.spec.ts
+++ b/test/factory/has-one.spec.ts
@@ -46,6 +46,9 @@ test.group('Factory | HasOne | make', (group) => {
   test('make model with relationship', async (assert) => {
     class Profile extends BaseModel {
       @column()
+      public id: number
+
+      @column()
       public userId: number
 
       @column()
@@ -79,16 +82,22 @@ test.group('Factory | HasOne | make', (group) => {
       .relation('profile', () => profileFactory)
       .build()
 
-    const user = await factory.with('profile').make()
+    const user = await factory.with('profile').makeStubbed()
 
+    assert.exists(user.id)
     assert.isFalse(user.$isPersisted)
     assert.instanceOf(user.profile, Profile)
+
+    assert.exists(user.profile.id)
     assert.isFalse(user.profile.$isPersisted)
     assert.equal(user.profile.userId, user.id)
   })
 
   test('pass custom attributes to relationship', async (assert) => {
     class Profile extends BaseModel {
+      @column()
+      public id: number
+
       @column()
       public userId: number
 
@@ -125,13 +134,15 @@ test.group('Factory | HasOne | make', (group) => {
 
     const user = await factory
       .with('profile', 1, (related) => related.merge({ displayName: 'Romain' }))
-      .make()
+      .makeStubbed()
 
+    assert.exists(user.id)
     assert.isFalse(user.$isPersisted)
     assert.instanceOf(user.profile, Profile)
     assert.isFalse(user.profile.$isPersisted)
     assert.equal(user.profile.displayName, 'Romain')
     assert.equal(user.profile.userId, user.id)
+    assert.exists(user.profile.id)
   })
 })
 

--- a/test/factory/has-one.spec.ts
+++ b/test/factory/has-one.spec.ts
@@ -68,12 +68,14 @@ test.group('Factory | HasOne | make', (group) => {
     }
 
     const profileFactory = new FactoryModel(Profile, () => {
-      const profile = new Profile()
-      profile.displayName = 'virk'
-      return profile
+      return {
+        displayName: 'virk',
+      }
     }).build()
 
-    const factory = new FactoryModel(User, () => new User())
+    const factory = new FactoryModel(User, () => {
+      return {}
+    })
       .related('profile', () => profileFactory)
       .build()
 
@@ -109,18 +111,20 @@ test.group('Factory | HasOne | make', (group) => {
       public profile: HasOne<typeof Profile>
     }
 
-    const profileFactory = new FactoryModel(Profile, (_, attributes?: any) => {
-      const profile = new Profile()
-      profile.displayName = attributes?.displayName || 'virk'
-      return profile
+    const profileFactory = new FactoryModel(Profile, () => {
+      return {
+        displayName: 'virk',
+      }
     }).build()
 
-    const factory = new FactoryModel(User, () => new User())
+    const factory = new FactoryModel(User, () => {
+      return {}
+    })
       .related('profile', () => profileFactory)
       .build()
 
     const user = await factory
-      .with('profile', 1, (related) => related.fill({ displayName: 'Romain' }))
+      .with('profile', 1, (related) => related.merge({ displayName: 'Romain' }))
       .make()
 
     assert.isFalse(user.$isPersisted)
@@ -172,12 +176,14 @@ test.group('Factory | HasOne | create', (group) => {
     }
 
     const profileFactory = new FactoryModel(Profile, () => {
-      const profile = new Profile()
-      profile.displayName = 'virk'
-      return profile
+      return {
+        displayName: 'virk',
+      }
     }).build()
 
-    const factory = new FactoryModel(User, () => new User())
+    const factory = new FactoryModel(User, () => {
+      return {}
+    })
       .related('profile', () => profileFactory)
       .build()
 
@@ -213,18 +219,20 @@ test.group('Factory | HasOne | create', (group) => {
       public profile: HasOne<typeof Profile>
     }
 
-    const profileFactory = new FactoryModel(Profile, (_, attributes?: any) => {
-      const profile = new Profile()
-      profile.displayName = attributes?.displayName || 'virk'
-      return profile
+    const profileFactory = new FactoryModel(Profile, () => {
+      return {
+        displayName: 'virk',
+      }
     }).build()
 
-    const factory = new FactoryModel(User, () => new User())
+    const factory = new FactoryModel(User, () => {
+      return {}
+    })
       .related('profile', () => profileFactory)
       .build()
 
     const user = await factory
-      .with('profile', 1, (related) => related.fill({ displayName: 'Romain' }))
+      .with('profile', 1, (related) => related.merge({ displayName: 'Romain' }))
       .create()
 
     assert.isTrue(user.$isPersisted)
@@ -259,12 +267,14 @@ test.group('Factory | HasOne | create', (group) => {
     }
 
     const profileFactory = new FactoryModel(Profile, () => {
-      const profile = new Profile()
-      profile.displayName = 'virk'
-      return profile
+      return {
+        displayName: 'virk',
+      }
     }).build()
 
-    const factory = new FactoryModel(User, () => new User())
+    const factory = new FactoryModel(User, () => {
+      return {}
+    })
       .related('profile', () => profileFactory)
       .build()
 
@@ -303,11 +313,12 @@ test.group('Factory | HasOne | create', (group) => {
     }
 
     const profileFactory = new FactoryModel(Profile, () => {
-      const profile = new Profile()
-      return profile
+      return {}
     }).build()
 
-    const factory = new FactoryModel(User, () => new User())
+    const factory = new FactoryModel(User, () => {
+      return {}
+    })
       .related('profile', () => profileFactory)
       .build()
 

--- a/test/factory/has-one.spec.ts
+++ b/test/factory/has-one.spec.ts
@@ -76,7 +76,7 @@ test.group('Factory | HasOne | make', (group) => {
     const factory = new FactoryModel(User, () => {
       return {}
     })
-      .related('profile', () => profileFactory)
+      .relation('profile', () => profileFactory)
       .build()
 
     const user = await factory.with('profile').make()
@@ -120,7 +120,7 @@ test.group('Factory | HasOne | make', (group) => {
     const factory = new FactoryModel(User, () => {
       return {}
     })
-      .related('profile', () => profileFactory)
+      .relation('profile', () => profileFactory)
       .build()
 
     const user = await factory
@@ -184,7 +184,7 @@ test.group('Factory | HasOne | create', (group) => {
     const factory = new FactoryModel(User, () => {
       return {}
     })
-      .related('profile', () => profileFactory)
+      .relation('profile', () => profileFactory)
       .build()
 
     const user = await factory.with('profile').create()
@@ -228,7 +228,7 @@ test.group('Factory | HasOne | create', (group) => {
     const factory = new FactoryModel(User, () => {
       return {}
     })
-      .related('profile', () => profileFactory)
+      .relation('profile', () => profileFactory)
       .build()
 
     const user = await factory
@@ -275,7 +275,7 @@ test.group('Factory | HasOne | create', (group) => {
     const factory = new FactoryModel(User, () => {
       return {}
     })
-      .related('profile', () => profileFactory)
+      .relation('profile', () => profileFactory)
       .build()
 
     const user = await factory.with('profile').create()
@@ -319,7 +319,7 @@ test.group('Factory | HasOne | create', (group) => {
     const factory = new FactoryModel(User, () => {
       return {}
     })
-      .related('profile', () => profileFactory)
+      .relation('profile', () => profileFactory)
       .build()
 
     try {

--- a/test/factory/has-one.spec.ts
+++ b/test/factory/has-one.spec.ts
@@ -11,6 +11,7 @@
 
 import test from 'japa'
 import { HasOne } from '@ioc:Adonis/Lucid/Relations'
+import { FactoryManager } from '../../src/Factory/index'
 import { column, hasOne } from '../../src/Orm/Decorators'
 
 import {
@@ -26,6 +27,7 @@ import {
 let db: ReturnType<typeof getDb>
 let BaseModel: ReturnType<typeof getBaseModel>
 const FactoryModel = getFactoryModel()
+const factoryManager = new FactoryManager()
 
 test.group('Factory | HasOne | make', (group) => {
   group.before(async () => {
@@ -74,11 +76,11 @@ test.group('Factory | HasOne | make', (group) => {
       return {
         displayName: 'virk',
       }
-    }).build()
+    }, factoryManager).build()
 
     const factory = new FactoryModel(User, () => {
       return {}
-    })
+    }, factoryManager)
       .relation('profile', () => profileFactory)
       .build()
 
@@ -124,11 +126,11 @@ test.group('Factory | HasOne | make', (group) => {
       return {
         displayName: 'virk',
       }
-    }).build()
+    }, factoryManager).build()
 
     const factory = new FactoryModel(User, () => {
       return {}
-    })
+    }, factoryManager)
       .relation('profile', () => profileFactory)
       .build()
 
@@ -190,11 +192,11 @@ test.group('Factory | HasOne | create', (group) => {
       return {
         displayName: 'virk',
       }
-    }).build()
+    }, factoryManager).build()
 
     const factory = new FactoryModel(User, () => {
       return {}
-    })
+    }, factoryManager)
       .relation('profile', () => profileFactory)
       .build()
 
@@ -234,11 +236,11 @@ test.group('Factory | HasOne | create', (group) => {
       return {
         displayName: 'virk',
       }
-    }).build()
+    }, factoryManager).build()
 
     const factory = new FactoryModel(User, () => {
       return {}
-    })
+    }, factoryManager)
       .relation('profile', () => profileFactory)
       .build()
 
@@ -281,11 +283,11 @@ test.group('Factory | HasOne | create', (group) => {
       return {
         displayName: 'virk',
       }
-    }).build()
+    }, factoryManager).build()
 
     const factory = new FactoryModel(User, () => {
       return {}
-    })
+    }, factoryManager)
       .relation('profile', () => profileFactory)
       .build()
 
@@ -325,11 +327,11 @@ test.group('Factory | HasOne | create', (group) => {
 
     const profileFactory = new FactoryModel(Profile, () => {
       return {}
-    }).build()
+    }, factoryManager).build()
 
     const factory = new FactoryModel(User, () => {
       return {}
-    })
+    }, factoryManager)
       .relation('profile', () => profileFactory)
       .build()
 

--- a/test/factory/many-to-many.spec.ts
+++ b/test/factory/many-to-many.spec.ts
@@ -11,6 +11,7 @@
 
 import test from 'japa'
 import { ManyToMany } from '@ioc:Adonis/Lucid/Relations'
+import { FactoryManager } from '../../src/Factory/index'
 import { column, manyToMany } from '../../src/Orm/Decorators'
 
 import {
@@ -26,6 +27,7 @@ import {
 let db: ReturnType<typeof getDb>
 let BaseModel: ReturnType<typeof getBaseModel>
 const FactoryModel = getFactoryModel()
+const factoryManager = new FactoryManager()
 
 test.group('Factory | ManyToMany | make', (group) => {
   group.before(async () => {
@@ -71,11 +73,11 @@ test.group('Factory | ManyToMany | make', (group) => {
       return {
         name: 'Programming',
       }
-    }).build()
+    }, factoryManager).build()
 
     const factory = new FactoryModel(User, () => {
       return {}
-    })
+    }, factoryManager)
       .relation('skills', () => postFactory)
       .build()
 
@@ -122,11 +124,11 @@ test.group('Factory | ManyToMany | make', (group) => {
       return {
         name: 'Programming',
       }
-    }).build()
+    }, factoryManager).build()
 
     const factory = new FactoryModel(User, () => {
       return {}
-    })
+    }, factoryManager)
       .relation('skills', () => postFactory)
       .build()
 
@@ -173,11 +175,11 @@ test.group('Factory | ManyToMany | make', (group) => {
       return {
         name: 'Programming',
       }
-    }).build()
+    }, factoryManager).build()
 
     const factory = new FactoryModel(User, () => {
       return {}
-    })
+    }, factoryManager)
       .relation('skills', () => postFactory)
       .build()
 
@@ -252,11 +254,11 @@ test.group('Factory | ManyToMany | create', (group) => {
       return {
         name: 'Programming',
       }
-    }).build()
+    }, factoryManager).build()
 
     const factory = new FactoryModel(User, () => {
       return {}
-    })
+    }, factoryManager)
       .relation('skills', () => postFactory)
       .build()
 
@@ -300,11 +302,11 @@ test.group('Factory | ManyToMany | create', (group) => {
       return {
         name: 'Programming',
       }
-    }).build()
+    }, factoryManager).build()
 
     const factory = new FactoryModel(User, () => {
       return {}
-    })
+    }, factoryManager)
       .relation('skills', () => postFactory)
       .build()
 
@@ -351,11 +353,11 @@ test.group('Factory | ManyToMany | create', (group) => {
       return {
         name: 'Programming',
       }
-    }).build()
+    }, factoryManager).build()
 
     const factory = new FactoryModel(User, () => {
       return {}
-    })
+    }, factoryManager)
       .relation('skills', () => postFactory)
       .build()
 
@@ -413,11 +415,11 @@ test.group('Factory | ManyToMany | create', (group) => {
 
     const postFactory = new FactoryModel(Skill, () => {
       return {}
-    }).build()
+    }, factoryManager).build()
 
     const factory = new FactoryModel(User, () => {
       return {}
-    })
+    }, factoryManager)
       .relation('skills', () => postFactory)
       .build()
 

--- a/test/factory/many-to-many.spec.ts
+++ b/test/factory/many-to-many.spec.ts
@@ -68,12 +68,14 @@ test.group('Factory | ManyToMany | make', (group) => {
     }
 
     const postFactory = new FactoryModel(Skill, () => {
-      const skill = new Skill()
-      skill.name = 'Programming'
-      return skill
+      return {
+        name: 'Programming',
+      }
     }).build()
 
-    const factory = new FactoryModel(User, () => new User())
+    const factory = new FactoryModel(User, () => {
+      return {}
+    })
       .related('skills', () => postFactory)
       .build()
 
@@ -109,18 +111,20 @@ test.group('Factory | ManyToMany | make', (group) => {
       public skills: ManyToMany<typeof Skill>
     }
 
-    const postFactory = new FactoryModel(Skill, (_, attributes?: any) => {
-      const skill = new Skill()
-      skill.name = attributes?.name || 'Programming'
-      return skill
+    const postFactory = new FactoryModel(Skill, () => {
+      return {
+        name: 'Programming',
+      }
     }).build()
 
-    const factory = new FactoryModel(User, () => new User())
+    const factory = new FactoryModel(User, () => {
+      return {}
+    })
       .related('skills', () => postFactory)
       .build()
 
     const user = await factory.with('skills', 1, (related) => {
-      related.fill({ name: 'Dancing' })
+      related.merge({ name: 'Dancing' })
     }).make()
 
     assert.isFalse(user.$isPersisted)
@@ -154,18 +158,20 @@ test.group('Factory | ManyToMany | make', (group) => {
       public skills: ManyToMany<typeof Skill>
     }
 
-    const postFactory = new FactoryModel(Skill, (_, attributes?: any) => {
-      const skill = new Skill()
-      skill.name = attributes?.name || 'Programming'
-      return skill
+    const postFactory = new FactoryModel(Skill, () => {
+      return {
+        name: 'Programming',
+      }
     }).build()
 
-    const factory = new FactoryModel(User, () => new User())
+    const factory = new FactoryModel(User, () => {
+      return {}
+    })
       .related('skills', () => postFactory)
       .build()
 
     const user = await factory.with('skills', 2, (related) => {
-      related.fill({ name: 'Dancing' })
+      related.merge({ name: 'Dancing' })
     }).make()
 
     assert.isFalse(user.$isPersisted)
@@ -222,12 +228,14 @@ test.group('Factory | ManyToMany | create', (group) => {
     }
 
     const postFactory = new FactoryModel(Skill, () => {
-      const skill = new Skill()
-      skill.name = 'Programming'
-      return skill
+      return {
+        name: 'Programming',
+      }
     }).build()
 
-    const factory = new FactoryModel(User, () => new User())
+    const factory = new FactoryModel(User, () => {
+      return {}
+    })
       .related('skills', () => postFactory)
       .build()
 
@@ -267,18 +275,20 @@ test.group('Factory | ManyToMany | create', (group) => {
       public skills: ManyToMany<typeof Skill>
     }
 
-    const postFactory = new FactoryModel(Skill, (_, attributes?: any) => {
-      const skill = new Skill()
-      skill.name = attributes?.name || 'Programming'
-      return skill
+    const postFactory = new FactoryModel(Skill, () => {
+      return {
+        name: 'Programming',
+      }
     }).build()
 
-    const factory = new FactoryModel(User, () => new User())
+    const factory = new FactoryModel(User, () => {
+      return {}
+    })
       .related('skills', () => postFactory)
       .build()
 
     const user = await factory
-      .with('skills', 1, (related) => related.fill({ name: 'Dancing' }))
+      .with('skills', 1, (related) => related.merge({ name: 'Dancing' }))
       .create()
 
     assert.isTrue(user.$isPersisted)
@@ -316,18 +326,20 @@ test.group('Factory | ManyToMany | create', (group) => {
       public skills: ManyToMany<typeof Skill>
     }
 
-    const postFactory = new FactoryModel(Skill, (_, attributes?: any) => {
-      const skill = new Skill()
-      skill.name = attributes?.name || 'Programming'
-      return skill
+    const postFactory = new FactoryModel(Skill, () => {
+      return {
+        name: 'Programming',
+      }
     }).build()
 
-    const factory = new FactoryModel(User, () => new User())
+    const factory = new FactoryModel(User, () => {
+      return {}
+    })
       .related('skills', () => postFactory)
       .build()
 
     const user = await factory
-      .with('skills', 2, (related) => related.fill([
+      .with('skills', 2, (related) => related.merge([
         { name: 'Dancing' },
         { name: 'Programming' },
       ]))
@@ -379,11 +391,12 @@ test.group('Factory | ManyToMany | create', (group) => {
     }
 
     const postFactory = new FactoryModel(Skill, () => {
-      const skill = new Skill()
-      return skill
+      return {}
     }).build()
 
-    const factory = new FactoryModel(User, () => new User())
+    const factory = new FactoryModel(User, () => {
+      return {}
+    })
       .related('skills', () => postFactory)
       .build()
 

--- a/test/factory/many-to-many.spec.ts
+++ b/test/factory/many-to-many.spec.ts
@@ -76,7 +76,7 @@ test.group('Factory | ManyToMany | make', (group) => {
     const factory = new FactoryModel(User, () => {
       return {}
     })
-      .related('skills', () => postFactory)
+      .relation('skills', () => postFactory)
       .build()
 
     const user = await factory.with('skills').make()
@@ -120,7 +120,7 @@ test.group('Factory | ManyToMany | make', (group) => {
     const factory = new FactoryModel(User, () => {
       return {}
     })
-      .related('skills', () => postFactory)
+      .relation('skills', () => postFactory)
       .build()
 
     const user = await factory.with('skills', 1, (related) => {
@@ -167,7 +167,7 @@ test.group('Factory | ManyToMany | make', (group) => {
     const factory = new FactoryModel(User, () => {
       return {}
     })
-      .related('skills', () => postFactory)
+      .relation('skills', () => postFactory)
       .build()
 
     const user = await factory.with('skills', 2, (related) => {
@@ -236,7 +236,7 @@ test.group('Factory | ManyToMany | create', (group) => {
     const factory = new FactoryModel(User, () => {
       return {}
     })
-      .related('skills', () => postFactory)
+      .relation('skills', () => postFactory)
       .build()
 
     const user = await factory.with('skills').create()
@@ -284,7 +284,7 @@ test.group('Factory | ManyToMany | create', (group) => {
     const factory = new FactoryModel(User, () => {
       return {}
     })
-      .related('skills', () => postFactory)
+      .relation('skills', () => postFactory)
       .build()
 
     const user = await factory
@@ -335,7 +335,7 @@ test.group('Factory | ManyToMany | create', (group) => {
     const factory = new FactoryModel(User, () => {
       return {}
     })
-      .related('skills', () => postFactory)
+      .relation('skills', () => postFactory)
       .build()
 
     const user = await factory
@@ -397,7 +397,7 @@ test.group('Factory | ManyToMany | create', (group) => {
     const factory = new FactoryModel(User, () => {
       return {}
     })
-      .related('skills', () => postFactory)
+      .relation('skills', () => postFactory)
       .build()
 
     try {

--- a/test/factory/many-to-many.spec.ts
+++ b/test/factory/many-to-many.spec.ts
@@ -119,8 +119,8 @@ test.group('Factory | ManyToMany | make', (group) => {
       .related('skills', () => postFactory)
       .build()
 
-    const user = await factory.with('skills', 1, (factory) => {
-      factory.fill({ name: 'Dancing' })
+    const user = await factory.with('skills', 1, (related) => {
+      related.fill({ name: 'Dancing' })
     }).make()
 
     assert.isFalse(user.$isPersisted)
@@ -164,8 +164,8 @@ test.group('Factory | ManyToMany | make', (group) => {
       .related('skills', () => postFactory)
       .build()
 
-    const user = await factory.with('skills', 2, (factory) => {
-      factory.fill({ name: 'Dancing' })
+    const user = await factory.with('skills', 2, (related) => {
+      related.fill({ name: 'Dancing' })
     }).make()
 
     assert.isFalse(user.$isPersisted)
@@ -278,7 +278,7 @@ test.group('Factory | HasMany | create', (group) => {
       .build()
 
     const user = await factory
-      .with('skills', 1, (factory) => factory.fill({ name: 'Dancing' }))
+      .with('skills', 1, (related) => related.fill({ name: 'Dancing' }))
       .create()
 
     assert.isTrue(user.$isPersisted)
@@ -327,9 +327,9 @@ test.group('Factory | HasMany | create', (group) => {
       .build()
 
     const user = await factory
-      .with('skills', 2, (factory) => factory.fill([
+      .with('skills', 2, (related) => related.fill([
         { name: 'Dancing' },
-        { name: 'Programming' }
+        { name: 'Programming' },
       ]))
       .create()
 

--- a/test/factory/many-to-many.spec.ts
+++ b/test/factory/many-to-many.spec.ts
@@ -181,7 +181,7 @@ test.group('Factory | ManyToMany | make', (group) => {
   })
 })
 
-test.group('Factory | HasMany | create', (group) => {
+test.group('Factory | ManyToMany | create', (group) => {
   group.before(async () => {
     db = getDb()
     BaseModel = getBaseModel(ormAdapter(db))

--- a/test/factory/many-to-many.spec.ts
+++ b/test/factory/many-to-many.spec.ts
@@ -79,11 +79,18 @@ test.group('Factory | ManyToMany | make', (group) => {
       .relation('skills', () => postFactory)
       .build()
 
-    const user = await factory.with('skills').make()
+    const user = await factory.with('skills').makeStubbed()
 
+    assert.exists(user.id)
     assert.isFalse(user.$isPersisted)
     assert.lengthOf(user.skills, 1)
+
+    assert.exists(user.skills[0].id)
     assert.instanceOf(user.skills[0], Skill)
+    assert.deepEqual(user.skills[0].$extras, {
+      skill_id: user.skills[0].id,
+      user_id: user.id,
+    })
     assert.isFalse(user.skills[0].$isPersisted)
   })
 
@@ -125,13 +132,17 @@ test.group('Factory | ManyToMany | make', (group) => {
 
     const user = await factory.with('skills', 1, (related) => {
       related.merge({ name: 'Dancing' })
-    }).make()
+    }).makeStubbed()
 
     assert.isFalse(user.$isPersisted)
     assert.lengthOf(user.skills, 1)
     assert.instanceOf(user.skills[0], Skill)
     assert.isFalse(user.skills[0].$isPersisted)
     assert.equal(user.skills[0].name, 'Dancing')
+    assert.deepEqual(user.skills[0].$extras, {
+      skill_id: user.skills[0].id,
+      user_id: user.id,
+    })
   })
 
   test('make many relationship', async (assert) => {
@@ -172,7 +183,7 @@ test.group('Factory | ManyToMany | make', (group) => {
 
     const user = await factory.with('skills', 2, (related) => {
       related.merge({ name: 'Dancing' })
-    }).make()
+    }).makeStubbed()
 
     assert.isFalse(user.$isPersisted)
     assert.lengthOf(user.skills, 2)
@@ -184,6 +195,16 @@ test.group('Factory | ManyToMany | make', (group) => {
     assert.instanceOf(user.skills[1], Skill)
     assert.isFalse(user.skills[1].$isPersisted)
     assert.equal(user.skills[1].name, 'Dancing')
+
+    assert.deepEqual(user.skills[0].$extras, {
+      skill_id: user.skills[0].id,
+      user_id: user.id,
+    })
+
+    assert.deepEqual(user.skills[1].$extras, {
+      skill_id: user.skills[1].id,
+      user_id: user.id,
+    })
   })
 })
 

--- a/test/factory/many-to-many.spec.ts
+++ b/test/factory/many-to-many.spec.ts
@@ -1,0 +1,404 @@
+/*
+* @adonisjs/lucid
+*
+* (c) Harminder Virk <virk@adonisjs.com>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+/// <reference path="../../adonis-typings/index.ts" />
+
+import test from 'japa'
+import { ManyToMany } from '@ioc:Adonis/Lucid/Relations'
+import { column, manyToMany } from '../../src/Orm/Decorators'
+
+import {
+  setup,
+  getDb,
+  cleanup,
+  ormAdapter,
+  resetTables,
+  getBaseModel,
+  getFactoryModel,
+} from '../../test-helpers'
+
+let db: ReturnType<typeof getDb>
+let BaseModel: ReturnType<typeof getBaseModel>
+const FactoryModel = getFactoryModel()
+
+test.group('Factory | ManyToMany | make', (group) => {
+  group.before(async () => {
+    db = getDb()
+    BaseModel = getBaseModel(ormAdapter(db))
+    await setup()
+  })
+
+  group.after(async () => {
+    await cleanup()
+    await db.manager.closeAll()
+  })
+
+  group.afterEach(async () => {
+    await resetTables()
+  })
+
+  test('make model with relationship', async (assert) => {
+    class Skill extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public name: string
+    }
+    Skill.boot()
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number = 0
+
+      @manyToMany(() => Skill)
+      public skills: ManyToMany<typeof Skill>
+    }
+
+    const postFactory = new FactoryModel(Skill, () => {
+      const skill = new Skill()
+      skill.name = 'Programming'
+      return skill
+    }).build()
+
+    const factory = new FactoryModel(User, () => new User())
+      .related('skills', () => postFactory)
+      .build()
+
+    const user = await factory.with('skills').make()
+
+    assert.isFalse(user.$isPersisted)
+    assert.lengthOf(user.skills, 1)
+    assert.instanceOf(user.skills[0], Skill)
+    assert.isFalse(user.skills[0].$isPersisted)
+  })
+
+  test('pass custom attributes to relationship', async (assert) => {
+    class Skill extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public name: string
+    }
+    Skill.boot()
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number = 0
+
+      @manyToMany(() => Skill)
+      public skills: ManyToMany<typeof Skill>
+    }
+
+    const postFactory = new FactoryModel(Skill, (_, attributes?: any) => {
+      const skill = new Skill()
+      skill.name = attributes?.name || 'Programming'
+      return skill
+    }).build()
+
+    const factory = new FactoryModel(User, () => new User())
+      .related('skills', () => postFactory)
+      .build()
+
+    const user = await factory.with('skills', 1, (factory) => {
+      factory.fill({ name: 'Dancing' })
+    }).make()
+
+    assert.isFalse(user.$isPersisted)
+    assert.lengthOf(user.skills, 1)
+    assert.instanceOf(user.skills[0], Skill)
+    assert.isFalse(user.skills[0].$isPersisted)
+    assert.equal(user.skills[0].name, 'Dancing')
+  })
+
+  test('make many relationship', async (assert) => {
+    class Skill extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public name: string
+    }
+    Skill.boot()
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number = 0
+
+      @manyToMany(() => Skill)
+      public skills: ManyToMany<typeof Skill>
+    }
+
+    const postFactory = new FactoryModel(Skill, (_, attributes?: any) => {
+      const skill = new Skill()
+      skill.name = attributes?.name || 'Programming'
+      return skill
+    }).build()
+
+    const factory = new FactoryModel(User, () => new User())
+      .related('skills', () => postFactory)
+      .build()
+
+    const user = await factory.with('skills', 2, (factory) => {
+      factory.fill({ name: 'Dancing' })
+    }).make()
+
+    assert.isFalse(user.$isPersisted)
+    assert.lengthOf(user.skills, 2)
+
+    assert.instanceOf(user.skills[0], Skill)
+    assert.isFalse(user.skills[0].$isPersisted)
+    assert.equal(user.skills[0].name, 'Dancing')
+
+    assert.instanceOf(user.skills[1], Skill)
+    assert.isFalse(user.skills[1].$isPersisted)
+    assert.equal(user.skills[1].name, 'Dancing')
+  })
+})
+
+test.group('Factory | HasMany | create', (group) => {
+  group.before(async () => {
+    db = getDb()
+    BaseModel = getBaseModel(ormAdapter(db))
+    await setup()
+  })
+
+  group.after(async () => {
+    await cleanup()
+    await db.manager.closeAll()
+  })
+
+  group.afterEach(async () => {
+    await resetTables()
+  })
+
+  test('create model with relationship', async (assert) => {
+    class Skill extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public name: string
+    }
+    Skill.boot()
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number = 0
+
+      @manyToMany(() => Skill)
+      public skills: ManyToMany<typeof Skill>
+    }
+
+    const postFactory = new FactoryModel(Skill, () => {
+      const skill = new Skill()
+      skill.name = 'Programming'
+      return skill
+    }).build()
+
+    const factory = new FactoryModel(User, () => new User())
+      .related('skills', () => postFactory)
+      .build()
+
+    const user = await factory.with('skills').create()
+
+    assert.isTrue(user.$isPersisted)
+    assert.lengthOf(user.skills, 1)
+    assert.instanceOf(user.skills[0], Skill)
+    assert.isTrue(user.skills[0].$isPersisted)
+    assert.deepEqual(user.skills[0].$extras, {
+      user_id: user.id,
+      skill_id: user.skills[0].id,
+    })
+  })
+
+  test('pass custom attributes', async (assert) => {
+    class Skill extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public name: string
+    }
+    Skill.boot()
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number = 0
+
+      @manyToMany(() => Skill)
+      public skills: ManyToMany<typeof Skill>
+    }
+
+    const postFactory = new FactoryModel(Skill, (_, attributes?: any) => {
+      const skill = new Skill()
+      skill.name = attributes?.name || 'Programming'
+      return skill
+    }).build()
+
+    const factory = new FactoryModel(User, () => new User())
+      .related('skills', () => postFactory)
+      .build()
+
+    const user = await factory
+      .with('skills', 1, (factory) => factory.fill({ name: 'Dancing' }))
+      .create()
+
+    assert.isTrue(user.$isPersisted)
+    assert.lengthOf(user.skills, 1)
+    assert.instanceOf(user.skills[0], Skill)
+    assert.isTrue(user.skills[0].$isPersisted)
+    assert.equal(user.skills[0].name, 'Dancing')
+    assert.deepEqual(user.skills[0].$extras, {
+      user_id: user.id,
+      skill_id: user.skills[0].id,
+    })
+  })
+
+  test('create many relationships', async (assert) => {
+    class Skill extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public name: string
+    }
+    Skill.boot()
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number = 0
+
+      @manyToMany(() => Skill)
+      public skills: ManyToMany<typeof Skill>
+    }
+
+    const postFactory = new FactoryModel(Skill, (_, attributes?: any) => {
+      const skill = new Skill()
+      skill.name = attributes?.name || 'Programming'
+      return skill
+    }).build()
+
+    const factory = new FactoryModel(User, () => new User())
+      .related('skills', () => postFactory)
+      .build()
+
+    const user = await factory
+      .with('skills', 2, (factory) => factory.fill([
+        { name: 'Dancing' },
+        { name: 'Programming' }
+      ]))
+      .create()
+
+    assert.isTrue(user.$isPersisted)
+    assert.lengthOf(user.skills, 2)
+    assert.instanceOf(user.skills[0], Skill)
+    assert.isTrue(user.skills[0].$isPersisted)
+    assert.equal(user.skills[0].name, 'Dancing')
+    assert.deepEqual(user.skills[0].$extras, {
+      user_id: user.id,
+      skill_id: user.skills[0].id,
+    })
+
+    assert.instanceOf(user.skills[1], Skill)
+    assert.isTrue(user.skills[1].$isPersisted)
+    assert.equal(user.skills[1].name, 'Programming')
+    assert.deepEqual(user.skills[1].$extras, {
+      user_id: user.id,
+      skill_id: user.skills[1].id,
+    })
+  })
+
+  test('rollback changes on error', async (assert) => {
+    assert.plan(4)
+
+    class Skill extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public name: string
+    }
+    Skill.boot()
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @column()
+      public points: number = 0
+
+      @manyToMany(() => Skill)
+      public skills: ManyToMany<typeof Skill>
+    }
+
+    const postFactory = new FactoryModel(Skill, () => {
+      const skill = new Skill()
+      return skill
+    }).build()
+
+    const factory = new FactoryModel(User, () => new User())
+      .related('skills', () => postFactory)
+      .build()
+
+    try {
+      await factory.with('skills').create()
+    } catch (error) {
+      assert.exists(error)
+    }
+
+    const users = await db.from('users').exec()
+    const skills = await db.from('skills').exec()
+    const userSkills = await db.from('skill_user').exec()
+
+    assert.lengthOf(users, 0)
+    assert.lengthOf(skills, 0)
+    assert.lengthOf(userSkills, 0)
+  })
+})


### PR DESCRIPTION
> This is a draft PR. More features yet to come

## What are factories?

Factories provides a quick way to whip up model instances along with the relationships. 

They are usually helpful during tests, as you can create database records without writing much code. However, people also use them for seeding databases with some initial state (we will talk about database seeding in-depth).

## Factories during tests
First begin with a scenario, where there are not factories and you have to manually use models for setting up the test data.

### Without factories

```ts
import User from 'App/Models/User'
import Post from 'App/Models/Post'

test('only list published posts', () => {
  // Create a user
  const user = await User.create({
    username: 'foo',
    email: 'foo@bar.com',
    password: 'secret',
  })

  // Create some published posts
  const publishedPosts = await user.related('posts').createMany([
    {
      title: 'Adonis 101',
      body: 'some content',
      isPublished: true
    },
    {
      title: 'Lucid 101',
      body: 'some content',
      isPublished: true
    },
  ])

  // Create some draft posts
  const draftPosts = await user.related('posts').createMany([
    {
      title: 'Mail 101',
      body: 'some content',
      isPublished: false
    },
    {
      title: 'Testing 101',
      body: 'some content',
      isPublished: false
    },
  ])

  // here comes the tests code
})
```

### With factories

```ts
import { UserFactory } from 'Database/factory'

const user = UserFactory
  .with('posts', 2, (posts) => {
    posts.apply('published') // published is a pre-defined state
  })
  .with('posts', 2)
  .create()

console.log(user)
console.log(user.posts.length) // 4 (2 draft + 2 published)
```

## Defining factories
Factories are defined only once and then you can use them for `n` number of times to quickly create records.

```ts
import User from 'App/Models/User'
import Post from 'App/Models/Post'
import Factory from '@ioc:Adonis/Lucid/Factory'

export const UserFactory = Factory.define(User, ({ faker, sequence }) => {
  return {
    username: sequence.username,
    email: sequence.email,
    password: faker.password()
  }
})

export const PostFactory = Factory.define(Post, ({ faker }) => {
  return {
    title: faker.lorem.sentence(),
    body: faker.lorem.sentence(4),
  }
})
```

## Define factory relationships
You can also define relationships at the factory level. Only the relationships that exists on the original model are allowed within factories.

```ts
export const UserFactory = Factory
  .define(User, ({ faker, sequence }) => {
    return {
      username: sequence.username,
      email: sequence.email,
      password: faker.password()
    }
  })
  .relation('posts', () => PostFactory)
```

The `relation` method just needs to return the Factory that it relies on.

## Define factory states
The states are defined as follows:

```ts
export const PostFactory = Factory
  .define(Post, ({ faker }) => {
    return {
      title: faker.lorem.sentence(),
      body: faker.lorem.sentence(4),
    }
  })
  .state('published', (post) => post.isPublished = true)
```

## Jobs to be done
Following the feature set we are looking to accomplish

- [x] Define one or more factories for a single Lucid model
- [x] Define factory states
- [x] Define relationships at factory level
- [x] Allow creating model instances, along with relationships (nested as well)
- [x] Allow defining custom attributes at the time of using the factory.
- [x] Allow stubbing of database calls, along with relationships.
- [x] Faker object for creating on the fly data
- [ ] Sequences for generating unique values (inspired by Ruby factory bot)
- [x] Factory hooks (`beforeCreate`, `afterCreate`, `beforeMake`, `afterMake`)
- [x] Stubbing API should also set `ids` (currently it does not)