### PR TITLE
fix: merge recursively when attribute is object

### DIFF
--- a/src/Orm/BaseModel/index.ts
+++ b/src/Orm/BaseModel/index.ts
@@ -1567,7 +1567,11 @@ export class BaseModel implements LucidRow {
          * Set as column
          */
         if (Model.$hasColumn(key)) {
-          this[key] = value
+          if (isObject(this[key])) {
+            lodash.merge(this[key], value)
+          } else {
+            this[key] = value
+          }
           return
         }
 

--- a/test/orm/base-model.spec.ts
+++ b/test/orm/base-model.spec.ts
@@ -2205,6 +2205,22 @@ test.group('BaseModel | fill/merge', (group) => {
     assert.deepEqual(user.$attributes, { username: 'virk', age: 22 })
   })
 
+  test('merge recursively when attribute is object', (assert) => {
+    class User extends BaseModel {
+      @column()
+      public preferences: object
+    }
+
+    const user = new User()
+    user.preferences = {
+      theme: 'dark',
+    }
+
+    assert.deepEqual(user.$attributes, { preferences: { theme: 'dark' } })
+    user.merge({ preferences: { notifications: true } })
+    assert.deepEqual(user.$attributes, { preferences: { theme: 'dark', notifications: true } })
+  })
+
   test('set properties with explicit undefined values', (assert) => {
     class User extends BaseModel {
       @column()


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Hi @thetutlage @RomainLanz,

I have a `users` table with the following column:
```ts
table.json('preferences');
```

And defined the column as follows on the `User` model:
```ts
export default class User extends BaseModel {
    @column({
        prepare: (value: string) => JSON.stringify(value),
        consume: (value: string) => JSON.parse(value)
    })
    public preferences: Preferences | null;
}
```

Consider the following validator / controller:
```ts
preferences: schema.object.optional().members({
    theme: schema.enum.optional(['light', 'dark'] as const),
    notifications: schema.boolean.optional()
})
```

```ts
// Route.patch('/user', 'UsersController.update').middleware('auth');

export default class UsersController {
    public async update({ auth, request }: HttpContextContract) {
        const user = auth.use('api').user!;
        const payload = await request.validate(UpdateUser);

        await user.merge(payload).save(); // <-------------------------

        return user.serialize();
    }
}
```

The current `merge` implementation overrides the attribute with the new value. But I actually expect this to do a recursive merge and I'm curious what your opinion on this is? We could also make it an opt-in param next to `allowExtraProperties`, so merging recursively won't be the default.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] New feature (non-breaking change which adds functionality)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/lucid/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
