### PR TITLE
Fix typo in comment

### DIFF
--- a/templates/migration-make.txt
+++ b/templates/migration-make.txt
@@ -8,7 +8,7 @@ export default class {{#toClassName}}{{ filename }}{{/toClassName}} extends Base
       table.increments('id')
 
       /**
-       * Uses timestampz for PostgreSQL and DATETIME2 for MSSQL
+       * Uses timestamptz for PostgreSQL and DATETIME2 for MSSQL
        */
       table.timestamp('created_at', { useTz: true })
       table.timestamp('updated_at', { useTz: true })


### PR DESCRIPTION
A very minor, one-character pull request! Fix the typo "timestampz" to "timestamptz" :)