### PR TITLE
fix: fix table name duplication in withCount query builder

### DIFF
--- a/npm-audit.html
+++ b/npm-audit.html
@@ -55,7 +55,7 @@
                 <div class="card">
                     <div class="card-body">
                         <h5 class="card-title">
-                            February 18th 2021, 8:39:13 pm
+                            February 19th 2021, 7:22:32 am
                         </h5>
                         <p class="card-text">Last updated</p>
                     </div>

--- a/npm-audit.html
+++ b/npm-audit.html
@@ -1,0 +1,156 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <!-- Bootstrap CSS -->
+    <link rel="stylesheet"
+        href="https://unpkg.com/bootstrap-material-design@4.1.1/dist/css/bootstrap-material-design.min.css"
+        integrity="sha384-wXznGJNEXNG1NFsbm0ugrLFMQPWswR3lds2VeinahP8N0zJw9VWSopbjv2x7WCvX" crossorigin="anonymous">
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs4/dt-1.10.20/datatables.min.css" />
+    <link rel="stylesheet"
+        href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@10.3.1/build/styles/atom-one-dark.min.css">
+
+    <title>NPM Audit Report</title>
+    <meta name="description" content="0 known vulnerabilities found.">
+
+    <style>
+        pre {
+            background-color: #333333;
+            padding: 15px;
+        }
+
+        pre code {
+            color: #fff;
+        }
+    </style>
+
+</head>
+
+<body class="mb-3">
+    <div class="container">
+        <h1 class="mt-5 text-center">NPM Audit Report</h1>
+
+        <div class="text-center">
+            <div class="card-deck my-3">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+                            0
+                        </h5>
+                        <p class="card-text">Known vulnerabilities</p>
+                    </div>
+                </div>
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+                            0
+                        </h5>
+                        <p class="card-text">Dependencies</p>
+                    </div>
+                </div>
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+                            February 18th 2021, 8:39:13 pm
+                        </h5>
+                        <p class="card-text">Last updated</p>
+                    </div>
+                </div>
+            </div>
+            <div class="card-deck my-3">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+                            0
+                        </h5>
+                        <p class="card-text">
+                            <span class="badge badge-danger">critical</span>
+                        </p>
+                    </div>
+                </div>
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+                            0
+                        </h5>
+                        <p class="card-text">
+                            <span class="badge badge-warning">high</span>
+                        </p>
+                    </div>
+                </div>
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+                            0
+                        </h5>
+                        <p class="card-text">
+                            <span class="badge badge-secondary">moderate</span>
+                        </p>
+                    </div>
+                </div>
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+                            0
+                        </h5>
+                        <p class="card-text">
+                            <span class="badge badge-primary">low</span>
+                        </p>
+                    </div>
+                </div>
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+                            0
+                        </h5>
+                        <p class="card-text">
+                            <span class="badge badge-info">info</span>
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col">
+
+                <table id="advisories" class="table">
+                    <thead>
+                        <tr>
+                            <th scope="col">Name</th>
+                            <th scope="col">Module</th>
+                            <th scope="col">Severity</th>
+                            <th scope="col">CVEs</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+
+
+    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
+        integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
+        crossorigin="anonymous"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
+        integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
+        crossorigin="anonymous"></script>
+    <script type="text/javascript" src="https://cdn.datatables.net/v/bs4/dt-1.10.20/datatables.min.js"></script>
+
+    <script>
+        $(document).ready(function () {
+            $('#advisories').DataTable({
+                order: [[2, 'asc']]
+            });
+        });
+    </script>
+</body>
+
+</html>

--- a/src/Orm/QueryBuilder/index.ts
+++ b/src/Orm/QueryBuilder/index.ts
@@ -425,7 +425,7 @@ export class ModelQueryBuilder extends Chainable implements ModelQueryBuilderCon
 		 * Select "*" when no custom selects are defined
 		 */
 		if (!this.columns.length) {
-			this.select(`${this.model.table}.*`)
+			this.select('*')
 		}
 
 		/**

--- a/test-helpers/index.ts
+++ b/test-helpers/index.ts
@@ -255,6 +255,25 @@ export async function setup(destroyDb: boolean = true) {
 		})
 	}
 
+	const hasGroupsTable = await db.schema.hasTable('groups')
+	if (!hasGroupsTable) {
+		await db.schema.createTable('groups', (table) => {
+			table.increments()
+			table.string('name').notNullable()
+			table.timestamps()
+		})
+	}
+
+	const hasGroupUsersTable = await db.schema.hasTable('group_user')
+	if (!hasGroupUsersTable) {
+		await db.schema.createTable('group_user', (table) => {
+			table.increments()
+			table.integer('group_id')
+			table.integer('user_id')
+			table.timestamps()
+		})
+	}
+
 	if (destroyDb) {
 		await db.destroy()
 	}
@@ -286,6 +305,8 @@ export async function cleanup(customTables?: string[]) {
 	await db.schema.dropTableIfExists('comments')
 	await db.schema.dropTableIfExists('identities')
 	await db.schema.dropTableIfExists('knex_migrations')
+	await db.schema.dropTableIfExists('groups')
+	await db.schema.dropTableIfExists('group_user')
 
 	await db.destroy()
 }
@@ -306,6 +327,8 @@ export async function resetTables() {
 	await db.table('posts').truncate()
 	await db.table('comments').truncate()
 	await db.table('identities').truncate()
+	await db.table('groups').truncate()
+	await db.table('group_user').truncate()
 	await db.destroy()
 }
 

--- a/test/database/query-client.spec.ts
+++ b/test/database/query-client.spec.ts
@@ -449,6 +449,8 @@ test.group('Query client | get tables', (group) => {
 				'countries',
 				'follows',
 				'friends',
+				'group_user',
+				'groups',
 				'identities',
 				'posts',
 				'profiles',

--- a/test/database/query-client.spec.ts
+++ b/test/database/query-client.spec.ts
@@ -465,6 +465,8 @@ test.group('Query client | get tables', (group) => {
 				'countries',
 				'follows',
 				'friends',
+				'group_user',
+				'groups',
 				'identities',
 				'posts',
 				'profiles',

--- a/test/orm/model-many-to-many.spec.ts
+++ b/test/orm/model-many-to-many.spec.ts
@@ -1845,7 +1845,7 @@ test.group('Model | ManyToMany | withCount', (group) => {
 			.insertQuery()
 			.table('skills')
 			.insert([{ name: 'Programming' }, { name: 'Dancing' }])
-		
+
 		await db
 			.insertQuery()
 			.table('groups')
@@ -1868,7 +1868,7 @@ test.group('Model | ManyToMany | withCount', (group) => {
 					skill_id: 2,
 				},
 			])
-		
+
 		await db
 			.insertQuery()
 			.table('group_user')
@@ -1887,8 +1887,8 @@ test.group('Model | ManyToMany | withCount', (group) => {
 				},
 			])
 
-		let group = await Group.find(1)
-		const users = await group!.related('users').query().withCount('skills').orderBy('id', 'asc')
+		let firstGroup = await Group.find(1)
+		const users = await firstGroup!.related('users').query().withCount('skills').orderBy('id', 'asc')
 		assert.lengthOf(users, 2)
 
 		assert.deepEqual(Number(users[0].$extras.skills_count), 2)

--- a/test/orm/model-many-to-many.spec.ts
+++ b/test/orm/model-many-to-many.spec.ts
@@ -1809,6 +1809,91 @@ test.group('Model | ManyToMany | withCount', (group) => {
 		assert.deepEqual(Number(users[0].$extras.mySkills), 2)
 		assert.deepEqual(Number(users[1].$extras.mySkills), 1)
 	})
+
+	test('get count of a relationship rows of relationship', async (assert) => {
+		class Skill extends BaseModel {
+			@column({ isPrimary: true })
+			public id: number
+
+			@column()
+			public name: string
+		}
+
+		class User extends BaseModel {
+			@column({ isPrimary: true })
+			public id: number
+
+			@manyToMany(() => Skill)
+			public skills: ManyToMany<typeof Skill>
+		}
+
+		class Group extends BaseModel {
+			@column({ isPrimary: true })
+			public id: number
+
+			@manyToMany(() => User)
+			public users: ManyToMany<typeof User>
+		}
+
+		User.boot()
+		await db
+			.insertQuery()
+			.table('users')
+			.insert([{ username: 'virk' }, { username: 'nikk' }])
+
+		await db
+			.insertQuery()
+			.table('skills')
+			.insert([{ name: 'Programming' }, { name: 'Dancing' }])
+		
+		await db
+			.insertQuery()
+			.table('groups')
+			.insert([{ name: 'Tech' }, { name: 'Movie' }])
+
+		await db
+			.insertQuery()
+			.table('skill_user')
+			.insert([
+				{
+					user_id: 1,
+					skill_id: 1,
+				},
+				{
+					user_id: 1,
+					skill_id: 2,
+				},
+				{
+					user_id: 2,
+					skill_id: 2,
+				},
+			])
+		
+		await db
+			.insertQuery()
+			.table('group_user')
+			.insert([
+				{
+					group_id: 1,
+					user_id: 1,
+				},
+				{
+					group_id: 1,
+					user_id: 2,
+				},
+				{
+					group_id: 2,
+					user_id: 2,
+				},
+			])
+
+		let group = await Group.find(1)
+		const users = await group!.related('users').query().withCount('skills').orderBy('id', 'asc')
+		assert.lengthOf(users, 2)
+
+		assert.deepEqual(Number(users[0].$extras.skills_count), 2)
+		assert.deepEqual(Number(users[1].$extras.skills_count), 1)
+	})
 })
 
 test.group('Model | ManyToMany | has', (group) => {


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

I corrected the table name duplication in withQuery query builder results in undefined column in base table.
I prepared one test to make sure that my changes does not break anything.

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/lucid/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Before I fix the problem the query bellow (also exists in test file):
```typescript
let firstGroup = await Group.find(1)
const users = await firstGroup!.related('users').query().withCount('skills').orderBy('id', 'asc')
```
returns:
```bash
Error: select `users`.`users`.*, (select count(*) from `skills` inner join `skill_user` on `skills`.`id` = `skill_user`.`skill_id` where `users`.`id` = `skill_user`.`user_id`) as `skills_count`, `group_user`.`group_id` as `pivot_group_id`, `group_user`.`user_id` as `pivot_user_id` from `users` inner join `group_user` on `users`.`id` = `group_user`.`user_id` where `group_user`.`group_id` = 1 order by `id` asc - SQLITE_ERROR: near "*": syntax error
```

note duplication of `users` table in query expression.