### PR TITLE
Add helper to load all factories

### DIFF
--- a/src/Bindings/Repl.ts
+++ b/src/Bindings/Repl.ts
@@ -38,7 +38,7 @@ export function defineReplBindings(app: ApplicationContract, Repl: ReplContract)
       setupReplState(repl, 'models', requireAll(modelsAbsPath))
     },
     {
-      description: 'Recursively models Lucid models to the "models" property',
+      description: 'Recursively load Lucid models to the "models" property',
     }
   )
 
@@ -52,6 +52,33 @@ export function defineReplBindings(app: ApplicationContract, Repl: ReplContract)
     },
     {
       description: 'Load database provider to the "Db" property',
+    }
+  )
+
+  /**
+   * Load all factories to the factories property
+   */
+  Repl.addMethod(
+    'loadFactories',
+    (repl) => {
+      const factoriesPath = app.resolveNamespaceDirectory('factories') || 'database/factories'
+      console.log(repl.colors.dim(`recursively reading factories from "${factoriesPath}"`))
+
+      const factoriesAbsPath = app.makePath(factoriesPath)
+      const loadedFactories = requireAll(factoriesAbsPath)
+
+      if (!loadedFactories) {
+        return
+      }
+
+      setupReplState(
+        repl,
+        'factories',
+        Object.values(loadedFactories).reduce((acc, items) => ({ ...acc, ...items }), {})
+      )
+    },
+    {
+      description: 'Recursively load factories to the "factories" property',
     }
   )
 }


### PR DESCRIPTION
Hey there! 👋🏻 

This helper let us load all factories inside the Repl, making it easier to use them.

They will be available inside the `factories` property in the Repl context.

```
CONTEXT PROPERTIES/METHODS:
{
  factories: {
    EpisodeFactory2: [Object],
    UserFactory: [Object],
    EpisodeFactory: [Object],
    SeriesFactory: [Object]
  }
}
```