### PR TITLE
feat(Migrator): add step options to rollback command

### DIFF
--- a/adonis-typings/migrator.ts
+++ b/adonis-typings/migrator.ts
@@ -23,6 +23,7 @@ declare module '@ioc:Adonis/Lucid/Migrator' {
 		| {
 				direction: 'down'
 				batch?: number
+				step?: number
 				connectionName?: string
 				dryRun?: boolean
 		  }

--- a/commands/Migration/Rollback.ts
+++ b/commands/Migration/Rollback.ts
@@ -45,6 +45,11 @@ export default class Migrate extends MigrationsBase {
 	})
 	public batch: number
 
+	@flags.number({
+		description: 'Define custom number of migrations to rollback',
+	})
+	public step: number
+
 	/**
 	 * This command loads the application, since we need the runtime
 	 * to find the migration directories for a given connection
@@ -89,6 +94,7 @@ export default class Migrate extends MigrationsBase {
 		const migrator = new Migrator(db, this.application, {
 			direction: 'down',
 			batch: this.batch,
+			step: this.step,
 			connectionName: this.connection,
 			dryRun: this.dryRun,
 		})

--- a/test/migrations/migrator.spec.ts
+++ b/test/migrations/migrator.spec.ts
@@ -602,6 +602,101 @@ test.group('Migrator', (group) => {
 		])
 	})
 
+	test('cannot define batch & step options at the same time', async (assert) => {
+		const app = new Application(fs.basePath, {} as any, {} as any, {})
+
+		const migrator = getMigrator(db, app, {
+			direction: 'down',
+			batch: 1,
+			step: 2,
+			connectionName: 'primary',
+		})
+
+		await migrator.run()
+
+		assert.equal(migrator.error!.message, 'You cannot define --step and --batch at the same time.')
+	})
+
+	test('rollback given number of migration file', async (assert) => {
+		const app = new Application(fs.basePath, {} as any, {} as any, {})
+
+		await fs.add(
+			'database/migrations/users.ts',
+			`
+      import { Schema } from '../../../../../src/Schema'
+      module.exports = class User extends Schema {
+        public async up () {
+          this.schema.createTable('schema_users', (table) => {
+            table.increments()
+          })
+        }
+
+        public async down () {
+          this.schema.dropTable('schema_users')
+        }
+      }
+    `
+		)
+
+		const migrator = getMigrator(db, app, { direction: 'up', connectionName: 'primary' })
+		await migrator.run()
+
+		await fs.add(
+			'database/migrations/accounts.ts',
+			`
+      import { Schema } from '../../../../../src/Schema'
+      module.exports = class User extends Schema {
+        public async up () {
+          this.schema.createTable('schema_accounts', (table) => {
+            table.increments()
+          })
+        }
+
+        public async down () {
+          this.schema.dropTable('schema_accounts')
+        }
+      }
+    `
+		)
+
+		const migrator1 = getMigrator(db, app, { direction: 'up', connectionName: 'primary' })
+		await migrator1.run()
+
+		const migrator2 = getMigrator(db, app, {
+			direction: 'down',
+			step: 2,
+			connectionName: 'primary',
+		})
+		await migrator2.run()
+
+		const migrated = await db.connection().from('adonis_schema').select('*')
+		const hasUsersTable = await db.connection().schema.hasTable('schema_users')
+		const hasAccountsTable = await db.connection().schema.hasTable('schema_accounts')
+		const migratedFiles = Object.keys(migrator2.migratedFiles).map((file) => {
+			return {
+				status: migrator2.migratedFiles[file].status,
+				file: file,
+				queries: migrator2.migratedFiles[file].queries,
+			}
+		})
+
+		assert.lengthOf(migrated, 0)
+		assert.isFalse(hasUsersTable)
+		assert.isFalse(hasAccountsTable)
+		assert.deepEqual(migratedFiles, [
+			{
+				status: 'completed',
+				file: 'database/migrations/accounts',
+				queries: [],
+			},
+			{
+				status: 'completed',
+				file: 'database/migrations/users',
+				queries: [],
+			},
+		])
+	})
+
 	test('rollback multiple times must be a noop', async (assert) => {
 		await fs.add(
 			'database/migrations/users.ts',

--- a/test/migrations/migrator.spec.ts
+++ b/test/migrations/migrator.spec.ts
@@ -603,8 +603,6 @@ test.group('Migrator', (group) => {
 	})
 
 	test('cannot define batch & step options at the same time', async (assert) => {
-		const app = new Application(fs.basePath, {} as any, {} as any, {})
-
 		const migrator = getMigrator(db, app, {
 			direction: 'down',
 			batch: 1,
@@ -618,8 +616,6 @@ test.group('Migrator', (group) => {
 	})
 
 	test('rollback given number of migration file', async (assert) => {
-		const app = new Application(fs.basePath, {} as any, {} as any, {})
-
 		await fs.add(
 			'database/migrations/users.ts',
 			`


### PR DESCRIPTION
Hey! 👋 

This PR add the option `--step` when running `migration:rollback`.

It let us choose the number of **migrated files** we want to rollback.

```bash
> node ace migration:rollback --step 2
```

This example will rollback the two latest migrated files.