### PR TITLE
Fix the Contributing link at README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
       Guides
     </a>
     <span> | </span>
-    <a href="CONTRIBUTING.md">
+    <a href=".github/CONTRIBUTING.md">
       Contributing
     </a>
   </h3>


### PR DESCRIPTION
## Proposed changes

Contributing link at the README link was broken, changed the url from "contributing.md" to  [.github/contributing.md](https://github.com/adonisjs/lucid/blob/develop/.github/CONTRIBUTING.md)

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/adonisjs/lucid/blob/master/.github/CONTRIBUTING.md) doc