### PR TITLE
Use Github Action to generate the Audit HTML file instead of pre-commit hook

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,22 @@
+name: Package Audit
+on:
+	schedule:
+		# At 12:00 AM, only on Friday
+		- cron: "0 0 * * FRI"
+	workflow_dispatch:
+jobs:
+	build:
+		runs-on: ubuntu-latest
+		steps:
+			- uses: actions/checkout@v2
+			- name: Install deps
+				run: npm i
+			- name: Create audit file
+				run: npm audit --production --json | ./node_modules/.bin/npm-audit-html
+			- name: Commit the file
+				run: |
+          git config user.name "Github Action"
+          git config user.email github-action@users.noreply.github.com
+          git add npm-audit.html
+          git commit -m "chore: update packages' audit"
+          git push

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,20 +1,20 @@
 name: Package Audit
 on:
-	schedule:
-		# At 12:00 AM, only on Friday
-		- cron: "0 0 * * FRI"
-	workflow_dispatch:
+  schedule:
+    # At 12:00 AM, only on Friday
+    - cron: '0 0 * * FRI'
+  workflow_dispatch:
 jobs:
-	build:
-		runs-on: ubuntu-latest
-		steps:
-			- uses: actions/checkout@v2
-			- name: Install deps
-				run: npm i
-			- name: Create audit file
-				run: npm audit --production --json | ./node_modules/.bin/npm-audit-html
-			- name: Commit the file
-				run: |
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install deps
+        run: npm i
+      - name: Create audit file
+        run: npm audit --production --json | ./node_modules/.bin/npm-audit-html
+      - name: Commit the file
+        run: |
           git config user.name "Github Action"
           git config user.email github-action@users.noreply.github.com
           git add npm-audit.html

--- a/package.json
+++ b/package.json
@@ -112,8 +112,7 @@
   },
   "husky": {
     "hooks": {
-      "commit-msg": "node ./node_modules/@adonisjs/mrm-preset/validateCommit/conventional/validate.js",
-      "pre-commit": "npm audit --production --json | ./node_modules/.bin/npm-audit-html && git add npm-audit.html"
+      "commit-msg": "node ./node_modules/@adonisjs/mrm-preset/validateCommit/conventional/validate.js"
     }
   },
   "config": {


### PR DESCRIPTION
👋 

The hook will run once a week on Friday.
We can also run it ourself inside the `Actions` tab of the repository.