### PR TITLE
Use anonymous classes for migrations

### DIFF
--- a/templates/migration-alter.txt
+++ b/templates/migration-alter.txt
@@ -1,6 +1,6 @@
 import BaseSchema from '@ioc:Adonis/Lucid/Schema'
 
-export default class {{#toClassName}}{{ filename }}{{/toClassName}} extends BaseSchema {
+export default class extends BaseSchema {
   protected tableName = '{{#toTableName}}{{ filename }}{{/toTableName}}'
 
   public async up () {

--- a/templates/migration-make.txt
+++ b/templates/migration-make.txt
@@ -1,6 +1,6 @@
 import BaseSchema from '@ioc:Adonis/Lucid/Schema'
 
-export default class {{#toClassName}}{{ filename }}{{/toClassName}} extends BaseSchema {
+export default class extends BaseSchema {
   protected tableName = '{{#toTableName}}{{ filename }}{{/toTableName}}'
 
   public async up () {


### PR DESCRIPTION
Hey there! 👋🏻 

I believe we should use anonymous classes when generating migrations.
There is no need to define a name to this class and it can create confusion when fuzzy searching for your model name (since migration has the same name when generating them with `node ace make:model X -m`.

