### PR TITLE
Use import type for importing type

### DIFF
--- a/templates/database.txt
+++ b/templates/database.txt
@@ -9,7 +9,7 @@ import Env from '@ioc:Adonis/Core/Env'
 {{#sqlite}}
 import Application from '@ioc:Adonis/Core/Application'
 {{/sqlite}}
-import { DatabaseConfig } from '@ioc:Adonis/Lucid/Database'
+import type { DatabaseConfig } from '@ioc:Adonis/Lucid/Database'
 
 const databaseConfig: DatabaseConfig = {
   /*


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

This change won't give error when `importsNotUsedAsValues` is set to `error` in tsconfig.json and won't break existing code

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/lucid/blob/master/.github/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)