### PR TITLE
feat(query-builder): add support for columns for with and withRecursive

### DIFF
--- a/adonis-typings/querybuilder.ts
+++ b/adonis-typings/querybuilder.ts
@@ -380,7 +380,11 @@ declare module '@ioc:Adonis/Lucid/Database' {
    * Possible signatures of `with` CTE
    */
   interface With<Builder extends ChainableContract> {
-    (alias: string, query: RawQuery | ChainableContract | QueryCallback<Builder>): Builder
+    (
+      alias: string,
+      query: RawQuery | ChainableContract | QueryCallback<Builder>,
+      columns?: string[]
+    ): Builder
   }
 
   /**

--- a/src/Database/QueryBuilder/Chainable.ts
+++ b/src/Database/QueryBuilder/Chainable.ts
@@ -1504,16 +1504,26 @@ export abstract class Chainable extends Macroable implements ChainableContract {
   /**
    * Define `with` CTE
    */
-  public with(alias: any, query: any): this {
-    this.knexQuery.with(alias, this.transformValue(query))
+  public with(alias: any, query: any, columns: string[] = []): this {
+    if (columns.length > 0) {
+      this.knexQuery.with(alias, columns, this.transformValue(query))
+    } else {
+      this.knexQuery.with(alias, this.transformValue(query))
+    }
+
     return this
   }
 
   /**
    * Define `with` CTE with recursive keyword
    */
-  public withRecursive(alias: any, query: any): this {
-    this.knexQuery.withRecursive(alias, this.transformValue(query))
+  public withRecursive(alias: any, query: any, columns: string[] = []): this {
+    if (columns.length > 0) {
+      this.knexQuery.withRecursive(alias, columns, this.transformValue(query))
+    } else {
+      this.knexQuery.withRecursive(alias, this.transformValue(query))
+    }
+
     return this
   }
 

--- a/test/database/query-builder.spec.ts
+++ b/test/database/query-builder.spec.ts
@@ -11657,6 +11657,29 @@ test.group('Query Builder | with', (group) => {
 
     await connection.disconnect()
   })
+
+  test('define with clause and column list', async ({ assert }) => {
+    const connection = new Connection('primary', getConfig(), app.logger)
+    connection.connect()
+
+    const client = getQueryClient(connection, app)
+    let db = getQueryBuilder(client)
+
+    const { sql, bindings } = db
+      .from('users')
+      .with('with_alias', client.raw(`SELECT * FROM "users"`), ['id'])
+      .toSQL()
+
+    const { sql: knexSql, bindings: knexBindings } = connection
+      .client!.from('users')
+      .with('with_alias', ['id'], connection.client!.raw(`SELECT * FROM "users"`))
+      .toSQL()
+
+    assert.equal(sql, knexSql)
+    assert.deepEqual(bindings, knexBindings)
+
+    await connection.disconnect()
+  })
 })
 
 test.group('Query Builder | withRecursive', (group) => {
@@ -11675,7 +11698,7 @@ test.group('Query Builder | withRecursive', (group) => {
     await resetTables()
   })
 
-  test('define with clause as a raw query', async ({ assert }) => {
+  test('define with recursive clause as a raw query', async ({ assert }) => {
     const connection = new Connection('primary', getConfig(), app.logger)
     connection.connect()
 
@@ -11698,7 +11721,7 @@ test.group('Query Builder | withRecursive', (group) => {
     await connection.disconnect()
   })
 
-  test('define with clause as a callback', async ({ assert }) => {
+  test('define with recursive clause as a callback', async ({ assert }) => {
     const connection = new Connection('primary', getConfig(), app.logger)
     connection.connect()
 
@@ -11721,7 +11744,7 @@ test.group('Query Builder | withRecursive', (group) => {
     await connection.disconnect()
   })
 
-  test('define with clause as a subquery', async ({ assert }) => {
+  test('define with recursive clause as a subquery', async ({ assert }) => {
     const connection = new Connection('primary', getConfig(), app.logger)
     connection.connect()
 
@@ -11736,6 +11759,29 @@ test.group('Query Builder | withRecursive', (group) => {
     const { sql: knexSql, bindings: knexBindings } = connection
       .client!.from('users')
       .withRecursive('with_alias', connection.client!.from('users').select('*'))
+      .toSQL()
+
+    assert.equal(sql, knexSql)
+    assert.deepEqual(bindings, knexBindings)
+
+    await connection.disconnect()
+  })
+
+  test('define with recursive clause and column list', async ({ assert }) => {
+    const connection = new Connection('primary', getConfig(), app.logger)
+    connection.connect()
+
+    const client = getQueryClient(connection, app)
+    let db = getQueryBuilder(client)
+
+    const { sql, bindings } = db
+      .from('users')
+      .withRecursive('with_alias', client.raw(`SELECT * FROM "users"`), ['id'])
+      .toSQL()
+
+    const { sql: knexSql, bindings: knexBindings } = connection
+      .client!.from('users')
+      .withRecursive('with_alias', ['id'], connection.client!.raw(`SELECT * FROM "users"`))
       .toSQL()
 
     assert.equal(sql, knexSql)


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/lucid/blob/master/.github/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Add support for columns to Query Builder with and withRecursive methods. Knex already support them but it was not possible to pass columns using Lucid QB methods.

If this PR is merged, I will add the corresponding docs.