### PR TITLE
refactor(orm): use naming strategy for computed field

### DIFF
--- a/src/orm/base_model/index.ts
+++ b/src/orm/base_model/index.ts
@@ -347,7 +347,10 @@ class BaseModelImpl implements LucidRow {
    */
   static $addComputed(name: string, options: Partial<ComputedOptions>) {
     const computed: ComputedOptions = {
-      serializeAs: options.serializeAs || name,
+      serializeAs:
+        options.serializeAs !== undefined
+          ? options.serializeAs
+          : this.namingStrategy.serializedName(this, name),
       meta: options.meta,
     }
     this.$computedDefinitions.set(name, computed)

--- a/test/orm/base_model.spec.ts
+++ b/test/orm/base_model.spec.ts
@@ -2506,7 +2506,7 @@ test.group('Base Model | toJSON', (group) => {
     const user = new User()
     user.username = 'virk'
 
-    assert.deepEqual(user.toJSON(), { username: 'virk', fullName: 'VIRK' })
+    assert.deepEqual(user.toJSON(), { username: 'virk', full_name: 'VIRK' })
   })
 
   test('do not add computed property when it returns undefined', async ({ fs, assert }) => {
@@ -2585,7 +2585,7 @@ test.group('Base Model | toJSON', (group) => {
 
     assert.deepEqual(user.toJSON(), {
       username: 'virk',
-      fullName: 'VIRK',
+      full_name: 'VIRK',
       meta: {
         postsCount: 10,
       },
@@ -2623,7 +2623,7 @@ test.group('Base Model | toJSON', (group) => {
 
     assert.deepEqual(user.toJSON(), {
       username: 'virk',
-      fullName: 'VIRK',
+      full_name: 'VIRK',
       posts: {
         count: 10,
       },
@@ -7612,7 +7612,7 @@ test.group('Base model | inheritance', (group) => {
           'fullName',
           {
             meta: undefined,
-            serializeAs: 'fullName',
+            serializeAs: 'full_name',
           },
         ],
         [
@@ -7638,7 +7638,7 @@ test.group('Base model | inheritance', (group) => {
           'fullName',
           {
             meta: undefined,
-            serializeAs: 'fullName',
+            serializeAs: 'full_name',
           },
         ],
       ])
@@ -7733,7 +7733,7 @@ test.group('Base model | inheritance', (group) => {
           'fullName',
           {
             meta: undefined,
-            serializeAs: 'fullName',
+            serializeAs: 'full_name',
           },
         ],
       ])


### PR DESCRIPTION
> **WARNING**
> This is a **breaking change** that must be documented.
> To keep the previous behavior, users must manually set the name using the `serializeAs` option.
> ```ts
>  class User extends BaseModel {
>    @computed({ serializeAs: 'fullName' })
>    declare fullName: string
>  }
> ```

Hey! 👋🏻 

This PR changes the way `computed` field works.

Beforehand, the computed field serialization wasn't using the naming strategy. Making the output inconsistent.
After this PR, the computed field will be serialized using the naming strategy (same as `column` field).