### PR TITLE
fix: upgrade faker to v6 

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "homepage": "https://github.com/adonisjs/lucid#readme",
   "dependencies": {
-    "@faker-js/faker": "^5.5.3",
+    "@faker-js/faker": "^6.0.0",
     "@poppinss/hooks": "^5.0.2",
     "@poppinss/utils": "^4.0.2",
     "fast-deep-equal": "^3.1.3",


### PR DESCRIPTION
Closes #814 

As mentionned in this issue, typings wasn't working since migration to the new Faker package ( #791 )

We were using version 5.5.3 of Faker, and to get the good typings with this version, we had to follow this : https://github.com/faker-js/faker#typescript-support

So I just upgraded to version 6.0, which has no breaking changes ( https://fakerjs.dev/migration-guide-v5/ ), and now typings works properly 




