### PR TITLE
Small improvements for PR 764

### DIFF
--- a/adonis-typings/database.ts
+++ b/adonis-typings/database.ts
@@ -57,17 +57,21 @@ declare module '@ioc:Adonis/Lucid/Database' {
       | 'better-sqlite3'
     readonly version?: string
     readonly supportsAdvisoryLocks: boolean
+    readonly supportsViews: boolean
+    readonly supportsTypes: boolean
     readonly dateTimeFormat: string
 
     getAllTables(schemas?: string[]): Promise<string[]>
-    getAllViews(schemas?: string[]): Promise<string[]>
-    getAllTypes(schemas?: string[]): Promise<string[]>
-
     dropAllTables(schemas?: string[]): Promise<void>
+
+    getAllViews(schemas?: string[]): Promise<string[]>
     dropAllViews(schemas?: string[]): Promise<void>
+
+    getAllTypes(schemas?: string[]): Promise<string[]>
     dropAllTypes(schemas?: string[]): Promise<void>
 
     truncate(table: string, cascade?: boolean): Promise<void>
+
     getAdvisoryLock(key: string | number, timeout?: number): Promise<boolean>
     releaseAdvisoryLock(key: string | number): Promise<boolean>
   }

--- a/commands/DbWipe.ts
+++ b/commands/DbWipe.ts
@@ -1,3 +1,12 @@
+/*
+ * @adonisjs/lucid
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 import { BaseCommand, flags } from '@adonisjs/core/build/standalone'
 
 export default class DbWipe extends BaseCommand {
@@ -14,13 +23,13 @@ export default class DbWipe extends BaseCommand {
   /**
    * Drop all views in database
    */
-  @flags.boolean({ description: 'Also drop all views in database' })
+  @flags.boolean({ description: 'Drop all views' })
   public dropViews: boolean
 
   /**
    * Drop all types in database
    */
-  @flags.boolean({ description: 'Also drop all types in database ( Postgres only )' })
+  @flags.boolean({ description: 'Drop all custom types ( Postgres only )' })
   public dropTypes: boolean
 
   /**
@@ -60,17 +69,31 @@ export default class DbWipe extends BaseCommand {
       return
     }
 
+    /**
+     * Drop views
+     */
     if (this.dropViews) {
-      await db.connection().dropAllViews()
-      this.logger.info('All views dropped successfully')
+      if (connection.dialect.supportsViews) {
+        await connection.dropAllViews()
+        this.logger.success('Dropped views successfully')
+      } else {
+        this.logger.warning(`Dropping views is not supported by "${connection.dialect.name}"`)
+      }
     }
 
+    /**
+     * Drop all tables
+     */
     await db.connection().dropAllTables()
-    this.logger.info('All tables have been dropped successfully')
+    this.logger.success('Dropped tables successfully')
 
     if (this.dropTypes) {
-      await db.connection().dropAllTypes()
-      this.logger.info('All types dropped successfully')
+      if (connection.dialect.supportsTypes) {
+        await db.connection().dropAllTypes()
+        this.logger.success('Dropped custom types successfully')
+      } else {
+        this.logger.warning(`Dropping types is not supported by "${connection.dialect.name}"`)
+      }
     }
   }
 

--- a/commands/DbWipe.ts
+++ b/commands/DbWipe.ts
@@ -84,12 +84,12 @@ export default class DbWipe extends BaseCommand {
     /**
      * Drop all tables
      */
-    await db.connection().dropAllTables()
+    await connection.dropAllTables()
     this.logger.success('Dropped tables successfully')
 
     if (this.dropTypes) {
       if (connection.dialect.supportsTypes) {
-        await db.connection().dropAllTypes()
+        await connection.dropAllTypes()
         this.logger.success('Dropped custom types successfully')
       } else {
         this.logger.warning(`Dropping types is not supported by "${connection.dialect.name}"`)

--- a/commands/Migration/Base.ts
+++ b/commands/Migration/Base.ts
@@ -11,8 +11,8 @@ import prettyHrTime from 'pretty-hrtime'
 import { BaseCommand } from '@adonisjs/core/build/standalone'
 import { MigratedFileNode, MigratorContract } from '@ioc:Adonis/Lucid/Migrator'
 
-import { prettyPrint } from '../../src/Helpers/prettyPrint'
 import { getDDLMethod } from '../../src/utils'
+import { prettyPrint } from '../../src/Helpers/prettyPrint'
 
 /**
  * Base class to execute migrations and print logs

--- a/commands/Migration/Fresh.ts
+++ b/commands/Migration/Fresh.ts
@@ -1,8 +1,18 @@
+/*
+ * @adonisjs/lucid
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 import { flags } from '@adonisjs/core/build/standalone'
+
+import Run from './Run'
 import DbSeed from '../DbSeed'
 import DbWipe from '../DbWipe'
 import MigrationsBase from './Base'
-import Run from './Run'
 
 /**
  * This command reset the database by rolling back to batch 0 and then
@@ -33,19 +43,19 @@ export default class Refresh extends MigrationsBase {
   /**
    * Run seeders
    */
-  @flags.boolean({ description: 'Indicates if the seed task should run.' })
+  @flags.boolean({ description: 'Run seeders' })
   public seed: boolean
 
   /**
    * Drop all views in database
    */
-  @flags.boolean({ description: 'Also drop all views in database' })
+  @flags.boolean({ description: 'Drop all views' })
   public dropViews: boolean
 
   /**
    * Drop all types in database
    */
-  @flags.boolean({ description: 'Also drop all types in database ( Postgres only )' })
+  @flags.boolean({ description: 'Drop all custom types ( Postgres only )' })
   public dropTypes: boolean
 
   /**

--- a/commands/Migration/Refresh.ts
+++ b/commands/Migration/Refresh.ts
@@ -1,8 +1,18 @@
+/*
+ * @adonisjs/lucid
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 import { flags } from '@adonisjs/core/build/standalone'
+
+import Run from './Run'
+import Reset from './Reset'
 import DbSeed from '../DbSeed'
 import MigrationsBase from './Base'
-import Reset from './Reset'
-import Run from './Run'
 
 /**
  * This command reset the database by rolling back to batch 0 and then
@@ -33,7 +43,7 @@ export default class Refresh extends MigrationsBase {
   /**
    * Run seeders
    */
-  @flags.boolean({ description: 'Indicates if the seed task should run.' })
+  @flags.boolean({ description: 'Run seeders' })
   public seed: boolean
 
   /**

--- a/commands/Migration/Reset.ts
+++ b/commands/Migration/Reset.ts
@@ -1,4 +1,14 @@
+/*
+ * @adonisjs/lucid
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 import { flags } from '@adonisjs/core/build/standalone'
+
 import MigrationsBase from './Base'
 
 /**

--- a/commands/Migration/Run.ts
+++ b/commands/Migration/Run.ts
@@ -8,6 +8,7 @@
  */
 
 import { flags } from '@adonisjs/core/build/standalone'
+
 import MigrationsBase from './Base'
 
 /**

--- a/commands/Migration/Status.ts
+++ b/commands/Migration/Status.ts
@@ -9,6 +9,7 @@
 
 import { flags } from '@adonisjs/core/build/standalone'
 import { MigrationListNode } from '@ioc:Adonis/Lucid/Migrator'
+
 import MigrationsBase from './Base'
 
 /**

--- a/src/Dialects/Mssql.ts
+++ b/src/Dialects/Mssql.ts
@@ -15,6 +15,8 @@ import { DialectContract, QueryClientContract } from '@ioc:Adonis/Lucid/Database
 export class MssqlDialect implements DialectContract {
   public readonly name = 'mssql'
   public readonly supportsAdvisoryLocks = false
+  public readonly supportsViews = false
+  public readonly supportsTypes = false
 
   /**
    * Reference to the database version. Knex.js fetches the version after

--- a/src/Dialects/Mysql.ts
+++ b/src/Dialects/Mysql.ts
@@ -15,6 +15,8 @@ import { DialectContract, QueryClientContract } from '@ioc:Adonis/Lucid/Database
 export class MysqlDialect implements DialectContract {
   public readonly name = 'mysql'
   public readonly supportsAdvisoryLocks = true
+  public readonly supportsViews = true
+  public readonly supportsTypes = false
 
   /**
    * Reference to the database version. Knex.js fetches the version after

--- a/src/Dialects/Oracle.ts
+++ b/src/Dialects/Oracle.ts
@@ -14,6 +14,8 @@ import { DialectContract, QueryClientContract } from '@ioc:Adonis/Lucid/Database
 export class OracleDialect implements DialectContract {
   public readonly name = 'oracledb'
   public readonly supportsAdvisoryLocks = false
+  public readonly supportsViews = false
+  public readonly supportsTypes = false
 
   /**
    * Reference to the database version. Knex.js fetches the version after

--- a/src/Dialects/Pg.ts
+++ b/src/Dialects/Pg.ts
@@ -14,6 +14,8 @@ import { DialectContract, QueryClientContract } from '@ioc:Adonis/Lucid/Database
 export class PgDialect implements DialectContract {
   public readonly name = 'postgres'
   public readonly supportsAdvisoryLocks = true
+  public readonly supportsViews = true
+  public readonly supportsTypes = true
 
   /**
    * Reference to the database version. Knex.js fetches the version after

--- a/src/Dialects/Redshift.ts
+++ b/src/Dialects/Redshift.ts
@@ -14,6 +14,8 @@ import { DialectContract, QueryClientContract } from '@ioc:Adonis/Lucid/Database
 export class RedshiftDialect implements DialectContract {
   public readonly name = 'redshift'
   public readonly supportsAdvisoryLocks = false
+  public readonly supportsViews = true
+  public readonly supportsTypes = true
 
   /**
    * Reference to the database version. Knex.js fetches the version after

--- a/src/Dialects/SqliteBase.ts
+++ b/src/Dialects/SqliteBase.ts
@@ -14,6 +14,8 @@ import { DialectContract, QueryClientContract } from '@ioc:Adonis/Lucid/Database
 export abstract class BaseSqliteDialect implements DialectContract {
   public abstract readonly name: 'sqlite3' | 'better-sqlite3'
   public readonly supportsAdvisoryLocks = false
+  public readonly supportsViews = true
+  public readonly supportsTypes = false
 
   /**
    * Reference to the database version. Knex.js fetches the version after


### PR DESCRIPTION
- Added flags to know if the dialect has support for `views` and `types` or not.
- The commands will not attempt to drop views and types if not supported. Instead prints a warning.
- Changes to command help copy.
- Use a single instance of `connection` in `db:wipe` command. https://github.com/adonisjs/lucid/pull/802/files#diff-1a14967e29eb6d0558f9f78c400f487be6a5a392dfe21fefd066cdf000315e44L64-R77