### PR TITLE
fix: set correct key for mssql connection

### DIFF
--- a/templates/database.txt
+++ b/templates/database.txt
@@ -139,7 +139,7 @@ const databaseConfig: DatabaseConfig & { orm: Partial<OrmConfig> } = {
     | npm i mssql
     |
     */
-		oracle: {
+		mssql: {
 			client: 'mssql',
       connection: {
 				user: Env.get('MSSQL_USER'),


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Fix the generation of the `database.ts` file after run `node ace invoke @adonisjs/lucid` when the database used is mssql.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/adonisjs/lucid/blob/master/CONTRIBUTING.md) doc
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
