### PR TITLE
improvement: pass trx object to hooks

### DIFF
--- a/src/Lucid/Model/index.js
+++ b/src/Lucid/Model/index.js
@@ -529,7 +529,7 @@ class Model extends BaseModel {
    */
   _setCreatedAt (values) {
     const createdAtColumn = this.constructor.createdAtColumn
-    if (createdAtColumn) {
+    if (createdAtColumn && !values[createdAtColumn]) {
       values[createdAtColumn] = this._getSetterValue(createdAtColumn, new Date())
     }
   }
@@ -548,7 +548,7 @@ class Model extends BaseModel {
    */
   _setUpdatedAt (values) {
     const updatedAtColumn = this.constructor.updatedAtColumn
-    if (updatedAtColumn) {
+    if (updatedAtColumn && !this.dirty[updatedAtColumn]) {
       values[updatedAtColumn] = this._getSetterValue(updatedAtColumn, new Date())
     }
   }

--- a/src/Lucid/Model/index.js
+++ b/src/Lucid/Model/index.js
@@ -529,7 +529,7 @@ class Model extends BaseModel {
    */
   _setCreatedAt (values) {
     const createdAtColumn = this.constructor.createdAtColumn
-    if (createdAtColumn && !values[createdAtColumn]) {
+    if (createdAtColumn) {
       values[createdAtColumn] = this._getSetterValue(createdAtColumn, new Date())
     }
   }
@@ -548,7 +548,7 @@ class Model extends BaseModel {
    */
   _setUpdatedAt (values) {
     const updatedAtColumn = this.constructor.updatedAtColumn
-    if (updatedAtColumn && !this.dirty[updatedAtColumn]) {
+    if (updatedAtColumn) {
       values[updatedAtColumn] = this._getSetterValue(updatedAtColumn, new Date())
     }
   }
@@ -587,7 +587,7 @@ class Model extends BaseModel {
     /**
      * Executing before hooks
      */
-    await this.constructor.$hooks.before.exec('create', this)
+    await this.constructor.$hooks.before.exec('create', this, trx)
 
     /**
      * Set timestamps
@@ -632,7 +632,7 @@ class Model extends BaseModel {
     /**
      * Executing after hooks
      */
-    await this.constructor.$hooks.after.exec('create', this)
+    await this.constructor.$hooks.after.exec('create', this, trx)
     return true
   }
 
@@ -650,7 +650,7 @@ class Model extends BaseModel {
     /**
      * Executing before hooks
      */
-    await this.constructor.$hooks.before.exec('update', this)
+    await this.constructor.$hooks.before.exec('update', this, trx)
     let affected = 0
 
     const query = this.constructor.query()
@@ -679,7 +679,7 @@ class Model extends BaseModel {
     /**
      * Executing after hooks
      */
-    await this.constructor.$hooks.after.exec('update', this)
+    await this.constructor.$hooks.after.exec('update', this, trx)
 
     if (this.isDirty) {
       /**
@@ -805,14 +805,18 @@ class Model extends BaseModel {
    *
    * @return {Boolean}
    */
-  async delete () {
+  async delete (trx) {
     /**
      * Executing before hooks
      */
-    await this.constructor.$hooks.before.exec('delete', this)
+    await this.constructor.$hooks.before.exec('delete', this, trx)
 
-    const affected = await this.constructor
-      .query()
+    const query = this.constructor.query()
+
+    if (trx) {
+      query.transacting(trx)
+    }
+    const affected = await query
       .where(this.constructor.primaryKey, this.primaryKeyValue)
       .ignoreScopes()
       .delete()
@@ -827,7 +831,7 @@ class Model extends BaseModel {
     /**
      * Executing after hooks
      */
-    await this.constructor.$hooks.after.exec('delete', this)
+    await this.constructor.$hooks.after.exec('delete', this, trx)
     return !!affected
   }
 


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Fix work with transactions

Lucid v6.1.3 doesn't work correctly with transactions. In hooks there no posibility to get current transaction, and no posibility to make addition rows in transaction such as logs, etc.
Also model.delete didn't have trx param, and there were no posibility to delete row in transactions 

## Types of changes

Added trx to all hooks emits,

Added trx to delete function

_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-lucid/blob/master/CONTRIBUTING.md) doc
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
