### PR TITLE
Fix pg drop functions

### DIFF
--- a/src/Dialects/Pg.ts
+++ b/src/Dialects/Pg.ts
@@ -89,7 +89,7 @@ export class PgDialect implements DialectContract {
     const tables = await this.getAllTables(schemas)
     if (!tables.length) return
 
-    await this.client.rawQuery('DROP TABLE IF EXISTS "' + tables.join('", "') + '" CASCADE;')
+    await this.client.rawQuery(`DROP TABLE IF EXISTS "${tables.join('", "')}" CASCADE;`)
   }
 
   /**
@@ -99,7 +99,7 @@ export class PgDialect implements DialectContract {
     const views = await this.getAllViews(schemas)
     if (!views.length) return
 
-    await this.client.rawQuery('DROP VIEW IF EXISTS "' + views.join('", "') + '" CASCADE;')
+    await this.client.rawQuery(`DROP VIEW IF EXISTS "${views.join('", "')}" CASCADE;`)
   }
 
   /**
@@ -109,7 +109,7 @@ export class PgDialect implements DialectContract {
     const types = await this.getAllTypes(schemas)
     if (!types.length) return
 
-    await this.client.rawQuery('DROP TYPE IF EXISTS "' + types.join('", "') + '" CASCADE;')
+    await this.client.rawQuery(`DROP TYPE IF EXISTS "${types.join('", "')}" CASCADE;`)
   }
 
   /**

--- a/src/Dialects/Pg.ts
+++ b/src/Dialects/Pg.ts
@@ -89,7 +89,7 @@ export class PgDialect implements DialectContract {
     const tables = await this.getAllTables(schemas)
     if (!tables.length) return
 
-    await this.client.rawQuery(`DROP table ${tables.join(',')} CASCADE;`)
+    await this.client.rawQuery('DROP TABLE IF EXISTS "' + tables.join('", "') + '" CASCADE;')
   }
 
   /**
@@ -99,7 +99,7 @@ export class PgDialect implements DialectContract {
     const views = await this.getAllViews(schemas)
     if (!views.length) return
 
-    await this.client.rawQuery(`DROP view ${views.join(',')} CASCADE;`)
+    await this.client.rawQuery('DROP VIEW IF EXISTS "' + views.join('", "') + '" CASCADE;')
   }
 
   /**
@@ -109,7 +109,7 @@ export class PgDialect implements DialectContract {
     const types = await this.getAllTypes(schemas)
     if (!types.length) return
 
-    await this.client.rawQuery(`DROP type ${types.join(',')};`)
+    await this.client.rawQuery('DROP TYPE IF EXISTS "' + types.join('", "') + '" CASCADE;')
   }
 
   /**


### PR DESCRIPTION
## Proposed changes

The drop functions in the PostgreSQL dialect will no longer fail on Windows when using case-sensitive table names, such as camelCase.

## Types of changes

The drop queries will now use double quotes for literal names, and the "IF EXISTS" parameter so it doesn't fail if a table/view/type no longer exists after getting the list.

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/lucid/blob/master/.github/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
