### PR TITLE
fix: fix table name duplication in withCount query builder

### DIFF
--- a/src/Orm/QueryBuilder/index.ts
+++ b/src/Orm/QueryBuilder/index.ts
@@ -425,7 +425,7 @@ export class ModelQueryBuilder extends Chainable implements ModelQueryBuilderCon
 		 * Select "*" when no custom selects are defined
 		 */
 		if (!this.columns.length) {
-			this.select(`${this.model.table}.*`)
+			this.select('*')
 		}
 
 		/**


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

I corrected the table name duplication in `withQuery` query builder results in undefined column in base table.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/lucid/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
