### PR TITLE
feat: add `--compact-output` on DbSeed command

### DIFF
--- a/commands/DbSeed.ts
+++ b/commands/DbSeed.ts
@@ -50,6 +50,12 @@ export default class DbSeed extends BaseCommand {
   public files: string[] = []
 
   /**
+   * Display migrations result in one compact single-line output
+   */
+  @flags.boolean({ description: 'A compact single-line output' })
+  public compactOutput: boolean = false
+
+  /**
    * Print log message to the console
    */
   private printLogMessage(file: SeederFileNode) {
@@ -142,6 +148,61 @@ export default class DbSeed extends BaseCommand {
   }
 
   /**
+   * Execute selected seeders
+   */
+  private async executedSeeders(selectedSeederFiles: string[], files: FileNode<unknown>[]) {
+    const seedersResults: SeederFileNode[] = []
+
+    for (let fileName of selectedSeederFiles) {
+      const sourceFile = files.find(({ name }) => slash(fileName) === slash(name))
+
+      if (!sourceFile) {
+        this.printNotAValidFile(fileName)
+        this.hasError = true
+        return
+      }
+
+      const response = await this.seeder.run(sourceFile)
+      if (response.status === 'failed') {
+        this.hasError = true
+      }
+
+      if (!this.compactOutput) {
+        this.printLogMessage(response)
+      }
+
+      seedersResults.push(response)
+    }
+
+    return seedersResults
+  }
+
+  /**
+   * Print Single-line output when `compact-output` is enabled
+   */
+  private logCompactFinalStatus(seedersResults: SeederFileNode[]) {
+    const countByStatus = seedersResults.reduce(
+      (acc, value) => {
+        acc[value.status] = acc[value.status] + 1
+        return acc
+      },
+      { completed: 0, failed: 0, ignored: 0, pending: 0 }
+    )
+    let message = `❯ Executed ${countByStatus.completed} seeders`
+
+    if (countByStatus.failed) {
+      message += `, ${countByStatus.failed} failed`
+    }
+
+    if (countByStatus.ignored) {
+      message += `, ${countByStatus.ignored} ignored`
+    }
+
+    const color = countByStatus.failed ? 'red' : 'grey'
+    this.logger.log(this.colors[color](message) as string)
+  }
+
+  /**
    * Run as a subcommand. Never close database connection or exit
    * process here
    */
@@ -170,23 +231,10 @@ export default class DbSeed extends BaseCommand {
     await this.instantiateSeeder()
     const files = await this.seeder.getList()
     const cherryPickedFiles = await this.getCherryPickedFiles(files)
+    const result = await this.executedSeeders(cherryPickedFiles, files)
 
-    /**
-     * Execute selected seeders
-     */
-    for (let fileName of cherryPickedFiles) {
-      const sourceFile = files.find(({ name }) => slash(fileName) === slash(name))
-
-      if (!sourceFile) {
-        this.printNotAValidFile(fileName)
-        this.hasError = true
-      } else {
-        const response = await this.seeder.run(sourceFile)
-        if (response.status === 'failed') {
-          this.hasError = true
-        }
-        this.printLogMessage(response)
-      }
+    if (this.compactOutput && result) {
+      this.logCompactFinalStatus(result)
     }
 
     this.exitCode = this.hasError ? 1 : 0

--- a/commands/DbSeed.ts
+++ b/commands/DbSeed.ts
@@ -200,6 +200,15 @@ export default class DbSeed extends BaseCommand {
 
     const color = countByStatus.failed ? 'red' : 'grey'
     this.logger.log(this.colors[color](message) as string)
+
+    if (countByStatus.failed > 0) {
+      const erroredSeeder = seedersResults.find((seeder) => seeder.status === 'failed')
+
+      const seederName = this.colors.grey(erroredSeeder!.file.name + ':')
+      const error = this.colors.red(erroredSeeder!.error!.message)
+
+      this.logger.log(`${seederName} ${error}\n`)
+    }
   }
 
   /**

--- a/src/TestUtils/Seeder.ts
+++ b/src/TestUtils/Seeder.ts
@@ -16,7 +16,7 @@ export class TestsSeeder {
   constructor(private ace: typeof Ace, private connectionName?: string) {}
 
   private async runCommand(commandName: string) {
-    const args: string[] = []
+    const args: string[] = ['--compact-output']
     if (this.connectionName) {
       args.push(`--connection=${this.connectionName}`)
     }

--- a/test/commands/db-seed.spec.ts
+++ b/test/commands/db-seed.spec.ts
@@ -111,12 +111,11 @@ test.group('DbSeed', (group) => {
     const kernel = new Kernel(app).mockConsoleOutput()
     kernel.register([DbSeed])
 
-    process.env.NODE_ENV = 'production'
+    app.nodeEnvironment = 'production'
     const command = await kernel.exec('db:seed', ['--compact-output'])
+    app.nodeEnvironment = 'test'
 
     assert.deepEqual(command.ui.testingRenderer.logs.length, 1)
     assert.deepInclude(command.ui.testingRenderer.logs[0].message, 'Executed 2 seeders, 1 ignored')
-
-    delete process.env.NODE_ENV
   })
 })

--- a/test/commands/db-seed.spec.ts
+++ b/test/commands/db-seed.spec.ts
@@ -83,4 +83,40 @@ test.group('DbSeed', (group) => {
     assert.equal(process.env.EXEC_POST_SEEDER, 'true')
     delete process.env.EXEC_POST_SEEDER
   })
+
+  test('run seeders with compact output', async ({ assert }) => {
+    await fs.add(
+      'database/seeders/user.ts',
+      `export default class UserSeeder {
+        public async run () {}
+      }`
+    )
+
+    await fs.add(
+      'database/seeders/client.ts',
+      `export default class ClientSeeder {
+        public async run () {}
+      }`
+    )
+
+    await fs.add(
+      'database/seeders/post.ts',
+      `export default class PostSeeder {
+        public static developmentOnly = true
+
+        public async run () {}
+      }`
+    )
+
+    const kernel = new Kernel(app).mockConsoleOutput()
+    kernel.register([DbSeed])
+
+    process.env.NODE_ENV = 'production'
+    const command = await kernel.exec('db:seed', ['--compact-output'])
+
+    assert.deepEqual(command.ui.testingRenderer.logs.length, 1)
+    assert.deepInclude(command.ui.testingRenderer.logs[0].message, 'Executed 2 seeders, 1 ignored')
+
+    delete process.env.NODE_ENV
+  })
 })


### PR DESCRIPTION
## Proposed changes

Adds a `--compact-output` flag to the `db:seed` command
This flag will be set by default when migrations are executed using `TestUtils.db().seed()`
Fix #831 

---

Output : 
![image](https://user-images.githubusercontent.com/8337858/167263210-00a28b0d-adc4-4580-a153-ffdf8acb5131.png)

Error output : 
![image](https://user-images.githubusercontent.com/8337858/167263746-457b0aa0-1d2a-4ffe-a226-f960dc18acba.png)