### PR TITLE
fix(migrations): change stubs to not use TZ

### DIFF
--- a/stubs/make/migration/create.stub
+++ b/stubs/make/migration/create.stub
@@ -9,12 +9,8 @@ export default class extends BaseSchema {
   async up() {
     this.schema.createTable(this.tableName, (table) => {
       table.increments('id')
-
-      /**
-       * Uses timestamptz for PostgreSQL and DATETIME2 for MSSQL
-       */
-      table.timestamp('created_at', { useTz: true })
-      table.timestamp('updated_at', { useTz: true })
+      table.timestamp('created_at', { useTz: false })
+      table.timestamp('updated_at', { useTz: false })
     })
   }
 


### PR DESCRIPTION
Hey there! 👋🏻 

This PR removes the usage of `timestamptz` for the default `created_at` and `updated_at` fields.
It does not really make sense to use a "timezoned" date for those two fields.