### PR TITLE
chore(docker): remove 'restart: always' directive

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ version: '3.4'
 services:
   mysql_legacy:
     image: mysql:5.7
-    restart: always
     environment:
       MYSQL_DATABASE: lucid
       MYSQL_USER: virk
@@ -12,7 +11,6 @@ services:
       - '3306:3306'
   mysql:
     image: mysql:8.0
-    restart: always
     command: --default-authentication-plugin=mysql_native_password --sync_binlog=0 --innodb_doublewrite=OFF  --innodb-flush-log-at-trx-commit=0 --innodb-flush-method=nosync
     environment:
       MYSQL_DATABASE: lucid
@@ -23,7 +21,6 @@ services:
       - '3307:3306'
   pg:
     image: postgres:11
-    restart: always
     environment:
       POSTGRES_DB: lucid
       POSTGRES_USER: virk

--- a/npm-audit.html
+++ b/npm-audit.html
@@ -47,7 +47,7 @@
                 <div class="card">
                     <div class="card-body">
                         <h5 class="card-title">
-                            180
+                            0
                         </h5>
                         <p class="card-text">Dependencies</p>
                     </div>
@@ -55,7 +55,7 @@
                 <div class="card">
                     <div class="card-body">
                         <h5 class="card-title">
-                            October 14th 2020, 9:20:42 am
+                            October 14th 2020, 3:35:39 pm
                         </h5>
                         <p class="card-text">Last updated</p>
                     </div>


### PR DESCRIPTION
Hey! 👋 

Having `restart: always` directive make all the images/containers start with the Docker Engine.
We should remove it since we don't want this behavior.