### PR TITLE
feat(commands): add migration:reset and migration:fresh commands

### DIFF
--- a/commands/Migration/Reset.ts
+++ b/commands/Migration/Reset.ts
@@ -16,8 +16,8 @@ import MigrationsBase from './Base'
  * in `down` direction.
  */
 export default class Migrate extends MigrationsBase {
-  public static commandName = 'migration:rollback'
-  public static description = 'Rollback migrations to a given batch number'
+  public static commandName = 'migration:reset'
+  public static description = 'Reset migrations to initial state'
 
   /**
    * Custom connection for running migrations.
@@ -36,14 +36,6 @@ export default class Migrate extends MigrationsBase {
    */
   @flags.boolean({ description: 'Print SQL queries, instead of running the migrations' })
   public dryRun: boolean
-
-  /**
-   * Define custom batch, instead of rolling back to the latest batch
-   */
-  @flags.number({
-    description: 'Define custom batch number for rollback. Use 0 to rollback to initial state',
-  })
-  public batch: number
 
   /**
    * This command loads the application, since we need the runtime
@@ -88,7 +80,7 @@ export default class Migrate extends MigrationsBase {
     const { Migrator } = await import('../../src/Migrator')
     const migrator = new Migrator(db, this.application, {
       direction: 'down',
-      batch: this.batch,
+      batch: 0,
       connectionName: this.connection,
       dryRun: this.dryRun,
     })

--- a/commands/index.ts
+++ b/commands/index.ts
@@ -14,5 +14,7 @@ export default [
   '@adonisjs/lucid/build/commands/MakeSeeder',
   '@adonisjs/lucid/build/commands/Migration/Run',
   '@adonisjs/lucid/build/commands/Migration/Rollback',
+  '@adonisjs/lucid/build/commands/Migration/Reset',
+  '@adonisjs/lucid/build/commands/Migration/Fresh',
   '@adonisjs/lucid/build/commands/Migration/Status',
 ]


### PR DESCRIPTION
migration:reset (migration:rollback --batch=0) makes rollback to initial state, migration:fresh (migration:rollback --batch=0; migration:run) makes rollback to inital state and run migrations.

Feature request: #622 (User created issue but gave up)

<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

I added migration:reset and migration:fresh commands like Laravel Artisan. Reset and Fresh commands can be use connection, dry-run, and force arguments like other commands (rollback, run).

And I changed a simple typo in Rollback.ts's comment line. Created migrator for 'down' but written 'up' at the comment line.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/lucid/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)

## Further comments

I wrote simple codes and I didn't change existing codes.