### PR TITLE
Fix for load method not showing debug output

### DIFF
--- a/adonis-typings/relations.ts
+++ b/adonis-typings/relations.ts
@@ -1025,8 +1025,8 @@ declare module '@ioc:Adonis/Lucid/Orm' {
    * Shape of the preloader to preload relationships
    */
   export interface PreloaderContract<Model extends LucidRow> {
-    processAllForOne(parent: Model, client: QueryClientContract): Promise<void>
-    processAllForMany(parent: Model[], client: QueryClientContract): Promise<void>
+    processAllForOne(parent: Model): Promise<void>
+    processAllForMany(parent: Model[]): Promise<void>
 
     load: Preload<Model, this>
     preload: Preload<Model, this>

--- a/src/Orm/BaseModel/index.ts
+++ b/src/Orm/BaseModel/index.ts
@@ -1688,7 +1688,7 @@ export class BaseModel implements LucidRow {
     }
 
     const Model = this.constructor as LucidModel
-    const preloader = new Preloader(Model)
+    const preloader = new Preloader(Model, Model.$adapter.modelClient(this))
 
     if (typeof relationName === 'function') {
       relationName(preloader)
@@ -1696,9 +1696,7 @@ export class BaseModel implements LucidRow {
       preloader.load(relationName, callback)
     }
 
-    await preloader
-      .sideload(this.$sideloaded)
-      .processAllForOne(this, Model.$adapter.modelClient(this))
+    await preloader.sideload(this.$sideloaded).processAllForOne(this)
   }
 
   /**

--- a/src/Orm/Preloader/index.ts
+++ b/src/Orm/Preloader/index.ts
@@ -38,17 +38,21 @@ export class Preloader implements PreloaderContract<LucidRow> {
    */
   private sideloaded: ModelObject = {}
 
-  private debugQueries: boolean
+  /**
+   * Control whether to debug the query or not. The initial
+   * value is inherited from the query client
+   */
+  private debugQueries: boolean = this.client.debug
 
-  constructor(private model: LucidModel) {}
+  constructor(private model: LucidModel, private client: QueryClientContract) {}
 
   /**
    * Processes a relationship for a single parent
    */
-  private async processRelation(name: string, parent: LucidRow, client: QueryClientContract) {
+  private async processRelation(name: string, parent: LucidRow) {
     const { relation, callback } = this.preloads[name]
     const query = relation
-      .eagerQuery(parent, client)
+      .eagerQuery(parent, this.client)
       .debug(this.debugQueries)
       .sideload(this.sideloaded)
 
@@ -79,14 +83,10 @@ export class Preloader implements PreloaderContract<LucidRow> {
    * Process a given relationship for many parent instances. This happens
    * during eagerloading
    */
-  private async processRelationForMany(
-    name: string,
-    parent: LucidRow[],
-    client: QueryClientContract
-  ) {
+  private async processRelationForMany(name: string, parent: LucidRow[]) {
     const { relation, callback } = this.preloads[name]
     const query = relation
-      .eagerQuery(parent, client)
+      .eagerQuery(parent, this.client)
       .debug(this.debugQueries)
       .sideload(this.sideloaded)
 
@@ -154,10 +154,10 @@ export class Preloader implements PreloaderContract<LucidRow> {
   /**
    * Process of all the preloaded relationships for a single parent
    */
-  public async processAllForOne(parent: LucidRow, client: QueryClientContract) {
+  public async processAllForOne(parent: LucidRow) {
     await Promise.all(
       Object.keys(this.preloads).map((relationName) => {
-        return this.processRelation(relationName, parent, client)
+        return this.processRelation(relationName, parent)
       })
     )
   }
@@ -165,14 +165,14 @@ export class Preloader implements PreloaderContract<LucidRow> {
   /**
    * Process of all the preloaded relationships for many parents
    */
-  public async processAllForMany(parent: LucidRow[], client: QueryClientContract) {
+  public async processAllForMany(parent: LucidRow[]) {
     if (!parent.length) {
       return
     }
 
     await Promise.all(
       Object.keys(this.preloads).map((relationName) => {
-        return this.processRelationForMany(relationName, parent, client)
+        return this.processRelationForMany(relationName, parent)
       })
     )
   }

--- a/src/Orm/QueryBuilder/index.ts
+++ b/src/Orm/QueryBuilder/index.ts
@@ -75,7 +75,7 @@ export class ModelQueryBuilder extends Chainable implements ModelQueryBuilderCon
   /**
    * A copy of defined preloads on the model instance
    */
-  protected preloader: PreloaderContract<LucidRow> = new Preloader(this.model)
+  protected preloader: PreloaderContract<LucidRow> = new Preloader(this.model, this.client)
 
   /**
    * A custom callback to transform each model row
@@ -207,7 +207,7 @@ export class ModelQueryBuilder extends Chainable implements ModelQueryBuilderCon
     await this.preloader
       .sideload(this.sideloaded)
       .debug(this.debugQueries)
-      .processAllForMany(modelInstances, this.client)
+      .processAllForMany(modelInstances)
 
     return modelInstances
   }


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

This is a fix for the `load` function on `src/Orm/BaseModel` not showing any debug ouput when debugging is enabled globally.

The cause is the `Preloader` class `debugQueries` member remains `undefined` when the `load` function is executed.

I've modeled the solution based on how `debugQueries` works in the other three `QueryBuilder` files (Database, Insert and Raw).

These classes pass in the client at construction time and then assign the client's `debug` property

Not sure if I should or where to add tests for this, if needed.

fix #950 

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/lucid/blob/master/.github/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
