### PR TITLE
feat: add `--compact-output` flag to run/rollback commands

### DIFF
--- a/commands/Migration/Rollback.ts
+++ b/commands/Migration/Rollback.ts
@@ -52,6 +52,12 @@ export default class Migrate extends MigrationsBase {
   public batch: number
 
   /**
+   * Display migrations result in one compact single-line output
+   */
+  @flags.boolean({ description: 'A compact single-line output' })
+  public compactOutput: boolean = false
+
+  /**
    * Instantiating the migrator instance
    */
   private instantiateMigrator() {

--- a/commands/Migration/Run.ts
+++ b/commands/Migration/Run.ts
@@ -43,6 +43,12 @@ export default class Migrate extends MigrationsBase {
   public dryRun: boolean
 
   /**
+   * Display migrations result in one compact single-line output
+   */
+  @flags.boolean({ description: 'A compact single-line output' })
+  public compactOutput: boolean = false
+
+  /**
    * Instantiating the migrator instance
    */
   private instantiateMigrator() {

--- a/src/TestUtils/Migration.ts
+++ b/src/TestUtils/Migration.ts
@@ -16,7 +16,7 @@ export class TestsMigrator {
   constructor(private ace: typeof Ace, private connectionName?: string) {}
 
   private async runCommand(commandName: string) {
-    const args: string[] = []
+    const args: string[] = ['--compact-output']
     if (this.connectionName) {
       args.push(`--connection=${this.connectionName}`)
     }

--- a/test/commands/migration/run.spec.ts
+++ b/test/commands/migration/run.spec.ts
@@ -35,7 +35,13 @@ test.group('migration:run', (group) => {
     app.container.bind('Adonis/Lucid/Migrator', () => Migrator)
     return async () => {
       await cleanup()
-      await cleanup(['adonis_schema', 'adonis_schema_versions', 'schema_users', 'schema_accounts'])
+      await cleanup([
+        'adonis_schema',
+        'adonis_schema_versions',
+        'schema_users',
+        'schema_accounts',
+        'schema_clients',
+      ])
       await db.manager.closeAll(true)
     }
   })

--- a/test/commands/migration/run.spec.ts
+++ b/test/commands/migration/run.spec.ts
@@ -156,4 +156,92 @@ test.group('migration:run', (group) => {
     assert.equal(migrated[0].name, 'database/migrations/users')
     assert.equal(migrated[0].batch, 1)
   })
+
+  test('run migrations with compact output should display one line', async ({ assert }) => {
+    await fs.add(
+      'database/migrations/users.ts',
+      `
+      import { Schema } from '../../../../src/Schema'
+      module.exports = class User extends Schema {
+        public async up () {
+          this.schema.createTable('schema_users', (table) => {
+            table.increments()
+          })
+        }
+      }
+    `
+    )
+
+    await fs.add(
+      'database/migrations/clients.ts',
+      `
+      import { Schema } from '../../../../src/Schema'
+      module.exports = class Client extends Schema {
+        public async up () {
+          this.schema.createTable('schema_clients', (table) => {
+            table.increments()
+          })
+        }
+      }
+    `
+    )
+
+    process.env.CLI_UI_IS_TESTING = 'true'
+    const kernel = new Kernel(app).mockConsoleOutput()
+    kernel.register([Migrate]).interactive(false)
+
+    const command = await kernel.exec('migration:run', ['--compact-output'])
+    const logs = command.ui.testingRenderer.logs.filter(
+      (log) => !log.message.includes('Upgrading migrations version from')
+    )
+
+    assert.deepEqual(logs.length, 1)
+    assert.isTrue(logs[0].message.includes('❯ Executed 2 migrations'))
+  })
+
+  test('run already migrated migrations with compact output should display one line', async ({
+    assert,
+  }) => {
+    await fs.add(
+      'database/migrations/users.ts',
+      `
+      import { Schema } from '../../../../src/Schema'
+      module.exports = class User extends Schema {
+        public async up () {
+          this.schema.createTable('schema_users', (table) => {
+            table.increments()
+          })
+        }
+      }
+    `
+    )
+
+    await fs.add(
+      'database/migrations/clients.ts',
+      `
+      import { Schema } from '../../../../src/Schema'
+      module.exports = class Client extends Schema {
+        public async up () {
+          this.schema.createTable('schema_clients', (table) => {
+            table.increments()
+          })
+        }
+      }
+    `
+    )
+
+    process.env.CLI_UI_IS_TESTING = 'true'
+    const kernel = new Kernel(app).mockConsoleOutput()
+    kernel.register([Migrate]).interactive(false)
+
+    await kernel.exec('migration:run', ['--compact-output'])
+    const command = await kernel.exec('migration:run', ['--compact-output'])
+    const logs = command.ui.testingRenderer.logs.filter(
+      (log) => !log.message.includes('Upgrading migrations version from')
+    )
+
+    assert.deepEqual(logs.length, 1)
+    console.log(logs[0].message)
+    assert.isTrue(logs[0].message.includes('❯ Already up to date'))
+  })
 })

--- a/test/commands/migration/run.spec.ts
+++ b/test/commands/migration/run.spec.ts
@@ -241,7 +241,6 @@ test.group('migration:run', (group) => {
     )
 
     assert.deepEqual(logs.length, 1)
-    console.log(logs[0].message)
     assert.isTrue(logs[0].message.includes('❯ Already up to date'))
   })
 })


### PR DESCRIPTION
## Proposed changes

Adds a `--compact-output` flag to run and rollback commands
This flag will be set by default when migrations are executed using `TestUtils.db()`
Fix #831 

---

Success output: 
![image](https://user-images.githubusercontent.com/8337858/167257681-fedd57a8-66aa-496b-8c15-32b33969578d.png)

Skipped output: 
![image](https://user-images.githubusercontent.com/8337858/167257704-631e5a1c-0874-4c2b-b060-774981125028.png)

Error output:
![image](https://user-images.githubusercontent.com/8337858/167257745-09d7da36-ce0b-46f1-8758-1e25c7fd2630.png)

I will add the same thing for seeders in another PR