### PR TITLE
fix(migrator): set primary key for schema_versions table

### DIFF
--- a/src/migration/runner.ts
+++ b/src/migration/runner.ts
@@ -327,7 +327,7 @@ export class MigrationRunner extends EventEmitter {
      */
     this.emit('create:schema_versions:table')
     await this.client.schema.createTable(this.schemaVersionsTableName, (table) => {
-      table.integer('version').notNullable()
+      table.integer('version').unsigned().primary()
     })
   }
 


### PR DESCRIPTION
Hey! 👋🏻 

This PR changes the definition of the `adonis_schema_versions` table to ensure a `PRIMARY KEY` is set.

In many DBMS, it is required to have a least one `PRIMARY KEY`. If you don't set one manually, the DBMS will try to figure out any indexes (`UNIQUE`), which may be used to act as the `PRIMARY KEY`. In this case, we had none.

Updated version of https://github.com/adonisjs/lucid/pull/945 for V6.