### PR TITLE
refactor: update `mysql` client to `mysql2`

### DIFF
--- a/templates/database.txt
+++ b/templates/database.txt
@@ -65,11 +65,11 @@ const databaseConfig: DatabaseConfig = {
     | Configuration for MySQL database. Make sure to install the driver
     | from npm when using this connection
     |
-    | npm i mysql
+    | npm i mysql2
     |
     */
     mysql: {
-      client: 'mysql',
+      client: 'mysql2',
       connection: {
         host: Env.get('MYSQL_HOST'),
         port: Env.get('MYSQL_PORT'),


### PR DESCRIPTION
## Proposed changes

Updating to `mysql2` allows to use MySQL 8 and above. There's been issue opened in `mysql` repo, but seems like it's stale https://github.com/mysqljs/mysql/issues/1959

`mysql2` is API compatible with `mysql` so there really shouldn't be any breaking changes

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/lucid/blob/master/.github/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes (Used GH online edit, didn't run tests)
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)  - https://github.com/adonisjs/docs.adonisjs.com/pull/179

## Further comments

