### PR TITLE
Enable foreign key support in SQLite

### DIFF
--- a/templates/database.txt
+++ b/templates/database.txt
@@ -42,6 +42,11 @@ const databaseConfig: DatabaseConfig = {
       connection: {
         filename: Application.tmpPath('db.sqlite3'),
       },
+      pool: {
+        afterCreate: (conn, cb) => {
+          conn.run('PRAGMA foreign_keys=true', cb)
+        }
+      },
       migrations: {
         naturalSort: true,
       },


### PR DESCRIPTION
SQLite does not enforce foreign key constraints on cascade deletes / updates by default, this can be turned on with the PRAGMA foreign_keys=true command, but that must be run each time a database connection is established. This changes the default SQLite connection to enable foreign key support so that .onDelete() and .onUpdate methods work as expected
