### PR TITLE
feat(QueryBuilder/where): add null type to where clause

### DIFF
--- a/adonis-typings/querybuilder.ts
+++ b/adonis-typings/querybuilder.ts
@@ -141,8 +141,12 @@ declare module '@ioc:Adonis/Lucid/Database' {
     /**
      * Key-value pair. The value can also be a subquery
      */
-    (key: string | RawQuery, value: StrictValues | ChainableContract): Builder
-    (key: string | RawQuery, operator: string, value: StrictValues | ChainableContract): Builder
+    (key: string | RawQuery, value: StrictValues | ChainableContract | null): Builder
+    (
+      key: string | RawQuery,
+      operator: string,
+      value: StrictValues | ChainableContract | null
+    ): Builder
   }
 
   /**


### PR DESCRIPTION
## Proposed changes

Referred to the issue #952 this PR allow to get informations in the db that is marked as `null` and don't get type error

## Types of changes

What types of changes does your code introduce?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/lucid/blob/master/.github/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
