### PR TITLE
feat: `make:factory` command + `--factory` flag to `make:model`

### DIFF
--- a/commands/MakeFactory.ts
+++ b/commands/MakeFactory.ts
@@ -1,0 +1,97 @@
+/*
+ * @adonisjs/assembler
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { join } from 'path'
+import { args, BaseCommand, flags } from '@adonisjs/core/build/standalone'
+
+/**
+ * Command to make a new Factory
+ */
+export default class MakeFactory extends BaseCommand {
+  public static commandName = 'make:factory'
+  public static description = 'Make a new factory'
+
+  /**
+   * Name of the model to be used in the factory
+   */
+  @args.string({ description: 'The name of the model' })
+  public model: string
+
+  /**
+   * Import path to the model used in the factory
+   */
+  @flags.string({ description: 'The path to the model' })
+  public modelPath: string
+
+  @flags.boolean({
+    description: 'Create the factory with the exact name as provided',
+    alias: 'e',
+  })
+  public exact: boolean
+
+  /**
+   * Generate model import path used in the factory
+   */
+  private generateModelImportPath() {
+    let base = this.application.rcFile.namespaces.models || 'App/Models'
+    if (!base.endsWith('/')) {
+      base += '/'
+    }
+
+    let importPath = this.model
+    if (this.modelPath) {
+      importPath = this.modelPath
+    } else if (importPath.endsWith('Factory')) {
+      importPath = importPath.replace(/Factory$/, '')
+    }
+
+    if (importPath.startsWith(base)) {
+      return importPath
+    }
+
+    return base + importPath
+  }
+
+  /**
+   * Path to the factories directory
+   */
+  protected getDestinationPath() {
+    const base = this.application.rcFile.directories.database || 'database'
+    return join(base, 'factories')
+  }
+
+  /**
+   * Passed down to the stub template
+   */
+  protected templateData() {
+    return {
+      model: this.model,
+      modelImportPath: this.generateModelImportPath(),
+      toModelName: () => {
+        return function (model: string, render: any) {
+          return render(model).split('/').pop()
+        }
+      },
+    }
+  }
+
+  public async run() {
+    const stub = join(__dirname, '..', 'templates', 'factory.txt')
+
+    this.generator
+      .addFile(this.model, { pattern: 'pascalcase', form: 'singular', suffix: 'Factory' })
+      .stub(stub)
+      .useMustache()
+      .destinationDir(this.getDestinationPath())
+      .appRoot(this.application.appRoot)
+      .apply(this.templateData())
+
+    await this.generator.run()
+  }
+}

--- a/commands/MakeModel.ts
+++ b/commands/MakeModel.ts
@@ -43,6 +43,9 @@ export default class MakeModel extends BaseCommand {
   })
   public controller: boolean
 
+  /**
+   * Defines if we generate the factory for the model.
+   */
   @flags.boolean({
     name: 'factory',
     alias: 'f',
@@ -76,6 +79,9 @@ export default class MakeModel extends BaseCommand {
     this.error = makeController.error
   }
 
+  /**
+   * Make factory
+   */
   private async runMakeFactory() {
     if (!this.factory) {
       return

--- a/commands/MakeModel.ts
+++ b/commands/MakeModel.ts
@@ -43,6 +43,13 @@ export default class MakeModel extends BaseCommand {
   })
   public controller: boolean
 
+  @flags.boolean({
+    name: 'factory',
+    alias: 'f',
+    description: 'Generate a factory for the model',
+  })
+  public factory: boolean
+
   /**
    * Run migrations
    */
@@ -69,6 +76,16 @@ export default class MakeModel extends BaseCommand {
     this.error = makeController.error
   }
 
+  private async runMakeFactory() {
+    if (!this.factory) {
+      return
+    }
+
+    const makeFactory = await this.kernel.exec('make:factory', [this.name])
+    this.exitCode = makeFactory.exitCode
+    this.error = makeFactory.error
+  }
+
   /**
    * Execute command
    */
@@ -91,5 +108,6 @@ export default class MakeModel extends BaseCommand {
     }
 
     await this.runMakeController()
+    await this.runMakeFactory()
   }
 }

--- a/commands/index.ts
+++ b/commands/index.ts
@@ -12,6 +12,7 @@ export default [
   '@adonisjs/lucid/build/commands/MakeModel',
   '@adonisjs/lucid/build/commands/MakeMigration',
   '@adonisjs/lucid/build/commands/MakeSeeder',
+  '@adonisjs/lucid/build/commands/MakeFactory',
   '@adonisjs/lucid/build/commands/DbWipe',
   '@adonisjs/lucid/build/commands/Migration/Run',
   '@adonisjs/lucid/build/commands/Migration/Rollback',

--- a/templates/factory.txt
+++ b/templates/factory.txt
@@ -1,0 +1,8 @@
+import {{#toModelName}}{{{ model }}}{{/toModelName}} from '{{{ modelImportPath }}}'
+import Factory from '@ioc:Adonis/Lucid/Factory'
+
+export default Factory.define({{#toModelName}}{{{ model }}}{{/toModelName}}, ({ faker }) => {
+  return {
+    //
+  }
+})

--- a/test-helpers/index.ts
+++ b/test-helpers/index.ts
@@ -667,3 +667,11 @@ export async function cleanupReplicaDb(connection: Knex) {
 export function sleep(timeout: number) {
   return new Promise((resolve) => setTimeout(resolve, timeout))
 }
+
+export function replaceFactoryBindings(source: string, model: string, importPath: string) {
+  return toNewlineArray(
+    source
+      .replace('{{{ modelImportPath }}}', importPath)
+      .replace(/{{#toModelName}}{{{ model }}}{{\/toModelName}}/gi, model)
+  )
+}

--- a/test/commands/make-factory.spec.ts
+++ b/test/commands/make-factory.spec.ts
@@ -1,0 +1,106 @@
+/*
+ * @adonisjs/assembler
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { test } from '@japa/runner'
+import { join } from 'path'
+import { Kernel } from '@adonisjs/ace'
+import { readJSONSync } from 'fs-extra'
+import { Filesystem } from '@poppinss/dev-utils'
+import { Application } from '@adonisjs/application'
+import { replaceFactoryBindings, toNewlineArray } from '../../test-helpers/index'
+import { ApplicationContract } from '@ioc:Adonis/Core/Application'
+import MakeFactory from '../../commands/MakeFactory'
+
+const fs = new Filesystem(join(__dirname, '__app'))
+const templates = new Filesystem(join(__dirname, '..', '..', 'templates'))
+
+test.group('Make Factory', async (group) => {
+  let app: ApplicationContract
+
+  // group.tap((_test) => _test.pin())
+
+  group.each.setup(async () => {
+    await fs.add('.adonisrc.json', JSON.stringify({}))
+    const rcContents = readJSONSync(join(fs.basePath, '.adonisrc.json'))
+    app = new Application(fs.basePath, 'test', rcContents)
+
+    process.env.ADONIS_ACE_CWD = fs.basePath
+
+    return async () => {
+      process.env.ADONIS_ACE_CWD = fs.basePath
+      await fs.cleanup()
+    }
+  })
+
+  test('generate a factory for {model}')
+    .with([
+      {
+        argument: 'User',
+        model: 'User',
+        finalDestination: 'UserFactory.ts',
+        finalImportPath: 'App/Models/User',
+      },
+      {
+        argument: 'Blog/Post',
+        model: 'Post',
+        finalDestination: 'Blog/PostFactory.ts',
+        finalImportPath: 'App/Models/Blog/Post',
+      },
+    ])
+    .run(async ({ assert }, set) => {
+      const factory = new MakeFactory(app, new Kernel(app).mockConsoleOutput())
+
+      factory.model = set.argument
+      await factory.run()
+
+      const UserFactory = await fs.get(`database/factories/${set.finalDestination}`)
+      const factoryTemplate = await templates.get('factory.txt')
+
+      assert.deepEqual(
+        toNewlineArray(UserFactory),
+        replaceFactoryBindings(factoryTemplate, set.model, set.finalImportPath)
+      )
+    })
+    .pin()
+
+  test('generate a factory with custom import path')
+    .with([
+      {
+        argument: 'User',
+        model: 'User',
+        modelPath: 'Test/User',
+        finalDestination: 'UserFactory.ts',
+        finalImportPath: 'App/Models/Test/User',
+      },
+      {
+        argument: 'Client',
+        model: 'Client',
+        modelPath: 'App/Models/Test/B/Client',
+        finalDestination: 'ClientFactory.ts',
+        finalImportPath: 'App/Models/Test/B/Client',
+      },
+    ])
+    .run(async ({ assert }, set) => {
+      const factory = new MakeFactory(app, new Kernel(app).mockConsoleOutput())
+
+      factory.model = set.model
+      factory.modelPath = set.modelPath
+
+      await factory.run()
+
+      const UserFactory = await fs.get(`database/factories/${set.finalDestination}`)
+      const factoryTemplate = await templates.get('factory.txt')
+
+      assert.deepEqual(
+        toNewlineArray(UserFactory),
+        replaceFactoryBindings(factoryTemplate, set.model, set.finalImportPath)
+      )
+    })
+    .pin()
+})

--- a/test/commands/make-factory.spec.ts
+++ b/test/commands/make-factory.spec.ts
@@ -10,30 +10,24 @@
 import { test } from '@japa/runner'
 import { join } from 'path'
 import { Kernel } from '@adonisjs/ace'
-import { readJSONSync } from 'fs-extra'
 import { Filesystem } from '@poppinss/dev-utils'
-import { Application } from '@adonisjs/application'
-import { replaceFactoryBindings, toNewlineArray } from '../../test-helpers/index'
 import { ApplicationContract } from '@ioc:Adonis/Core/Application'
 import MakeFactory from '../../commands/MakeFactory'
+import {
+  fs,
+  toNewlineArray,
+  setupApplication,
+  replaceFactoryBindings,
+} from '../../test-helpers/index'
 
-const fs = new Filesystem(join(__dirname, '__app'))
 const templates = new Filesystem(join(__dirname, '..', '..', 'templates'))
 
 test.group('Make Factory', async (group) => {
   let app: ApplicationContract
 
   group.each.setup(async () => {
-    await fs.add('.adonisrc.json', JSON.stringify({}))
-    const rcContents = readJSONSync(join(fs.basePath, '.adonisrc.json'))
-    app = new Application(fs.basePath, 'test', rcContents)
-
-    process.env.ADONIS_ACE_CWD = fs.basePath
-
-    return async () => {
-      process.env.ADONIS_ACE_CWD = fs.basePath
-      await fs.cleanup()
-    }
+    app = await setupApplication()
+    return () => fs.cleanup()
   })
 
   test('generate a factory for {model}')

--- a/test/commands/make-factory.spec.ts
+++ b/test/commands/make-factory.spec.ts
@@ -23,8 +23,6 @@ const templates = new Filesystem(join(__dirname, '..', '..', 'templates'))
 test.group('Make Factory', async (group) => {
   let app: ApplicationContract
 
-  // group.tap((_test) => _test.pin())
-
   group.each.setup(async () => {
     await fs.add('.adonisrc.json', JSON.stringify({}))
     const rcContents = readJSONSync(join(fs.basePath, '.adonisrc.json'))
@@ -67,7 +65,6 @@ test.group('Make Factory', async (group) => {
         replaceFactoryBindings(factoryTemplate, set.model, set.finalImportPath)
       )
     })
-    .pin()
 
   test('generate a factory with custom import path')
     .with([
@@ -102,5 +99,4 @@ test.group('Make Factory', async (group) => {
         replaceFactoryBindings(factoryTemplate, set.model, set.finalImportPath)
       )
     })
-    .pin()
 })


### PR DESCRIPTION
## Proposed changes

- Adds the `make:factory` command.
- Adds the `--factory` flag to `make:model`

```bash
Usage: make:factory <model>

Arguments
  model                The name of the model

Flags
  --model-path string  The path to the model
  -e, --exact boolean  Create the factory with the exact name as provided 
```

--- 

`node ace make:factory Client` gives : 

Destination : `database/factories/ClientFactory.ts`
```ts
import Client from 'App/Models/Client'
import Factory from '@ioc:Adonis/Lucid/Factory'

export default Factory.define(Client, ({ faker }) => {
  return {
    //
  }
})
```

In the case of a nested model ( let's stay Client model is stored in App/Models/Feature/Client, then :
`node ace make:factory Feature/Client` gives :

Destination: `database/factories/ClientFactory.ts`
```ts
import Client from 'App/Models/Test/Client'
import Factory from '@ioc:Adonis/Lucid/Factory'
...
```
---

The import path to the model used in the top of the factory stub can be customized using the `--model-path` flag :

`node ace make:factory ClientFactory --model-path=My/Nested/Model/Client`
or
`node ace make:factory ClientFactory --model-path=App/Models/My/Nested/Model/Client`

Gives: 
```ts
import Client from 'App/Models/My/Nested/Model/Client'
import Factory from '@ioc:Adonis/Lucid/Factory'
....
````

---

`node ace make:model MySuperModel -fcm`
Gives : 

```
CREATE: app\Models\MySuperModel.ts
CREATE: database\migrations\1651934462987_my_super_models.ts
CREATE: app\Controllers\Http\MySuperModelController.ts
CREATE: database\factories\MySuperModelFactory.ts
```

