### PR TITLE
feat: allow globally omitting fields

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,4 +3,4 @@
 In favor of active development we accept contributions from everyone. You can contribute by submitting a bug, creating pull requests or even by improving documentation.
 
 Below is the guide to be followed strictly before submitting your pull requests.
-http://adonisjs.com/docs/contributing
+https://preview.adonisjs.com/code-of-conduct

--- a/adonis-typings/model.ts
+++ b/adonis-typings/model.ts
@@ -128,6 +128,7 @@ declare module '@ioc:Adonis/Lucid/Model' {
   export type CherryPickFields = string[] | {
     pick?: string[],
     omit?: string[],
+    include?: string[],
   }
 
   /**
@@ -186,6 +187,7 @@ declare module '@ioc:Adonis/Lucid/Model' {
   export type ColumnOptions = {
     columnName: string, // database column name
     serializeAs: string | null, // null means do not serialize column
+    omitSerialization: boolean,
     isPrimary: boolean,
     meta?: any,
 
@@ -230,6 +232,7 @@ declare module '@ioc:Adonis/Lucid/Model' {
    */
   export type ComputedOptions = {
     serializeAs: string | null,
+    omitSerialization: boolean,
     meta?: any,
   }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -187,11 +187,13 @@ export function normalizeCherryPickObject (fields: CherryPickFields) {
     return {
       pick: fields,
       omit: [],
+      include: [],
     }
   }
 
   return {
     pick: fields.pick,
     omit: fields.omit,
+    include: fields.include,
   }
 }

--- a/test/orm/base-model.spec.ts
+++ b/test/orm/base-model.spec.ts
@@ -1658,6 +1658,30 @@ test.group('Base Model | toJSON', (group) => {
       fields: ['username'],
     }), { username: 'virk' })
   })
+
+  test('omitting serialization fields by default', async (assert) => {
+    class User extends BaseModel {
+      @column()
+      public username: string
+
+      @column({ omitSerialization: true })
+      public email: string
+
+      @computed()
+      public get fullName () {
+        return this.username.toUpperCase()
+      }
+    }
+
+    const user = new User()
+    user.username = 'virk'
+    user.email = 'virk@adonisjs.com'
+
+    assert.deepEqual(user.serialize(), { username: 'virk', fullName: 'VIRK' })
+    assert.deepEqual(user.serialize({
+      fields: {include: ['email']},
+    }), { username: 'virk', email: 'virk@adonisjs.com', fullName: 'VIRK' })
+  })
 })
 
 test.group('BaseModel | cache', (group) => {


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

This is basically an implementation of what I suggested in [this discussion](https://github.com/adonisjs/core/discussions/1342), it adds a "omitSerialization" to columns that make them be omitted by default, and an "include" array to cherry picking so that this omission can be overridden. 

Here is an example (from the tests):
```typescript
class User extends BaseModel {
  @column()
  public username: string

  @column({ omitSerialization: true })
  public email: string

  @computed()
  public get fullName () {
    return this.username.toUpperCase()
  }
}

const user = new User()
user.username = 'virk'
user.email = 'virk@adonisjs.com'

user.serialize() // { username: 'virk', fullName: 'VIRK' })
user.serialize({
  fields: {include: ['email']}
}) // { username: 'virk', email: 'virk@adonisjs.com', fullName: 'VIRK' })
```


## Types of changes

What types of changes does your code introduce?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-lucid/blob/master/CONTRIBUTING.md) doc
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
 ^ Not sure about this last one
