### PR TITLE
 Enhancement: Nullable 1-1 Relations  

### DIFF
--- a/adonis-typings/relations.ts
+++ b/adonis-typings/relations.ts
@@ -99,7 +99,7 @@ declare module '@ioc:Adonis/Lucid/Orm' {
   export type HasOneDecorator = <RelatedModel extends LucidModel>(
     model: () => RelatedModel,
     options?: RelationOptions<HasOne<RelatedModel>>
-  ) => TypedDecorator<HasOne<RelatedModel>>
+  ) => TypedDecorator<HasOne<RelatedModel> | null>
 
   /**
    * Decorator signature to define has many relationship
@@ -115,7 +115,7 @@ declare module '@ioc:Adonis/Lucid/Orm' {
   export type BelongsToDecorator = <RelatedModel extends LucidModel>(
     model: () => RelatedModel,
     options?: RelationOptions<HasOne<RelatedModel>>
-  ) => TypedDecorator<BelongsTo<RelatedModel>>
+  ) => TypedDecorator<BelongsTo<RelatedModel> | null>
 
   /**
    * Decorator signature to define many to many relationship


### PR DESCRIPTION
## Proposed changes

It is not uncommon to design relations between tables with a nullable foreign key, signalling a 0-1 relation rather than a 1-1. While lucid will allow this, the typings do not, meaning that downstream from the models the typings cannot be trusted. This change adds Typescript support for nullable `HasOne` and `BelongsTo`  relations, as such:

```ts
@hasOne(() => Profile)
public profile: HasOne<typeof Profile> | null
```

Discussed in:

* https://github.com/adonisjs/lucid/issues/941

## Types of changes

Relationship type changes

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/lucid/blob/master/.github/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
