### PR TITLE
fix(seeds): correct log for ignored seed

### DIFF
--- a/commands/DbSeed.ts
+++ b/commands/DbSeed.ts
@@ -77,7 +77,7 @@ export default class DbSeed extends BaseCommand {
         break
       case 'ignored':
         message = 'ignored  '
-        prefix = 'Enabled only in development environment'
+        prefix = 'Enabled only in another environment'
         color = 'dim'
         break
       case 'completed':

--- a/commands/DbSeed.ts
+++ b/commands/DbSeed.ts
@@ -77,7 +77,7 @@ export default class DbSeed extends BaseCommand {
         break
       case 'ignored':
         message = 'ignored  '
-        prefix = 'Enabled only in another environment'
+        prefix = `Disabled in "${this.application.environment}" environment`
         color = 'dim'
         break
       case 'completed':


### PR DESCRIPTION
Hey there! 👋🏻 

This PR fixes the logging message we display when a seed is ignored.
I am not sure that retrieving in which environment the file can run is beneficial. Therefore, I have displayed a generic message.

Closes https://github.com/adonisjs/lucid/issues/890