### PR TITLE
test(seeds): new environment config

### DIFF
--- a/adonis-typings/seeder.ts
+++ b/adonis-typings/seeder.ts
@@ -15,6 +15,7 @@ declare module '@ioc:Adonis/Lucid/Seeder' {
    */
   export type SeederConstructorContract = {
     developmentOnly: boolean
+    environment: string[]
     new (client: QueryClientContract): {
       client: QueryClientContract
       run(): Promise<void>

--- a/adonis-typings/seeder.ts
+++ b/adonis-typings/seeder.ts
@@ -14,6 +14,9 @@ declare module '@ioc:Adonis/Lucid/Seeder' {
    * Shape of seeder class
    */
   export type SeederConstructorContract = {
+    /**
+     * @deprecated
+     */
     developmentOnly: boolean
     environment: string[]
     new (client: QueryClientContract): {

--- a/src/BaseSeeder/index.ts
+++ b/src/BaseSeeder/index.ts
@@ -10,7 +10,11 @@
 import { QueryClientContract } from '@ioc:Adonis/Lucid/Database'
 
 export class BaseSeeder {
+  /**
+   * @deprecated
+   */
   public static developmentOnly: boolean
+  public static environment: string[]
   constructor(public client: QueryClientContract) {}
 
   public async run() {}

--- a/src/SeedsRunner/index.ts
+++ b/src/SeedsRunner/index.ts
@@ -60,7 +60,10 @@ export class SeedsRunner {
     /**
      * Ignore when when the node environement is not the same as the seeder configuration.
      */
-    if (Source.developmentOnly && !this.app.inDev || Source.environment && !Source.environment.includes(this.app.nodeEnvironment)) {
+    if (
+      (Source.developmentOnly && !this.app.inDev) ||
+      (Source.environment && !Source.environment.includes(this.app.nodeEnvironment))
+    ) {
       seeder.status = 'ignored'
       return seeder
     }

--- a/src/SeedsRunner/index.ts
+++ b/src/SeedsRunner/index.ts
@@ -58,10 +58,9 @@ export class SeedsRunner {
     }
 
     /**
-     * Ignore when running in non-development environment and seeder is development
-     * only
+     * Ignore when when the node environement is not the same as the seeder configuration.
      */
-    if (Source.developmentOnly && !this.app.inDev) {
+    if (Source.developmentOnly && !this.app.inDev || Source.environment && !Source.environment.includes(this.app.nodeEnvironment)) {
       seeder.status = 'ignored'
       return seeder
     }

--- a/src/SeedsRunner/index.ts
+++ b/src/SeedsRunner/index.ts
@@ -57,6 +57,10 @@ export class SeedsRunner {
       file: file,
     }
 
+    if ('developmentOnly' in Source) {
+      this.app.logger.warn(`Seeder "${file.name}" is using the deprecated flag "developmentOnly".`)
+    }
+
     /**
      * Ignore when when the node environement is not the same as the seeder configuration.
      */


### PR DESCRIPTION
Hey there! 👋🏻 

This PR adds the option `environment` to the Seeder class.
This allows us to configure what environment our seeder should run more precisely.

The current `developmentOnly` setting is too restrictive.