### PR TITLE
fix: release connection in provider shutdown

### DIFF
--- a/providers/database_provider.ts
+++ b/providers/database_provider.ts
@@ -110,4 +110,12 @@ export default class DatabaseServiceProvider {
     await this.registerReplBindings()
     await this.registerVineJSRules(db)
   }
+
+  /**
+   * Gracefully close connections during shutdown
+   */
+  async shutdown() {
+    const db = await this.app.container.make('lucid.db')
+    await db.manager.closeAll()
+  }
 }

--- a/test/database_provider.spec.ts
+++ b/test/database_provider.spec.ts
@@ -1,0 +1,84 @@
+import { test } from '@japa/runner'
+import { IgnitorFactory } from '@adonisjs/core/factories'
+
+import { defineConfig } from '../src/define_config.js'
+import { Database } from '../src/database/main.js'
+
+const BASE_URL = new URL('./tmp/', import.meta.url)
+const IMPORTER = (filePath: string) => {
+  if (filePath.startsWith('./') || filePath.startsWith('../')) {
+    return import(new URL(filePath, BASE_URL).href)
+  }
+  return import(filePath)
+}
+
+test.group('Database Provider', () => {
+  test('register database provider', async ({ assert }) => {
+    const ignitor = new IgnitorFactory()
+      .merge({
+        rcFileContents: {
+          providers: [() => import('../providers/database_provider.js')],
+        },
+      })
+      .withCoreConfig()
+      .withCoreProviders()
+      .merge({
+        config: {
+          database: defineConfig({
+            connection: 'sqlite',
+            connections: {
+              sqlite: {
+                client: 'sqlite',
+                connection: { filename: new URL('./tmp/database.sqlite', import.meta.url).href },
+                migrations: { naturalSort: true, paths: ['database/migrations'] },
+              },
+            },
+          }),
+        },
+      })
+      .create(BASE_URL, { importer: IMPORTER })
+
+    const app = ignitor.createApp('web')
+    await app.init()
+    await app.boot()
+
+    assert.instanceOf(await app.container.make('lucid.db'), Database)
+  })
+
+  test('release connection when app is terminating', async ({ assert }) => {
+    const ignitor = new IgnitorFactory()
+      .merge({
+        rcFileContents: {
+          providers: [() => import('../providers/database_provider.js')],
+        },
+      })
+      .withCoreConfig()
+      .withCoreProviders()
+      .merge({
+        config: {
+          database: defineConfig({
+            connection: 'sqlite',
+            connections: {
+              sqlite: {
+                client: 'sqlite',
+                connection: { filename: new URL('./tmp/database.sqlite', import.meta.url).href },
+                migrations: { naturalSort: true, paths: ['database/migrations'] },
+              },
+            },
+          }),
+        },
+      })
+      .create(BASE_URL, { importer: IMPORTER })
+
+    const app = ignitor.createApp('web')
+    await app.init()
+    await app.boot()
+
+    const db = await app.container.make('lucid.db')
+
+    await db.from('users').catch(() => {})
+    await app.terminate()
+
+    assert.isFalse(db.manager.isConnected('sqlite'))
+  })
+})


### PR DESCRIPTION
without this fix, Adonis apps dont shut down since database connections remain open
For example, tests in an Adonis 6 apps never end if Lucid is used. 

See the second test added