### PR TITLE
Fix paginate count query when used with distinct

### DIFF
--- a/src/Database/QueryBuilder/Database.ts
+++ b/src/Database/QueryBuilder/Database.ts
@@ -294,16 +294,14 @@ export class DatabaseQueryBuilder extends Chainable implements DatabaseQueryBuil
     page = Number(page)
     perPage = Number(perPage)
 
-    const countQuery = this.clone()
-      .clearOrder()
-      .clearLimit()
-      .clearOffset()
-      .clearSelect()
+    const countQuery = this.client
+      .query()
+      .from(this.clone().clearOrder().clearLimit().clearOffset().as('subQuery'))
       .count('* as total')
 
     const aggregates = await countQuery.exec()
 
-    const total = this.hasGroupBy ? aggregates.length : aggregates[0].total
+    const total = aggregates[0].total
     const results = total > 0 ? await this.forPage(page, perPage).exec() : []
 
     return new SimplePaginator(total, perPage, page, ...results)


### PR DESCRIPTION
fix(src/database/querybuilder/database.ts): move the query within a subquery in paginate total count

The main query has been mooved inside a subquery to keep its original syntax so that paginate() can
always count exact number of records fetch within it

fix #844

<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

The main problem with paginate is that is always counting total records with `COUNT(*)` followed by the original query. This is not a good way to do it, as for example the query could count records using `DISINCT some_field`. In this PR the count query is generalized since the actual user query, is put inside a subquery saving its original syntax, and counting total records with `COUNT(*)` on top of it.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/lucid/blob/master/.github/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
