### PR TITLE
refactor: use count query for exists / unique validators

### DIFF
--- a/src/Bindings/Validator.ts
+++ b/src/Bindings/Validator.ts
@@ -157,7 +157,7 @@ class DbRowCheck {
     { pointer, errorReporter, arrayExpressionPointer, refs }: ValidationRuntimeOptions
   ) {
     const client = this.database.connection(connection)
-    const query = client.from(table)
+    const query = client.from(table).select(1)
 
     /**
      * Convert datetime to a string

--- a/test/bindings/validator.spec.ts
+++ b/test/bindings/validator.spec.ts
@@ -76,6 +76,7 @@ test.group('Validator | exists', (group) => {
         const { sql: knexSql, bindings: knexBindings } = db
           .connection()
           .getReadClient()
+          .select(1)
           .from('users')
           .where('id', userId)
           .limit(1)
@@ -113,6 +114,7 @@ test.group('Validator | exists', (group) => {
         const { sql: knexSql, bindings: knexBindings } = db
           .connection()
           .getReadClient()
+          .select(1)
           .from('users')
           .where('id', userId)
           .where('username', 'nikk')
@@ -160,6 +162,7 @@ test.group('Validator | exists', (group) => {
         const { sql: knexSql, bindings: knexBindings } = db
           .connection()
           .getReadClient()
+          .select(1)
           .from('users')
           .where('id', userId)
           .where('username', 'nikk')
@@ -212,6 +215,7 @@ test.group('Validator | exists', (group) => {
         const { sql: knexSql, bindings: knexBindings } = db
           .connection()
           .getReadClient()
+          .select(1)
           .from('users')
           .where('id', userId)
           .whereIn('username', ['nikk', 'romain'])
@@ -259,6 +263,7 @@ test.group('Validator | exists', (group) => {
         const { sql: knexSql, bindings: knexBindings } = db
           .connection()
           .getReadClient()
+          .select(1)
           .from('users')
           .where('id', userId)
           .whereIn('username', ['nikk', 'romain'])
@@ -311,6 +316,7 @@ test.group('Validator | exists', (group) => {
         const { sql: knexSql, bindings: knexBindings } = db
           .connection()
           .getReadClient()
+          .select(1)
           .from('users')
           .where('id', userId)
           .whereNot('username', 'virk')
@@ -358,6 +364,7 @@ test.group('Validator | exists', (group) => {
         const { sql: knexSql, bindings: knexBindings } = db
           .connection()
           .getReadClient()
+          .select(1)
           .from('users')
           .where('id', userId)
           .whereNot('username', 'virk')
@@ -410,6 +417,7 @@ test.group('Validator | exists', (group) => {
         const { sql: knexSql, bindings: knexBindings } = db
           .connection()
           .getReadClient()
+          .select(1)
           .from('users')
           .where('id', userId)
           .whereNotIn('username', ['virk', 'nikk'])
@@ -457,6 +465,7 @@ test.group('Validator | exists', (group) => {
         const { sql: knexSql, bindings: knexBindings } = db
           .connection()
           .getReadClient()
+          .select(1)
           .from('users')
           .where('id', userId)
           .whereNotIn('username', ['virk', 'nikk'])
@@ -506,6 +515,7 @@ test.group('Validator | exists', (group) => {
         const { sql: knexSql, bindings: knexBindings } = db
           .connection()
           .getReadClient()
+          .select(1)
           .from('users')
           .whereRaw(`lower(username) = ?`, [db.connection().knexRawQuery(`lower(?)`, ['VIRK'])])
           .limit(1)
@@ -570,6 +580,7 @@ test.group('Validator | exists', (group) => {
         const knexQuery = db
           .connection()
           .getReadClient()
+          .select(1)
           .from('users')
           .where('created_at', '2020-10-20 00:00:00')
           .limit(1)
@@ -619,6 +630,7 @@ test.group('Validator | exists', (group) => {
         const knexQuery = db
           .connection()
           .getReadClient()
+          .select(1)
           .from('users')
           .where('created_at', '2020-10-20')
           .limit(1)
@@ -727,6 +739,7 @@ test.group('Validator | unique', (group) => {
         const { sql: knexSql, bindings: knexBindings } = db
           .connection()
           .getReadClient()
+          .select(1)
           .from('users')
           .where('id', userId)
           .where('username', 'virk')
@@ -774,6 +787,7 @@ test.group('Validator | unique', (group) => {
         const { sql: knexSql, bindings: knexBindings } = db
           .connection()
           .getReadClient()
+          .select(1)
           .from('users')
           .where('id', userId)
           .where('username', 'virk')
@@ -826,6 +840,7 @@ test.group('Validator | unique', (group) => {
         const { sql: knexSql, bindings: knexBindings } = db
           .connection()
           .getReadClient()
+          .select(1)
           .from('users')
           .where('id', userId)
           .whereIn('username', ['virk', 'nikk'])
@@ -873,6 +888,7 @@ test.group('Validator | unique', (group) => {
         const { sql: knexSql, bindings: knexBindings } = db
           .connection()
           .getReadClient()
+          .select(1)
           .from('users')
           .where('id', userId)
           .whereIn('username', ['virk', 'nikk'])
@@ -925,6 +941,7 @@ test.group('Validator | unique', (group) => {
         const { sql: knexSql, bindings: knexBindings } = db
           .connection()
           .getReadClient()
+          .select(1)
           .from('users')
           .where('id', userId)
           .whereNot('username', 'nikk')
@@ -972,6 +989,7 @@ test.group('Validator | unique', (group) => {
         const { sql: knexSql, bindings: knexBindings } = db
           .connection()
           .getReadClient()
+          .select(1)
           .from('users')
           .where('id', userId)
           .whereNot('username', 'nikk')
@@ -1024,6 +1042,7 @@ test.group('Validator | unique', (group) => {
         const { sql: knexSql, bindings: knexBindings } = db
           .connection()
           .getReadClient()
+          .select(1)
           .from('users')
           .where('id', userId)
           .whereNotIn('country_id', [1, 2])
@@ -1071,6 +1090,7 @@ test.group('Validator | unique', (group) => {
         const { sql: knexSql, bindings: knexBindings } = db
           .connection()
           .getReadClient()
+          .select(1)
           .from('users')
           .where('id', userId)
           .whereNotIn('country_id', [1, 2])
@@ -1119,6 +1139,7 @@ test.group('Validator | unique', (group) => {
         const { sql: knexSql, bindings: knexBindings } = db
           .connection()
           .getReadClient()
+          .select(1)
           .from('users')
           .whereRaw(`lower(username) = ?`, [db.connection().knexRawQuery(`lower(?)`, ['VIRK'])])
           .limit(1)
@@ -1193,6 +1214,7 @@ test.group('Validator | unique', (group) => {
         const knexQuery = db
           .connection()
           .getReadClient()
+          .select(1)
           .from('users')
           .where('created_at', '2020-10-20 00:00:00')
           .limit(1)
@@ -1246,6 +1268,7 @@ test.group('Validator | unique', (group) => {
         const knexQuery = db
           .connection()
           .getReadClient()
+          .select(1)
           .from('users')
           .where('created_at', '2020-10-20')
           .limit(1)


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

unique and exists validator as of now queries whole row(s) from the database, whereas, the same logic can be done through count as well. This PR does exactly that.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/lucid/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
