### PR TITLE
Removed warn about knex returning() on unsupported clients

### DIFF
--- a/src/Database/QueryBuilder/Database.ts
+++ b/src/Database/QueryBuilder/Database.ts
@@ -22,6 +22,7 @@ import {
 import { Chainable } from './Chainable'
 import { QueryRunner } from '../../QueryRunner'
 import { SimplePaginator } from '../Paginator/SimplePaginator'
+import { isReturningAvailable } from '../../utils'
 
 /**
  * Wrapping the user function for a query callback and give them
@@ -140,7 +141,9 @@ export class DatabaseQueryBuilder extends Chainable implements DatabaseQueryBuil
       ? columns.map((column) => this.resolveKey(column))
       : this.resolveKey(columns)
 
-    this.knexQuery.returning(columns)
+    if (isReturningAvailable(this.client)) {
+      this.knexQuery.returning(columns)
+    }
     return this
   }
 

--- a/src/Database/QueryBuilder/Insert.ts
+++ b/src/Database/QueryBuilder/Insert.ts
@@ -22,6 +22,7 @@ import { RawQueryBuilder } from './Raw'
 import { QueryRunner } from '../../QueryRunner'
 import { RawBuilder } from '../StaticBuilder/Raw'
 import { ReferenceBuilder } from '../StaticBuilder/Reference'
+import { isReturningAvailable } from '../../utils'
 
 /**
  * Exposes the API for performing SQL inserts
@@ -120,7 +121,9 @@ export class InsertQueryBuilder extends Macroable implements InsertQueryBuilderC
    * Define returning columns for the insert query
    */
   public returning(column: any): any {
-    this.knexQuery.returning(column)
+    if (isReturningAvailable(this.client)) {
+      this.knexQuery.returning(column)
+    }
     return this
   }
 

--- a/src/Orm/BaseModel/index.ts
+++ b/src/Orm/BaseModel/index.ts
@@ -55,6 +55,7 @@ import {
   ensureRelation,
   managedTransaction,
   normalizeCherryPickObject,
+  isReturningAvailable,
 } from '../../utils'
 import { SnakeCaseNamingStrategy } from '../NamingStrategies/SnakeCase'
 import { LazyLoadAggregates } from '../Relations/AggregatesLoader/LazyLoad'
@@ -1955,7 +1956,9 @@ export class BaseModel implements LucidRow {
      */
     if (action === 'insert') {
       const insertQuery = client.insertQuery().table(modelConstructor.table)
-      insertQuery.returning(primaryKeyColumn)
+      if (isReturningAvailable(client)) {
+        insertQuery.returning(primaryKeyColumn)
+      }
       return insertQuery
     }
 

--- a/src/Orm/QueryBuilder/index.ts
+++ b/src/Orm/QueryBuilder/index.ts
@@ -30,7 +30,7 @@ import {
   TransactionClientContract,
 } from '@ioc:Adonis/Lucid/Database'
 
-import { isObject } from '../../utils'
+import { isObject, isReturningAvailable } from '../../utils'
 import { Preloader } from '../Preloader'
 import { ModelPaginator } from '../Paginator'
 import { QueryRunner } from '../../QueryRunner'
@@ -369,7 +369,9 @@ export class ModelQueryBuilder extends Chainable implements ModelQueryBuilderCon
       ? columns.map((column) => this.resolveKey(column))
       : this.resolveKey(columns)
 
-    this.knexQuery.returning(columns)
+    if (isReturningAvailable(this.client)) {
+      this.knexQuery.returning(columns)
+    }
     return this
   }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -267,7 +267,7 @@ export function sourceFiles(
 /**
  * Verify if current client supports Knex returning
  */
- export function isReturningAvailable(client: QueryClientContract): boolean {
+export function isReturningAvailable(client: QueryClientContract): boolean {
   const returningClients = ['pg', 'mssql', 'oracledb']
 
   return returningClients.includes(client.connectionName)

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -263,3 +263,13 @@ export function sourceFiles(
     }
   })
 }
+
+/**
+ * Verify if current client supports Knex returning
+ */
+ export function isReturningAvailable(client: QueryClientContract): boolean {
+  const returningClients = ['pg', 'mssql', 'oracledb']
+
+  return returningClients.includes(client.connectionName)
+}
+


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

I was experiencing a warn on console saying that .returning() is not supported so i made this PR to fix it.

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/lucid/blob/master/.github/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)