### PR TITLE
feat: add updateOrCreateMany method to hasMany relation

### DIFF
--- a/adonis-typings/model.ts
+++ b/adonis-typings/model.ts
@@ -899,11 +899,10 @@ declare module '@ioc:Adonis/Lucid/Model' {
 		): Promise<InstanceType<T>[]>
 
 		/**
-		 * Update existing rows or create new one's.
+		 * Update existing rows or create new one's following primary key presence or absence
 		 */
 		updateOrCreateMany<T extends LucidModel>(
 			this: T,
-			uniqueKey: keyof ModelAttributes<InstanceType<T>>,
 			payload: Partial<ModelAttributes<InstanceType<T>>>[],
 			options?: ModelAdapterOptions
 		): Promise<InstanceType<T>[]>

--- a/adonis-typings/relations.ts
+++ b/adonis-typings/relations.ts
@@ -629,6 +629,14 @@ declare module '@ioc:Adonis/Lucid/Relations' {
 		): Promise<InstanceType<RelatedModel>[]>
 
 		/**
+		 * Update existing rows or create new one's.
+		 */
+		updateOrCreateMany(
+			uniqueKey: keyof ModelAttributes<InstanceType<RelatedModel>>,
+			payload: Partial<ModelAttributes<InstanceType<RelatedModel>>>[]
+		): Promise<InstanceType<RelatedModel>[]>
+
+		/**
 		 * Return a query builder instance of the relationship
 		 */
 		query<Result extends any = InstanceType<RelatedModel>>(): HasManyQueryBuilderContract<

--- a/adonis-typings/relations.ts
+++ b/adonis-typings/relations.ts
@@ -629,10 +629,9 @@ declare module '@ioc:Adonis/Lucid/Relations' {
 		): Promise<InstanceType<RelatedModel>[]>
 
 		/**
-		 * Update existing rows or create new one's.
+		 * Update existing rows or create new one's following primary key presence or absence
 		 */
 		updateOrCreateMany(
-			uniqueKey: keyof ModelAttributes<InstanceType<RelatedModel>>,
 			payload: Partial<ModelAttributes<InstanceType<RelatedModel>>>[]
 		): Promise<InstanceType<RelatedModel>[]>
 

--- a/npm-audit.html
+++ b/npm-audit.html
@@ -47,7 +47,7 @@
                 <div class="card">
                     <div class="card-body">
                         <h5 class="card-title">
-                            180
+                            181
                         </h5>
                         <p class="card-text">Dependencies</p>
                     </div>
@@ -55,7 +55,7 @@
                 <div class="card">
                     <div class="card-body">
                         <h5 class="card-title">
-                            October 25th 2020, 7:30:23 am
+                            October 28th 2020, 1:13:31 pm
                         </h5>
                         <p class="card-text">Last updated</p>
                     </div>

--- a/npm-audit.html
+++ b/npm-audit.html
@@ -55,7 +55,7 @@
                 <div class="card">
                     <div class="card-body">
                         <h5 class="card-title">
-                            October 28th 2020, 1:13:31 pm
+                            November 2nd 2020, 9:33:19 am
                         </h5>
                         <p class="card-text">Last updated</p>
                     </div>

--- a/src/Orm/Relations/HasMany/QueryClient.ts
+++ b/src/Orm/Relations/HasMany/QueryClient.ts
@@ -168,4 +168,24 @@ export class HasManyQueryClient implements HasManyClientContract<HasMany, LucidM
 				.updateOrCreate(valuesToPersist, updatePayload, { client: trx })
 		})
 	}
+
+	/**
+	 * Update existing rows or create missing one's
+	 */
+	public async updateOrCreateMany(uniqueKey: any, values: ModelObject[]): Promise<LucidRow[]> {
+		return managedTransaction(this.parent.$trx || this.client, async (trx) => {
+			this.parent.$trx = trx
+			await this.parent.save()
+
+			const valuesToPersist = values.map((value) => {
+				const valueToPersist = Object.assign({}, value)
+				this.relation.hydrateForPersistance(this.parent, valueToPersist)
+				return valueToPersist
+			})
+
+			return this.relation
+				.relatedModel()
+				.updateOrCreateMany(uniqueKey, valuesToPersist, { client: trx })
+		})
+	}
 }

--- a/src/Orm/Relations/HasMany/QueryClient.ts
+++ b/src/Orm/Relations/HasMany/QueryClient.ts
@@ -172,7 +172,7 @@ export class HasManyQueryClient implements HasManyClientContract<HasMany, LucidM
 	/**
 	 * Update existing rows or create missing one's
 	 */
-	public async updateOrCreateMany(uniqueKey: any, values: ModelObject[]): Promise<LucidRow[]> {
+	public async updateOrCreateMany(values: ModelObject[]): Promise<LucidRow[]> {
 		return managedTransaction(this.parent.$trx || this.client, async (trx) => {
 			this.parent.$trx = trx
 			await this.parent.save()
@@ -183,9 +183,7 @@ export class HasManyQueryClient implements HasManyClientContract<HasMany, LucidM
 				return valueToPersist
 			})
 
-			return this.relation
-				.relatedModel()
-				.updateOrCreateMany(uniqueKey, valuesToPersist, { client: trx })
+			return this.relation.relatedModel().updateOrCreateMany(valuesToPersist, { client: trx })
 		})
 	}
 }

--- a/test-helpers/index.ts
+++ b/test-helpers/index.ts
@@ -215,6 +215,7 @@ export async function setup(destroyDb: boolean = true) {
 			table.increments()
 			table.integer('user_id')
 			table.string('title').notNullable()
+			table.string('slug')
 			table.boolean('is_published').defaultTo(false)
 			table.timestamps()
 		})

--- a/test/orm/base-model-options.spec.ts
+++ b/test/orm/base-model-options.spec.ts
@@ -901,7 +901,7 @@ test.group('Model options | Model.updateOrCreateMany', (group) => {
 
 		await db.insertQuery().table('users').insert({ username: 'virk' })
 
-		const [user] = await User.updateOrCreateMany('username', [{ username: 'virk' }], {
+		const [user] = await User.updateOrCreateMany([{ id: 1, username: 'virk' }], {
 			connection: 'secondary',
 		})
 
@@ -924,7 +924,7 @@ test.group('Model options | Model.updateOrCreateMany', (group) => {
 			public username: string
 		}
 
-		const [user] = await User.updateOrCreateMany('username', [{ username: 'virk' }], {
+		const [user] = await User.updateOrCreateMany([{ username: 'virk' }], {
 			connection: 'secondary',
 		})
 
@@ -957,7 +957,7 @@ test.group('Model options | Model.updateOrCreateMany', (group) => {
 			return originalCreate(label)
 		}
 
-		const [user] = await User.updateOrCreateMany('username', [{ username: 'virk' }], { profiler })
+		const [user] = await User.updateOrCreateMany([{ id: 1, username: 'virk' }], { profiler })
 
 		const total = await db.from('users').count('*', 'total')
 
@@ -986,7 +986,7 @@ test.group('Model options | Model.updateOrCreateMany', (group) => {
 			return originalCreate(label)
 		}
 
-		const [user] = await User.updateOrCreateMany('username', [{ username: 'virk' }], { profiler })
+		const [user] = await User.updateOrCreateMany([{ username: 'virk' }], { profiler })
 
 		const total = await db.from('users').count('*', 'total')
 
@@ -1009,7 +1009,7 @@ test.group('Model options | Model.updateOrCreateMany', (group) => {
 		await db.insertQuery().table('users').insert({ username: 'virk' })
 		const client = db.connection('secondary')
 
-		const [user] = await User.updateOrCreateMany('username', [{ username: 'virk' }], { client })
+		const [user] = await User.updateOrCreateMany([{ id: 1, username: 'virk' }], { client })
 
 		const total = await db.from('users').count('*', 'total')
 
@@ -1031,7 +1031,7 @@ test.group('Model options | Model.updateOrCreateMany', (group) => {
 
 		const client = db.connection('secondary')
 
-		const [user] = await User.updateOrCreateMany('username', [{ username: 'virk' }], { client })
+		const [user] = await User.updateOrCreateMany([{ username: 'virk' }], { client })
 
 		const total = await db.from('users').count('*', 'total')
 
@@ -1057,7 +1057,7 @@ test.group('Model options | Model.updateOrCreateMany', (group) => {
 		}
 
 		try {
-			await User.updateOrCreateMany('username', [
+			await User.updateOrCreateMany([
 				{ username: 'virk', email: 'foo@bar.com' },
 				{ username: 'nikk', email: 'foo@bar.com' },
 				{ username: 'romain', email: 'foo@bar.com' },
@@ -1089,7 +1089,7 @@ test.group('Model options | Model.updateOrCreateMany', (group) => {
 			throw new Error('Never expected to be invoked')
 		}
 
-		await User.updateOrCreateMany('username', [{ username: 'virk', email: 'foo@bar.com' }], {
+		await User.updateOrCreateMany([{ username: 'virk', email: 'foo@bar.com' }], {
 			client: trx,
 		})
 

--- a/test/orm/base-model.spec.ts
+++ b/test/orm/base-model.spec.ts
@@ -3320,7 +3320,7 @@ test.group('Base Model | fetch', (group) => {
 			public points: number
 		}
 
-		const users = await User.updateOrCreateMany('username', [
+		const users = await User.updateOrCreateMany([
 			{
 				username: 'virk',
 				email: 'virk@adonisjs.com',
@@ -3373,8 +3373,9 @@ test.group('Base Model | fetch', (group) => {
 			points: 10,
 		})
 
-		const users = await User.updateOrCreateMany('username', [
+		const users = await User.updateOrCreateMany([
 			{
+				id: 1,
 				username: 'virk',
 				email: 'virk@adonisjs.com',
 				points: 4,
@@ -3433,9 +3434,9 @@ test.group('Base Model | fetch', (group) => {
 		const trx = await db.transaction()
 
 		await User.updateOrCreateMany(
-			'username',
 			[
 				{
+					id: 1,
 					username: 'virk',
 					email: 'virk@adonisjs.com',
 				},
@@ -3482,9 +3483,9 @@ test.group('Base Model | fetch', (group) => {
 		const trx = await db.transaction()
 
 		await User.updateOrCreateMany(
-			'username',
 			[
 				{
+					id: 1,
 					username: 'virk',
 					email: 'virk@adonisjs.com',
 					points: 4,
@@ -3542,14 +3543,16 @@ test.group('Base Model | fetch', (group) => {
 		})
 
 		await Promise.all([
-			User.updateOrCreateMany('username', [
+			User.updateOrCreateMany([
 				{
+					id: 1,
 					username: 'virk',
 					email: 'virk-1@adonisjs.com',
 				},
 			]),
-			User.updateOrCreateMany('username', [
+			User.updateOrCreateMany([
 				{
+					id: 1,
 					username: 'virk',
 					email: 'virk-1@adonisjs.com',
 				},

--- a/test/orm/model-has-many.spec.ts
+++ b/test/orm/model-has-many.spec.ts
@@ -3693,6 +3693,186 @@ test.group('Model | HasMany | createMany', (group) => {
 	})
 })
 
+test.group('Model | HasMany | updateOrCreateMany', (group) => {
+	group.before(async () => {
+		app = await setupApplication()
+		db = getDb(app)
+		BaseModel = getBaseModel(ormAdapter(db), app)
+		await setup()
+	})
+
+	group.after(async () => {
+		await db.manager.closeAll()
+		await cleanup()
+		await fs.cleanup()
+	})
+
+	group.afterEach(async () => {
+		await resetTables()
+	})
+
+	test('update or create many related instances', async (assert) => {
+		class Post extends BaseModel {
+			@column({ isPrimary: true })
+			public id: number
+
+			@column()
+			public userId: number
+
+			@column()
+			public title: string
+
+			@column()
+			public slug: string
+		}
+
+		class User extends BaseModel {
+			@column({ isPrimary: true })
+			public id: number
+
+			@column()
+			public username: string
+
+			@hasMany(() => Post)
+			public posts: HasMany<typeof Post>
+		}
+
+		const user = new User()
+		user.username = 'virk'
+		await user.save()
+
+		const postCreated = new Post()
+		postCreated.title = 'Adonis 100'
+		postCreated.slug = 'adonis-100'
+		postCreated.userId = user.id
+		await postCreated.save()
+
+		const [post, post1] = await user.related('posts').updateOrCreateMany('slug', [
+			{
+				title: 'Adonis 101',
+				slug: 'adonis-100',
+			},
+			{
+				title: 'Lucid 101',
+				slug: 'lucid-101',
+			},
+		])
+
+		assert.isTrue(post.$isPersisted)
+		assert.equal(user.id, post.userId)
+		assert.equal(post.title, 'Adonis 101')
+
+		assert.isTrue(post1.$isPersisted)
+		assert.equal(user.id, post1.userId)
+
+		const totalUsers = await db.query().from('users').count('*', 'total')
+		const totalPosts = await db.query().from('posts').count('*', 'total')
+
+		assert.equal(totalUsers[0].total, 1)
+		assert.equal(totalPosts[0].total, 2)
+	})
+
+	test('wrap update or create many calls inside transaction', async (assert) => {
+		assert.plan(4)
+
+		class Post extends BaseModel {
+			@column({ isPrimary: true })
+			public id: number
+
+			@column()
+			public userId: number
+
+			@column()
+			public title: string
+
+			@column()
+			public slug: string
+		}
+
+		class User extends BaseModel {
+			@column({ isPrimary: true })
+			public id: number
+
+			@column()
+			public username: string
+
+			@hasMany(() => Post)
+			public posts: HasMany<typeof Post>
+		}
+
+		const user = new User()
+		user.username = 'virk'
+
+		try {
+			await user
+				.related('posts')
+				.updateOrCreateMany('slug', [{ title: 'Adonis 101', slug: 'adonis-101' }, {}])
+		} catch (error) {
+			assert.exists(error)
+		}
+
+		const totalUsers = await db.query().from('users').count('*', 'total')
+		const totalPosts = await db.query().from('posts').count('*', 'total')
+
+		assert.equal(totalUsers[0].total, 0)
+		assert.equal(totalPosts[0].total, 0)
+		assert.isUndefined(user.$trx)
+	})
+
+	test('use parent model transaction when already exists', async (assert) => {
+		class Post extends BaseModel {
+			@column({ isPrimary: true })
+			public id: number
+
+			@column()
+			public userId: number
+
+			@column()
+			public title: string
+
+			@column()
+			public slug: string
+		}
+
+		class User extends BaseModel {
+			@column({ isPrimary: true })
+			public id: number
+
+			@column()
+			public username: string
+
+			@hasMany(() => Post)
+			public posts: HasMany<typeof Post>
+		}
+
+		const trx = await db.transaction()
+		const user = new User()
+		user.$trx = trx
+		user.username = 'virk'
+
+		const [post] = await user.related('posts').updateOrCreateMany('slug', [
+			{
+				title: 'Adonis 101',
+				slug: 'adonis-100',
+			},
+			{
+				title: 'Lucid 101',
+				slug: 'lucid-101',
+			},
+		])
+		assert.isFalse(user.$trx.isCompleted)
+		await trx.rollback()
+
+		const totalUsers = await db.query().from('users').count('*', 'total')
+		const totalPosts = await db.query().from('posts').count('*', 'total')
+
+		assert.equal(totalUsers[0].total, 0)
+		assert.equal(totalPosts[0].total, 0)
+		assert.isUndefined(user.$trx)
+		assert.isUndefined(post.$trx)
+	})
+})
+
 test.group('Model | HasMany | firstOrCreate', (group) => {
 	group.before(async () => {
 		app = await setupApplication()

--- a/test/orm/model-has-many.spec.ts
+++ b/test/orm/model-has-many.spec.ts
@@ -3747,8 +3747,9 @@ test.group('Model | HasMany | updateOrCreateMany', (group) => {
 		postCreated.userId = user.id
 		await postCreated.save()
 
-		const [post, post1] = await user.related('posts').updateOrCreateMany('slug', [
+		const [post, post1] = await user.related('posts').updateOrCreateMany([
 			{
+				id: 1,
 				title: 'Adonis 101',
 				slug: 'adonis-100',
 			},
@@ -3806,7 +3807,7 @@ test.group('Model | HasMany | updateOrCreateMany', (group) => {
 		try {
 			await user
 				.related('posts')
-				.updateOrCreateMany('slug', [{ title: 'Adonis 101', slug: 'adonis-101' }, {}])
+				.updateOrCreateMany([{ id: 1, title: 'Adonis 101', slug: 'adonis-101' }, {}])
 		} catch (error) {
 			assert.exists(error)
 		}
@@ -3850,7 +3851,7 @@ test.group('Model | HasMany | updateOrCreateMany', (group) => {
 		user.$trx = trx
 		user.username = 'virk'
 
-		const [post] = await user.related('posts').updateOrCreateMany('slug', [
+		const [post] = await user.related('posts').updateOrCreateMany([
 			{
 				title: 'Adonis 101',
 				slug: 'adonis-100',


### PR DESCRIPTION
## Proposed changes

Adds updateOrCreateMany method to HasMany relation, covering the situation when a Product has many Variants and you would like to update or create them directly.
Also updated the method and excluded `uniqueKey` replacing it by `primaryKey` instead by default. The reason is described [here](https://github.com/adonisjs/core/discussions/1799#discussioncomment-114237).

## Types of changes

What types of changes does your code introduce?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/lucid/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
