### PR TITLE
test(component): fix references to missing types upon compiling in tests

### DIFF
--- a/test/database/query-builder.spec.ts
+++ b/test/database/query-builder.spec.ts
@@ -7101,7 +7101,7 @@ test.group('Query Builder | havingNull', (group) => {
     const { sql: knexSql, bindings: knexBindings } = connection
       .client!.from('users')
       ['havingNull']('deleted_at')
-      .orHavingNull('updated_at')
+      ['orHavingNull']('updated_at')
       .toSQL()
 
     assert.equal(sql, knexSql)
@@ -7119,7 +7119,7 @@ test.group('Query Builder | havingNull', (group) => {
     const { sql: knexResolverSql, bindings: knexResolverBindings } = connection
       .client!.from('users')
       ['havingNull']('my_deleted_at')
-      .orHavingNull('my_updated_at')
+      ['orHavingNull']('my_updated_at')
       .toSQL()
 
     assert.equal(resolverSql, knexResolverSql)
@@ -7193,7 +7193,7 @@ test.group('Query Builder | havingNotNull', (group) => {
     const { sql: knexSql, bindings: knexBindings } = connection
       .client!.from('users')
       ['havingNotNull']('deleted_at')
-      .orHavingNotNull('updated_at')
+      ['orHavingNotNull']('updated_at')
       .toSQL()
 
     assert.equal(sql, knexSql)
@@ -7211,7 +7211,7 @@ test.group('Query Builder | havingNotNull', (group) => {
     const { sql: knexResolverSql, bindings: knexResolverBindings } = connection
       .client!.from('users')
       ['havingNotNull']('my_deleted_at')
-      .orHavingNotNull('my_updated_at')
+      ['orHavingNotNull']('my_updated_at')
       .toSQL()
 
     assert.equal(resolverSql, knexResolverSql)


### PR DESCRIPTION
On a fresh develop branch and compiling the Typescript code throws the following errors:
<img width="1147" alt="image" src="https://github.com/adonisjs/lucid/assets/1539229/672b8960-efbd-473d-a3a0-7f18b33c4788">

Knex is missing type definitions for `havingNotNull` and `orHavingNotNull`

<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Reference these methods by key like existing entries for `orHavingNull` and `orHavingNotNull` which also don't have type definitions.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/lucid/blob/master/.github/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
