### PR TITLE
feat(config): add connectionString option to PostgresConnectionNode type

### DIFF
--- a/adonis-typings/database.ts
+++ b/adonis-typings/database.ts
@@ -427,6 +427,7 @@ declare module '@ioc:Adonis/Lucid/Database' {
    */
   type PostgresConnectionNode = {
     ssl?: boolean | ConnectionOptions
+    connectionString?: string
   }
   export type PostgreConfig = SharedConfigNode & {
     client: 'pg' | 'postgres' | 'postgresql'


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Add the `connectionString` option to the Postgres connection config.

See: [https://node-postgres.com/features/connecting#connection-uri](https://node-postgres.com/features/connecting#connection-uri)

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/lucid/blob/master/.github/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Using the `connection.connectionString` option instead of just setting `connection` to the Postgres URI allows you to also set the `connection.ssl` options.
