### PR TITLE
fix(migrator): set primary key for schema_versions table

### DIFF
--- a/src/Migrator/index.ts
+++ b/src/Migrator/index.ts
@@ -321,7 +321,7 @@ export class Migrator extends EventEmitter implements MigratorContract {
      */
     this.emit('create:schema_versions:table')
     await this.client.schema.createTable(this.schemaVersionsTableName, (table) => {
-      table.integer('version').notNullable()
+      table.integer('version').unsigned().primary()
     })
   }
 


### PR DESCRIPTION
Hey! 👋🏻 

This PR changes the definition of the `adonis_schema_versions` table to ensure a `PRIMARY KEY` is set.

In many DBMS, it is required to have a least one `PRIMARY KEY`. If you don't set one manually, the DBMS will try to figure out any indexes (`UNIQUE`), which may be used to act as the `PRIMARY KEY`. In this case, we had none.