### PR TITLE
Default value for "column" property in the validator

### DIFF
--- a/adonis-typings/validator.ts
+++ b/adonis-typings/validator.ts
@@ -12,7 +12,7 @@ declare module '@ioc:Adonis/Core/Validator' {
 
   export type DbRowCheckOptions = {
     table: string,
-    column: string,
+    column?: string,
     connection?: string,
     constraints?: { [key: string]: any },
     where?: { [key: string]: any },

--- a/src/Bindings/Validator.ts
+++ b/src/Bindings/Validator.ts
@@ -102,8 +102,8 @@ class DbRowCheck {
     /**
      * Ensure options are defined with table and column name
      */
-    if (!options || !options.table || !options.column) {
-      throw new Exception(`"${this.ruleName}" rule expects a "table" and a "column" name`)
+    if (!options || !options.table) {
+      throw new Exception(`"${this.ruleName}" rule expects a "table" name`)
     }
 
     /**
@@ -118,7 +118,7 @@ class DbRowCheck {
 
     return {
       table: options.table,
-      column: options.column,
+      column: options.column || 'id',
       connection: options.connection,
       where: this.normalizeConstraints(options.where || options.constraints),
       whereNot: this.normalizeConstraints(options.whereNot),


### PR DESCRIPTION
## Proposed changes

Added a default column value 'id' for the validators so we could use exists with only the table property

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

I did this PR on the fly so I can't run lint / unit tests
- [ ] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-lucid/blob/master/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)

## Further comments

This is an opinionated change but I think it's interesting to have this default for the exists rule when trying to validate data.