### PR TITLE
Fix returning message

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -130,5 +130,5 @@ util.existy = function (value) {
  * @return {Boolean}
  */
 util.supportsReturning = function (client) {
-  return ['sqlite', 'sqlite3'].indexOf(client) === -1
+  return ['sqlite', 'sqlite3', 'mysql'].indexOf(client) === -1
 }

--- a/src/Lucid/Model/index.js
+++ b/src/Lucid/Model/index.js
@@ -607,30 +607,11 @@ class Model extends BaseModel {
     }
 
     /**
-     * Get our config from the IOC container, then get the database config
-     */
-    const config = ioc.use('Config');
-    const dbConfig = config.get('database');
-
-    /**
-     * Connection is set in the model, if it's undefined then it's using the default connection
-     */
-    const client = this.constructor.connection ? dbConfig[this.constructor.connection].client : dbConfig[dbConfig['connection']].client;
-
-    /**
      * Execute query
      */
-    const returningClients = ['pg', 'mssql', 'oracledb'];
-
-    let result;
-    if (returningClients.includes(client)) {
-      result = await query
-        .returning(this.constructor.primaryKey)
-        .insert(this.$attributes)
-    } else {
-      result = await query
-        .insert(this.$attributes)
-    }
+    const result = await query
+      .returning(this.constructor.primaryKey)
+      .insert(this.$attributes)
 
     /**
      * Only set the primary key value when incrementing is


### PR DESCRIPTION
This is a much simpler fix for Issue #571 which a fix was recently submitted for by @chadhobson (Pull Request #591)

It turns out a mechanism for preventing these warnings was already provided by @thetutlage via a monkey patch of `KnexQueryBuilder.prototype.returning` in `lib/utils.js`.  Simply just needed to add `mysql` to the list.