### PR TITLE
Add `migration:refresh`, `migration:reset`, `migration:fresh` and `db:wipe` commands

### DIFF
--- a/adonis-typings/database.ts
+++ b/adonis-typings/database.ts
@@ -180,6 +180,11 @@ declare module '@ioc:Adonis/Lucid/Database' {
     getAllTables(schemas?: string[]): Promise<string[]>
 
     /**
+     * Drop all tables inside database
+     */
+    dropAllTables(schemas?: string[]): Promise<void>
+
+    /**
      * Same as `query()`, but also selects the table for the query. The `from` method
      * doesn't allow defining the return type and one must use `query` to define
      * that.

--- a/commands/DbWipe.ts
+++ b/commands/DbWipe.ts
@@ -1,0 +1,67 @@
+import { BaseCommand, flags } from '@adonisjs/core/build/standalone'
+
+export default class DbWipe extends BaseCommand {
+  public static commandName = 'db:wipe'
+  public static description = 'Drop all tables in database'
+
+  /**
+   * Choose a custom pre-defined connection. Otherwise, we use the
+   * default connection
+   */
+  @flags.string({ description: 'Define a custom database connection', alias: 'c' })
+  public connection: string
+
+  /**
+   * Force run migrations in production
+   */
+  @flags.boolean({ description: 'Explicitly force to run migrations in production' })
+  public force: boolean
+
+  public static settings = {
+    loadApp: true,
+  }
+
+  /**
+   * Execute command
+   */
+  public async run(): Promise<void> {
+    const db = this.application.container.use('Adonis/Lucid/Database')
+    const connection = db.connection(this.connection || db.primaryConnectionName)
+    const continueWipe =
+      !this.application.inProduction || this.force || (await this.takeProductionConstent())
+
+    /**
+     * Prompt cancelled or rejected and hence do not continue
+     */
+    if (!continueWipe) {
+      return
+    }
+
+    /**
+     * Ensure the define connection name does exists in the
+     * config file
+     */
+    if (!connection) {
+      this.logger.error(
+        `${this.connection} is not a valid connection name. Double check config/database file`
+      )
+      return
+    }
+
+    await db.connection().dropAllTables()
+    this.logger.success('All tables have been dropped successfully')
+  }
+
+  /**
+   * Prompts to take consent for running migrations in production
+   */
+  protected async takeProductionConstent(): Promise<boolean> {
+    const question = 'You are in production environment. Continue ?'
+    try {
+      const continueMigrations = await this.prompt.confirm(question)
+      return continueMigrations
+    } catch (error) {
+      return false
+    }
+  }
+}

--- a/commands/DbWipe.ts
+++ b/commands/DbWipe.ts
@@ -12,9 +12,9 @@ export default class DbWipe extends BaseCommand {
   public connection: string
 
   /**
-   * Force run migrations in production
+   * Force command execution in production
    */
-  @flags.boolean({ description: 'Explicitly force to run migrations in production' })
+  @flags.boolean({ description: 'Explicitly force command to run in production' })
   public force: boolean
 
   public static settings = {

--- a/commands/Migration/Base.ts
+++ b/commands/Migration/Base.ts
@@ -19,6 +19,12 @@ import { getDDLMethod } from '../../src/utils'
  */
 export default abstract class MigrationsBase extends BaseCommand {
   /**
+   * Whether to close the connection after migrations are run
+   * Useful if the Migrator have to be used several times in a row.
+   */
+  public shouldCloseConnectionAfterMigrations: boolean = true
+
+  /**
    * Not a valid message
    */
   protected printNotAValidConnection(connection: string) {
@@ -88,7 +94,10 @@ export default abstract class MigrationsBase extends BaseCommand {
      */
     if (migrator.dryRun) {
       await migrator.run()
-      await migrator.close()
+
+      if (this.shouldCloseConnectionAfterMigrations) {
+        await migrator.close()
+      }
 
       Object.keys(migrator.migratedFiles).forEach((file) => {
         this.prettyPrintSql(migrator.migratedFiles[file], connectionName)
@@ -135,7 +144,9 @@ export default abstract class MigrationsBase extends BaseCommand {
      * Run and close db connection
      */
     await migrator.run()
-    await migrator.close()
+    if (this.shouldCloseConnectionAfterMigrations) {
+      await migrator.close()
+    }
 
     /**
      * Log all pending files. This will happen, when one of the migration

--- a/commands/Migration/Fresh.ts
+++ b/commands/Migration/Fresh.ts
@@ -27,7 +27,7 @@ export default class Refresh extends MigrationsBase {
   /**
    * Perform dry run
    */
-  @flags.boolean({ description: 'Print SQL queries, instead of running the migrations' })
+  @flags.boolean({ description: 'Only print SQL queries instead of executing them' })
   public dryRun: boolean
 
   /**

--- a/commands/Migration/Fresh.ts
+++ b/commands/Migration/Fresh.ts
@@ -1,0 +1,123 @@
+import { flags } from '@adonisjs/core/build/standalone'
+import DbSeed from '../DbSeed'
+import DbWipe from '../DbWipe'
+import MigrationsBase from './Base'
+import Run from './Run'
+
+/**
+ * This command reset the database by rolling back to batch 0 and then
+ * re-run all migrations.
+ */
+export default class Refresh extends MigrationsBase {
+  public static commandName = 'migration:fresh'
+  public static description = 'Drop all tables and re-run all migrations.'
+
+  /**
+   * Custom connection for running migrations.
+   */
+  @flags.string({ description: 'Define a custom database connection', alias: 'c' })
+  public connection: string
+
+  /**
+   * Force run migrations in production
+   */
+  @flags.boolean({ description: 'Explicitly force to run migrations in production' })
+  public force: boolean
+
+  /**
+   * Perform dry run
+   */
+  @flags.boolean({ description: 'Print SQL queries, instead of running the migrations' })
+  public dryRun: boolean
+
+  /**
+   * Run seeders
+   */
+  @flags.boolean({ description: 'Indicates if the seed task should run.' })
+  public seed: boolean
+
+  /**
+   * This command loads the application, since we need the runtime
+   * to find the migration directories for a given connection
+   */
+  public static settings = {
+    loadApp: true,
+  }
+
+  /**
+   * Handle command
+   */
+  public async run(): Promise<void> {
+    const db = this.application.container.use('Adonis/Lucid/Database')
+    this.connection = this.connection || db.primaryConnectionName
+
+    const continueMigrations =
+      !this.application.inProduction || this.force || (await this.takeProductionConstent())
+
+    /**
+     * Prompt cancelled or rejected and hence do not continue
+     */
+    if (!continueMigrations) {
+      return
+    }
+
+    const connection = db.getRawConnection(this.connection)
+
+    /**
+     * Ensure the define connection name does exists in the
+     * config file
+     */
+    if (!connection) {
+      this.printNotAValidConnection(this.connection)
+      this.exitCode = 1
+      return
+    }
+
+    await this.runDbWipe()
+    await this.runMigrationRun()
+
+    if (this.seed) {
+      await this.runSeeders()
+    }
+
+    /**
+     * Close the connection after the migrations since we gave
+     * the order to not close after previous Migrator operations
+     */
+    db.manager.closeAll(true)
+  }
+
+  /**
+   * Run the db:wipe command
+   */
+  public async runDbWipe(): Promise<void> {
+    const resetCmd = new DbWipe(this.application, this.kernel)
+    resetCmd.connection = this.connection
+    resetCmd.force = true
+
+    await resetCmd.run()
+  }
+
+  /**
+   * Run the migration:run command
+   */
+  public async runMigrationRun(): Promise<void> {
+    const migrateRunCmd = new Run(this.application, this.kernel)
+    migrateRunCmd.connection = this.connection
+    migrateRunCmd.force = true
+    migrateRunCmd.dryRun = this.dryRun
+    migrateRunCmd.shouldCloseConnectionAfterMigrations = false
+
+    await migrateRunCmd.run()
+  }
+
+  /**
+   * Run the seeders
+   */
+  public async runSeeders(): Promise<void> {
+    const seedCmd = new DbSeed(this.application, this.kernel)
+    seedCmd.connection = this.connection
+
+    await seedCmd.run()
+  }
+}

--- a/commands/Migration/Fresh.ts
+++ b/commands/Migration/Fresh.ts
@@ -19,9 +19,9 @@ export default class Refresh extends MigrationsBase {
   public connection: string
 
   /**
-   * Force run migrations in production
+   * Force command execution in production
    */
-  @flags.boolean({ description: 'Explicitly force to run migrations in production' })
+  @flags.boolean({ description: 'Explicitly force command to run in production' })
   public force: boolean
 
   /**

--- a/commands/Migration/Refresh.ts
+++ b/commands/Migration/Refresh.ts
@@ -27,7 +27,7 @@ export default class Refresh extends MigrationsBase {
   /**
    * Perform dry run
    */
-  @flags.boolean({ description: 'Print SQL queries, instead of running the migrations' })
+  @flags.boolean({ description: 'Only print SQL queries instead of executing them' })
   public dryRun: boolean
 
   /**

--- a/commands/Migration/Refresh.ts
+++ b/commands/Migration/Refresh.ts
@@ -19,9 +19,9 @@ export default class Refresh extends MigrationsBase {
   public connection: string
 
   /**
-   * Force run migrations in production
+   * Force command execution in production
    */
-  @flags.boolean({ description: 'Explicitly force to run migrations in production' })
+  @flags.boolean({ description: 'Explicitly force command to run in production' })
   public force: boolean
 
   /**

--- a/commands/Migration/Refresh.ts
+++ b/commands/Migration/Refresh.ts
@@ -1,0 +1,125 @@
+import { flags } from '@adonisjs/core/build/standalone'
+import DbSeed from '../DbSeed'
+import MigrationsBase from './Base'
+import Reset from './Reset'
+import Run from './Run'
+
+/**
+ * This command reset the database by rolling back to batch 0 and then
+ * re-run all migrations.
+ */
+export default class Refresh extends MigrationsBase {
+  public static commandName = 'migration:refresh'
+  public static description = 'Reset and re-run all migrations.'
+
+  /**
+   * Custom connection for running migrations.
+   */
+  @flags.string({ description: 'Define a custom database connection', alias: 'c' })
+  public connection: string
+
+  /**
+   * Force run migrations in production
+   */
+  @flags.boolean({ description: 'Explicitly force to run migrations in production' })
+  public force: boolean
+
+  /**
+   * Perform dry run
+   */
+  @flags.boolean({ description: 'Print SQL queries, instead of running the migrations' })
+  public dryRun: boolean
+
+  /**
+   * Run seeders
+   */
+  @flags.boolean({ description: 'Indicates if the seed task should run.' })
+  public seed: boolean
+
+  /**
+   * This command loads the application, since we need the runtime
+   * to find the migration directories for a given connection
+   */
+  public static settings = {
+    loadApp: true,
+  }
+
+  /**
+   * Handle command
+   */
+  public async run(): Promise<void> {
+    const db = this.application.container.use('Adonis/Lucid/Database')
+    this.connection = this.connection || db.primaryConnectionName
+
+    const continueMigrations =
+      !this.application.inProduction || this.force || (await this.takeProductionConstent())
+
+    /**
+     * Prompt cancelled or rejected and hence do not continue
+     */
+    if (!continueMigrations) {
+      return
+    }
+
+    const connection = db.getRawConnection(this.connection)
+
+    /**
+     * Ensure the define connection name does exists in the
+     * config file
+     */
+    if (!connection) {
+      this.printNotAValidConnection(this.connection)
+      this.exitCode = 1
+      return
+    }
+
+    await this.runDbReset()
+    await this.runMigrationRun()
+
+    if (this.seed) {
+      await this.runSeeders()
+    }
+
+    /**
+     * Close the connection after the migrations since we gave
+     * the order to not close after previous Migrator operations
+     */
+    db.manager.closeAll(true)
+  }
+
+  /**
+   * Run the migration:reset command
+   */
+  public async runDbReset(): Promise<void> {
+    const resetCmd = new Reset(this.application, this.kernel)
+    resetCmd.connection = this.connection
+    resetCmd.force = true
+    resetCmd.dryRun = this.dryRun
+    resetCmd.shouldCloseConnectionAfterMigrations = false
+
+    await resetCmd.run()
+  }
+
+  /**
+   * Run the migration:run command
+   */
+  public async runMigrationRun(): Promise<void> {
+    const migrateRunCmd = new Run(this.application, this.kernel)
+    migrateRunCmd.connection = this.connection
+    migrateRunCmd.force = true
+    migrateRunCmd.dryRun = this.dryRun
+    migrateRunCmd.shouldCloseConnectionAfterMigrations = false
+
+    await migrateRunCmd.run()
+  }
+
+  /**
+   * Run the seeders
+   */
+  public async runSeeders(): Promise<void> {
+    const seedCmd = new DbSeed(this.application, this.kernel)
+    seedCmd.connection = this.connection
+
+    await seedCmd.run()
+  }
+}

--- a/commands/Migration/Reset.ts
+++ b/commands/Migration/Reset.ts
@@ -15,9 +15,9 @@ export default class Reset extends MigrationsBase {
   public connection: string
 
   /**
-   * Force run migrations in production
+   * Force command execution in production
    */
-  @flags.boolean({ description: 'Explicitly force to run migrations in production' })
+  @flags.boolean({ description: 'Explicitly force command to run in production' })
   public force: boolean
 
   /**

--- a/commands/Migration/Reset.ts
+++ b/commands/Migration/Reset.ts
@@ -1,0 +1,79 @@
+import { flags } from '@adonisjs/core/build/standalone'
+import MigrationsBase from './Base'
+
+/**
+ * This command reset the database by rolling back to batch 0
+ */
+export default class Reset extends MigrationsBase {
+  public static commandName = 'migration:reset'
+  public static description = 'Reset migrations to initial state'
+
+  /**
+   * Custom connection for running migrations.
+   */
+  @flags.string({ description: 'Define a custom database connection', alias: 'c' })
+  public connection: string
+
+  /**
+   * Force run migrations in production
+   */
+  @flags.boolean({ description: 'Explicitly force to run migrations in production' })
+  public force: boolean
+
+  /**
+   * Perform dry run
+   */
+  @flags.boolean({ description: 'Print SQL queries, instead of running the migrations' })
+  public dryRun: boolean
+
+  /**
+   * This command loads the application, since we need the runtime
+   * to find the migration directories for a given connection
+   */
+  public static settings = {
+    loadApp: true,
+  }
+
+  /**
+   * Handle command
+   */
+  public async run(): Promise<void> {
+    const db = this.application.container.use('Adonis/Lucid/Database')
+    this.connection = this.connection || db.primaryConnectionName
+
+    const continueMigrations =
+      !this.application.inProduction || this.force || (await this.takeProductionConstent())
+
+    /**
+     * Prompt cancelled or rejected and hence do not continue
+     */
+    if (!continueMigrations) {
+      return
+    }
+
+    const connection = db.getRawConnection(this.connection)
+
+    /**
+     * Ensure the define connection name does exists in the
+     * config file
+     */
+    if (!connection) {
+      this.printNotAValidConnection(this.connection)
+      this.exitCode = 1
+      return
+    }
+
+    /**
+     * New down migrator
+     */
+    const { Migrator } = await import('../../src/Migrator')
+    const migrator = new Migrator(db, this.application, {
+      direction: 'down',
+      batch: 0,
+      connectionName: this.connection,
+      dryRun: this.dryRun,
+    })
+
+    await this.runMigrations(migrator, this.connection)
+  }
+}

--- a/commands/Migration/Reset.ts
+++ b/commands/Migration/Reset.ts
@@ -23,7 +23,7 @@ export default class Reset extends MigrationsBase {
   /**
    * Perform dry run
    */
-  @flags.boolean({ description: 'Print SQL queries, instead of running the migrations' })
+  @flags.boolean({ description: 'Only print SQL queries instead of executing them' })
   public dryRun: boolean
 
   /**

--- a/commands/index.ts
+++ b/commands/index.ts
@@ -15,4 +15,5 @@ export default [
   '@adonisjs/lucid/build/commands/Migration/Run',
   '@adonisjs/lucid/build/commands/Migration/Rollback',
   '@adonisjs/lucid/build/commands/Migration/Status',
+  '@adonisjs/lucid/build/commands/Migration/Reset',
 ]

--- a/commands/index.ts
+++ b/commands/index.ts
@@ -18,4 +18,5 @@ export default [
   '@adonisjs/lucid/build/commands/Migration/Status',
   '@adonisjs/lucid/build/commands/Migration/Reset',
   '@adonisjs/lucid/build/commands/Migration/Refresh',
+  '@adonisjs/lucid/build/commands/Migration/Fresh',
 ]

--- a/commands/index.ts
+++ b/commands/index.ts
@@ -16,4 +16,5 @@ export default [
   '@adonisjs/lucid/build/commands/Migration/Rollback',
   '@adonisjs/lucid/build/commands/Migration/Status',
   '@adonisjs/lucid/build/commands/Migration/Reset',
+  '@adonisjs/lucid/build/commands/Migration/Refresh',
 ]

--- a/commands/index.ts
+++ b/commands/index.ts
@@ -12,6 +12,7 @@ export default [
   '@adonisjs/lucid/build/commands/MakeModel',
   '@adonisjs/lucid/build/commands/MakeMigration',
   '@adonisjs/lucid/build/commands/MakeSeeder',
+  '@adonisjs/lucid/build/commands/DbWipe',
   '@adonisjs/lucid/build/commands/Migration/Run',
   '@adonisjs/lucid/build/commands/Migration/Rollback',
   '@adonisjs/lucid/build/commands/Migration/Status',

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:docker": "npm run test:sqlite && npm run test:mysql && npm run test:mysql_legacy && npm run test:pg && npm run test:mssql",
     "test": "docker-compose -f docker-compose.yml -f docker-compose-test.yml build && docker-compose -f docker-compose.yml -f docker-compose-test.yml run --rm test",
     "lint": "eslint . --ext=.ts",
-    "clean": "del build",
+    "clean": "del-cli build",
     "compile": "npm run lint && npm run clean && tsc && npm run copyfiles",
     "copyfiles": "copyfiles \"templates/**/*.txt\" \"instructions.md\" build",
     "build": "npm run compile",

--- a/src/Dialects/Pg.ts
+++ b/src/Dialects/Pg.ts
@@ -57,6 +57,8 @@ export class PgDialect implements DialectContract {
    */
   public async dropAllTables(schemas: string[]) {
     const tables = await this.getAllTables(schemas)
+    if (!tables.length) return
+
     await this.client.rawQuery(`DROP table ${tables.join(',')} CASCADE;`)
   }
 

--- a/src/Dialects/Redshift.ts
+++ b/src/Dialects/Redshift.ts
@@ -61,6 +61,8 @@ export class RedshiftDialect implements DialectContract {
    */
   public async dropAllTables(schemas: string[]) {
     const tables = await this.getAllTables(schemas)
+    if (!tables.length) return
+
     await this.client.rawQuery(`DROP table ${tables.join(',')} CASCADE;`)
   }
 

--- a/src/QueryClient/index.ts
+++ b/src/QueryClient/index.ts
@@ -127,6 +127,13 @@ export class QueryClient implements QueryClientContract {
   }
 
   /**
+   * Drop all tables inside database
+   */
+  public async dropAllTables(schemas?: string[]): Promise<void> {
+    return this.dialect.dropAllTables(schemas || ['public'])
+  }
+
+  /**
    * Returns an instance of a transaction. Each transaction will
    * query and hold a single connection for all queries.
    */

--- a/src/TransactionClient/index.ts
+++ b/src/TransactionClient/index.ts
@@ -122,6 +122,13 @@ export class TransactionClient extends EventEmitter implements TransactionClient
   }
 
   /**
+   * Drop all tables inside database
+   */
+  public async dropAllTables(schemas?: string[]): Promise<void> {
+    return this.dialect.dropAllTables(schemas || ['public'])
+  }
+
+  /**
    * Get a new query builder instance
    */
   public knexQuery(): Knex.QueryBuilder {

--- a/templates/database.txt
+++ b/templates/database.txt
@@ -42,6 +42,11 @@ const databaseConfig: DatabaseConfig = {
       connection: {
         filename: Application.tmpPath('db.sqlite3'),
       },
+      pool: {
+        afterCreate: (conn, cb) => {
+          conn.run('PRAGMA foreign_keys=true', cb)
+        }
+      },
       migrations: {
         naturalSort: true,
       },

--- a/test/commands/migrate.spec.ts
+++ b/test/commands/migrate.spec.ts
@@ -69,7 +69,7 @@ test.group('Migrate', (group) => {
 
     assert.lengthOf(migrated, 1)
     assert.isTrue(hasUsersTable)
-    assert.equal(migrated[0].name, 'database/migrations/users')
+    assert.equal(migrated[0].name.replaceAll('\\', '/'), 'database/migrations/users')
     assert.equal(migrated[0].batch, 1)
   })
 

--- a/test/commands/migrate.spec.ts
+++ b/test/commands/migrate.spec.ts
@@ -18,8 +18,9 @@ import { ApplicationContract } from '@ioc:Adonis/Core/Application'
 import { Migrator } from '../../src/Migrator'
 import Migrate from '../../commands/Migration/Run'
 import Rollback from '../../commands/Migration/Rollback'
-import { fs, setup, cleanup, getDb, setupApplication } from '../../test-helpers'
 import Reset from '../../commands/Migration/Reset'
+import Refresh from '../../commands/Migration/Refresh'
+import { fs, setup, cleanup, getDb, setupApplication } from '../../test-helpers'
 
 let db: ReturnType<typeof getDb>
 let app: ApplicationContract
@@ -227,7 +228,7 @@ test.group('Migrate', (group) => {
     delete process.env.NODE_ENV
   })
 
-  test.only('migration:reset should rollback to batch 0', async (assert) => {
+  test('migration:reset should rollback to batch 0', async (assert) => {
     await fs.add(
       'database/migrations/users.ts',
       `
@@ -281,5 +282,123 @@ test.group('Migrate', (group) => {
     assert.lengthOf(migrated, 0)
     assert.isFalse(hasUsersTable)
     assert.isFalse(hasAccountsTable)
+  })
+
+  test('migration:refresh should rollback to batch 0 then run all migrations', async (assert) => {
+    await fs.add(
+      'database/migrations/users.ts',
+      `
+        import { Schema } from '../../../../src/Schema'
+        module.exports = class User extends Schema {
+          public async up () {
+            this.schema.createTable('schema_users', (table) => {
+              table.increments()
+            })
+          }
+
+          public async down() {
+            this.schema.dropTable('schema_users')
+          }
+        }
+      `
+    )
+
+    await fs.add(
+      'database/migrations/posts.ts',
+      `
+        import { Schema } from '../../../../src/Schema'
+        module.exports = class Account extends Schema {
+          public async up () {
+            this.schema.createTable('schema_accounts', (table) => {
+              table.increments()
+            })
+          }
+
+          public async down() {
+            this.schema.dropTable('schema_accounts')
+          }
+        }
+      `
+    )
+
+    const migrate = new Migrate(app, new Kernel(app))
+    await migrate.run()
+
+    db = getDb(app)
+
+    const refresh = new Refresh(app, new Kernel(app))
+    await refresh.run()
+
+    db = getDb(app)
+
+    let migrated = await db.connection().from('adonis_schema').select('*')
+    let hasUsersTable = await db.connection().schema.hasTable('schema_users')
+    let hasAccountsTable = await db.connection().schema.hasTable('schema_accounts')
+
+    assert.lengthOf(migrated, 2)
+    assert.isTrue(hasUsersTable)
+    assert.isTrue(hasAccountsTable)
+  })
+
+  test('migration:refresh --seed should rollback to batch 0, run all migrations then run seeders', async (assert) => {
+    await fs.add(
+      'database/seeders/user.ts',
+      `export default class UserSeeder {
+				public async run () {
+          console.log('lets go')
+					process.env.EXEC_USER_SEEDER = 'true'
+				}
+			}`
+    )
+
+    await fs.add(
+      'database/migrations/users.ts',
+      `
+        import { Schema } from '../../../../src/Schema'
+        module.exports = class User extends Schema {
+          public async up () {
+            this.schema.createTable('schema_users', (table) => {
+              table.increments()
+            })
+          }
+
+          public async down() {
+            this.schema.dropTable('schema_users')
+          }
+        }
+      `
+    )
+
+    await fs.add(
+      'database/migrations/posts.ts',
+      `
+        import { Schema } from '../../../../src/Schema'
+        module.exports = class Account extends Schema {
+          public async up () {
+            this.schema.createTable('schema_accounts', (table) => {
+              table.increments()
+            })
+          }
+
+          public async down() {
+            this.schema.dropTable('schema_accounts')
+          }
+        }
+      `
+    )
+
+    const migrate = new Migrate(app, new Kernel(app))
+    await migrate.run()
+
+    db = getDb(app)
+
+    const reset = new Refresh(app, new Kernel(app))
+    reset.seed = true
+    await reset.run()
+
+    db = getDb(app)
+
+    assert.equal(process.env.EXEC_USER_SEEDER, 'true')
+    delete process.env.EXEC_USER_SEEDER
   })
 })

--- a/test/commands/migrate.spec.ts
+++ b/test/commands/migrate.spec.ts
@@ -345,7 +345,6 @@ test.group('Migrate', (group) => {
       'database/seeders/user.ts',
       `export default class UserSeeder {
 				public async run () {
-          console.log('lets go')
 					process.env.EXEC_USER_SEEDER = 'true'
 				}
 			}`

--- a/test/commands/wipe-fresh.spec.ts
+++ b/test/commands/wipe-fresh.spec.ts
@@ -8,6 +8,7 @@ import Migrate from '../../commands/Migration/Run'
 import { fs, setup, cleanup, getDb, setupApplication } from '../../test-helpers'
 import { Migrator } from '../../src/Migrator'
 import DbWipe from '../../commands/DbWipe'
+import Fresh from '../../commands/Migration/Fresh'
 
 let app: ApplicationContract
 let db: ReturnType<typeof getDb>
@@ -54,5 +55,80 @@ test.group('db:wipe and migrate:fresh', (group) => {
     db = getDb(app)
     const tables = await db.connection().getAllTables(['public'])
     assert.lengthOf(tables, 0)
+  })
+
+  test('migration:fresh should drop all tables and run migrations', async (assert) => {
+    await fs.add(
+      'database/migrations/users.ts',
+      `
+      import { Schema } from '../../../../src/Schema'
+      module.exports = class User extends Schema {
+        public async up () {
+          this.schema.createTable('schema_users', (table) => {
+            table.increments()
+          })
+        }
+      }
+    `
+    )
+
+    const kernel = new Kernel(app)
+    const migrate = new Migrate(app, kernel)
+    await migrate.run()
+
+    db = getDb(app)
+
+    const fresh = new Fresh(app, kernel)
+    await fresh.run()
+
+    db = getDb(app)
+
+    const migrated = await db.connection().from('adonis_schema').select('*')
+    const hasUsersTable = await db.connection().schema.hasTable('schema_users')
+
+    assert.lengthOf(migrated, 1)
+    assert.isTrue(hasUsersTable)
+    assert.equal(migrated[0].name.replaceAll('\\', '/'), 'database/migrations/users')
+    assert.equal(migrated[0].batch, 1)
+  })
+
+  test('migration:fresh --seed should run seeders', async (assert) => {
+    await fs.add(
+      'database/seeders/user.ts',
+      `export default class UserSeeder {
+				public async run () {
+					process.env.EXEC_USER_SEEDER = 'true'
+				}
+			}`
+    )
+
+    await fs.add(
+      'database/migrations/users.ts',
+      `
+      import { Schema } from '../../../../src/Schema'
+      module.exports = class User extends Schema {
+        public async up () {
+          this.schema.createTable('schema_users', (table) => {
+            table.increments()
+          })
+        }
+      }
+    `
+    )
+
+    const kernel = new Kernel(app)
+    const migrate = new Migrate(app, kernel)
+    await migrate.run()
+
+    db = getDb(app)
+
+    const fresh = new Fresh(app, kernel)
+    fresh.seed = true
+    await fresh.run()
+
+    db = getDb(app)
+
+    assert.equal(process.env.EXEC_USER_SEEDER, 'true')
+    delete process.env.EXEC_USER_SEEDER
   })
 })

--- a/test/commands/wipe-fresh.spec.ts
+++ b/test/commands/wipe-fresh.spec.ts
@@ -1,0 +1,58 @@
+/// <reference path="../../adonis-typings/index.ts" />
+
+import test from 'japa'
+import 'reflect-metadata'
+import { Kernel } from '@adonisjs/core/build/standalone'
+import { ApplicationContract } from '@ioc:Adonis/Core/Application'
+import Migrate from '../../commands/Migration/Run'
+import { fs, setup, cleanup, getDb, setupApplication } from '../../test-helpers'
+import { Migrator } from '../../src/Migrator'
+import DbWipe from '../../commands/DbWipe'
+
+let app: ApplicationContract
+let db: ReturnType<typeof getDb>
+
+test.group('db:wipe and migrate:fresh', (group) => {
+  group.beforeEach(async () => {
+    app = await setupApplication()
+    db = getDb(app)
+    app.container.bind('Adonis/Lucid/Database', () => db)
+    app.container.bind('Adonis/Lucid/Migrator', () => Migrator)
+    await setup()
+  })
+
+  group.afterEach(async () => {
+    await cleanup()
+    await cleanup(['adonis_schema', 'schema_users'])
+    await fs.cleanup()
+  })
+
+  test('db:wipe should drop all tables', async (assert) => {
+    await fs.add(
+      'database/migrations/users.ts',
+      `
+      import { Schema } from '../../../../src/Schema'
+      module.exports = class User extends Schema {
+        public async up () {
+          this.schema.createTable('schema_users', (table) => {
+            table.increments()
+          })
+        }
+      }
+    `
+    )
+
+    const kernel = new Kernel(app)
+    const migrate = new Migrate(app, kernel)
+    await migrate.run()
+
+    db = getDb(app)
+
+    const wipe = new DbWipe(app, kernel)
+    await wipe.run()
+
+    db = getDb(app)
+    const tables = await db.connection().getAllTables(['public'])
+    assert.lengthOf(tables, 0)
+  })
+})

--- a/test/database/drop-tables.spec.ts
+++ b/test/database/drop-tables.spec.ts
@@ -62,4 +62,19 @@ test.group('Query client | drop tables', (group) => {
     assert.isFalse(await connection.client!.schema.hasTable('profiles'))
     assert.isFalse(await connection.client!.schema.hasTable('identities'))
   })
+
+  test('dropAllTables should not throw when there are no tables', async (assert) => {
+    await fs.fsExtra.ensureDir(join(fs.basePath, 'temp'))
+    const connection = new Connection('primary', getConfig(), app.logger)
+    connection.connect()
+
+    const client = new QueryClient('dual', connection, app.container.use('Adonis/Core/Event'))
+
+    try {
+      await client.dropAllTables()
+      await client.dropAllTables()
+    } catch (err) {
+      assert.fail(err)
+    }
+  })
 })


### PR DESCRIPTION
## Proposed changes
Hey ! 👋 
This PR add the following commands :
```
node ace migration:refresh
node ace migration:reset
``` 

`node ace migration:reset` is basically an alias for node ace migration:rollback --batch 0. 
`node ace migration:refresh` calls migration:reset, migration:run, and db:seed ( if asked ).

`node ace migration:refresh` is a command that is absolutely missing in Adonis. I often find myself going into TablePlus, deleting my DB, and restarting my migrations + seeders. `node ace migration:refresh --seed` is a real time-saver in my opinion.
Also these two commands are very often used by Laravel developers, and they make up a big part of our community !

In a near future I will propose two new commands `db:wipe` and `migration:fresh` which will also have the same behavior as on Laravel : completely remove the DB (truncate, no rollback of migrations). That said it's a bit more complicated because I had a quick look and Knex doesn't seem to offer an abstraction for truncating, so we'll have to write our own abstraction or find a small plugin. ( If you have any recommendations please let me know )

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/lucid/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)

## Further comments

I don't expect this PR to be merged right away, I'm willing to work on it again because one point seems quite problematic to me: 

I would have liked to use `kernel.exec` to execute the commands, it would have been much cleaner, but the problem is that the MigrationBase class closes the connection to the database at the end of each command.

So I had to add a `shouldCloseConnectionAfterMigrations` property, which I set to false when I need to run several commands in the same process.
I'm really not sure if this is the best solution. If you have something better to suggest, don't hesitate and I'll make the necessary changes!