### PR TITLE
feat: update dateTimeFormat in MySQL Dialects

### DIFF
--- a/src/Dialects/Mysql.ts
+++ b/src/Dialects/Mysql.ts
@@ -26,7 +26,7 @@ export class MysqlDialect implements DialectContract {
 	 * The default format for datetime column. The date formats is
 	 * valid for luxon date parsing library
 	 */
-	public readonly dateTimeFormat = 'yyyy-MM-dd HH:mm:ss'
+	public readonly dateTimeFormat = 'yyyy-MM-dd HH:mm:ss.SSS'
 
 	constructor(private client: QueryClientContract) {}
 

--- a/test-helpers/index.ts
+++ b/test-helpers/index.ts
@@ -146,7 +146,7 @@ export async function setup(destroyDb: boolean = true) {
 			table.string('username').unique()
 			table.string('email').unique()
 			table.integer('points').defaultTo(0)
-			table.timestamp('joined_at', { useTz: process.env.DB === 'mssql' })
+			table.timestamp('joined_at', { precision: 3, useTz: process.env.DB === 'mssql' })
 			table.integer('parent_id').nullable()
 			table.timestamp('created_at').defaultTo(db.fn.now())
 			table.timestamp('updated_at').nullable()


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

It is better to enable to save precise timestamps to MySQL database.

detail here: https://github.com/adonisjs/lucid/issues/636

## Types of changes

What types of changes does your code introduce?


- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/lucid/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
=> But I'm not sure that my updating tests is appropriate. I expect reviewed.
- [ ] I have added necessary documentation (if appropriate)
=> I think it's maybe not necessary in this case.


## Further comments

This is my first time to contribute OSS, so I'm sorry if information is not enough.
