### PR TITLE
Add DatabaseTestUtils

### DIFF
--- a/commands/migration/rollback.ts
+++ b/commands/migration/rollback.ts
@@ -17,7 +17,7 @@ import { CommandOptions } from '@adonisjs/core/types/ace'
  * The command is meant to migrate the database by executing migrations
  * in `down` direction.
  */
-export default class Migrate extends MigrationsBase {
+export default class Rollback extends MigrationsBase {
   static commandName = 'migration:rollback'
   static description = 'Rollback migrations to a specific batch number'
   static options: CommandOptions = {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@adonisjs/assembler": "^7.1.0",
-    "@adonisjs/core": "^6.2.1",
+    "@adonisjs/core": "^6.2.2",
     "@adonisjs/eslint-config": "^1.2.1",
     "@adonisjs/prettier-config": "^1.2.1",
     "@adonisjs/tsconfig": "^1.2.1",
@@ -113,7 +113,7 @@
   },
   "peerDependencies": {
     "@adonisjs/assembler": "^7.0.0",
-    "@adonisjs/core": "^6.2.0",
+    "@adonisjs/core": "^6.2.2",
     "luxon": "^3.4.4"
   },
   "peerDependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test:mssql": "DB=mssql node --enable-source-maps --loader=ts-node/esm ./bin/test.js",
     "test:pg": "DB=pg node --enable-source-maps --loader=ts-node/esm ./bin/test.js",
     "test:docker": "npm run test:mysql && npm run test:mysql_legacy && npm run test:pg && npm run test:mssql",
+    "quick:test": "DB=sqlite node --enable-source-maps --loader=ts-node/esm ./bin/test.js",
     "lint": "eslint . --ext=.ts",
     "clean": "del-cli build",
     "compile": "npm run lint && npm run clean && tsc",

--- a/providers/database_provider.ts
+++ b/providers/database_provider.ts
@@ -29,7 +29,7 @@ declare module '@adonisjs/core/types' {
   }
 }
 
-declare module '@adonisjs/core' {
+declare module '@adonisjs/core/test_utils' {
   export interface TestUtils {
     db(connectionName?: string): DatabaseTestUtils
   }
@@ -91,14 +91,14 @@ export default class DatabaseServiceProvider {
    * Register TestUtils database macro
    */
   protected async registerTestUtils(db: Database) {
-    if (this.app.getEnvironment() === 'test') {
+    this.app.container.resolving('testUtils', async () => {
       const { TestUtils } = await import('@adonisjs/core/test_utils')
       const ace = await this.app.container.make('ace')
 
-      TestUtils.macro('db', function (this: typeof ace, connectionName?: string) {
+      TestUtils.macro('db', (connectionName?: string) => {
         return new DatabaseTestUtils(ace, db, connectionName)
       })
-    }
+    })
   }
 
   /**

--- a/providers/database_provider.ts
+++ b/providers/database_provider.ts
@@ -92,7 +92,7 @@ export default class DatabaseServiceProvider {
    */
   protected async registerTestUtils(db: Database) {
     if (this.app.getEnvironment() === 'test') {
-      const { TestUtils } = await import('@adonisjs/core')
+      const { TestUtils } = await import('@adonisjs/core/test_utils')
       const ace = await this.app.container.make('ace')
 
       TestUtils.macro('db', function (this: typeof ace, connectionName?: string) {

--- a/providers/database_provider.ts
+++ b/providers/database_provider.ts
@@ -90,13 +90,12 @@ export default class DatabaseServiceProvider {
   /**
    * Register TestUtils database macro
    */
-  protected async registerTestUtils(db: Database) {
+  protected async registerTestUtils() {
     this.app.container.resolving('testUtils', async () => {
       const { TestUtils } = await import('@adonisjs/core/test_utils')
-      const ace = await this.app.container.make('ace')
 
       TestUtils.macro('db', (connectionName?: string) => {
-        return new DatabaseTestUtils(ace, db, connectionName)
+        return new DatabaseTestUtils(this.app, connectionName)
       })
     })
   }
@@ -128,7 +127,7 @@ export default class DatabaseServiceProvider {
     const db = await this.app.container.make('lucid.db')
     BaseModel.$adapter = new Adapter(db)
 
-    await this.registerTestUtils(db)
+    await this.registerTestUtils()
     await this.registerReplBindings()
     await this.registerVineJSRules(db)
   }

--- a/src/test_utils/database.ts
+++ b/src/test_utils/database.ts
@@ -1,0 +1,78 @@
+/*
+ * @adonisjs/lucid
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import type { Kernel } from '@adonisjs/core/ace'
+
+import type { Database } from '../database/main.js'
+
+/**
+ * Database test utils are meant to be used during testing to
+ * perform common tasks like running migrations, seeds, etc.
+ */
+export class DatabaseTestUtils {
+  constructor(
+    protected kernel: Kernel,
+    protected db: Database,
+    protected connectionName?: string
+  ) {}
+
+  /**
+   * Runs a command through Ace
+   */
+  async #runCommand(commandName: string, args: string[] = []) {
+    if (this.connectionName) {
+      args.push(`--connection=${this.connectionName}`)
+    }
+
+    const command = await this.kernel.exec(commandName, args)
+    if (!command.exitCode) return
+
+    if (command.error) {
+      throw command.error
+    } else {
+      throw new Error(`"${commandName}" failed`)
+    }
+  }
+
+  /**
+   * Testing hook for running migrations ( if needed )
+   * Return a function to truncate the whole database but keep the schema
+   */
+  async truncate() {
+    await this.#runCommand('migration:run', ['--compact-output'])
+    return () => this.#runCommand('db:truncate')
+  }
+
+  /**
+   * Testing hook for running seeds
+   */
+  async seed() {
+    await this.#runCommand('db:seed')
+  }
+
+  /**
+   * Testing hook for running migrations
+   * Return a function to rollback the whole database
+   *
+   * Note that this is slower than truncate() because it
+   * has to run all migration in both directions when running tests
+   */
+  async migrate() {
+    await this.#runCommand('migration:run', ['--compact-output'])
+    return () => this.#runCommand('migration:rollback', ['--compact-output'])
+  }
+
+  /**
+   * Testing hook for creating a global transaction
+   */
+  async withGlobalTransaction() {
+    await this.db.beginGlobalTransaction(this.connectionName)
+    return () => this.db.rollbackGlobalTransaction(this.connectionName)
+  }
+}

--- a/test/database_provider.spec.ts
+++ b/test/database_provider.spec.ts
@@ -113,9 +113,7 @@ test.group('Database Provider', () => {
 
     const testUtils = await app.container.make('testUtils')
 
-    // @ts-expect-error
     assert.isDefined(testUtils.db)
-    // @ts-expect-error
     assert.isFunction(testUtils.db)
   })
 })

--- a/test/database_provider.spec.ts
+++ b/test/database_provider.spec.ts
@@ -81,4 +81,41 @@ test.group('Database Provider', () => {
 
     assert.isFalse(db.manager.isConnected('sqlite'))
   })
+
+  test('register testUtils.db() binding', async ({ assert }) => {
+    const ignitor = new IgnitorFactory()
+      .merge({
+        rcFileContents: {
+          providers: [() => import('../providers/database_provider.js')],
+        },
+      })
+      .withCoreConfig()
+      .withCoreProviders()
+      .merge({
+        config: {
+          database: defineConfig({
+            connection: 'sqlite',
+            connections: {
+              sqlite: {
+                client: 'sqlite',
+                connection: { filename: new URL('./tmp/database.sqlite', import.meta.url).href },
+                migrations: { naturalSort: true, paths: ['database/migrations'] },
+              },
+            },
+          }),
+        },
+      })
+      .create(BASE_URL, { importer: IMPORTER })
+
+    const app = ignitor.createApp('web')
+    await app.init()
+    await app.boot()
+
+    const testUtils = await app.container.make('testUtils')
+
+    // @ts-expect-error
+    assert.isDefined(testUtils.db)
+    // @ts-expect-error
+    assert.isFunction(testUtils.db)
+  })
 })

--- a/test/test_utils.spec.ts
+++ b/test/test_utils.spec.ts
@@ -1,0 +1,210 @@
+/*
+ * @adonisjs/lucid
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { test } from '@japa/runner'
+import { ListLoader } from '@adonisjs/core/ace'
+import { AceFactory } from '@adonisjs/core/factories'
+
+import DbSeed from '../commands/db_seed.js'
+import { getDb } from '../test-helpers/index.js'
+import Migrate from '../commands/migration/run.js'
+import DbTruncate from '../commands/db_truncate.js'
+import Rollback from '../commands/migration/rollback.js'
+import { DatabaseTestUtils } from '../src/test_utils/database.js'
+
+test.group('Database Test Utils', () => {
+  test('truncate() should run migration:run and db:truncate commands', async ({ fs, assert }) => {
+    let migrationRun = false
+    let truncateRun = false
+
+    const ace = await new AceFactory().make(fs.baseUrl, { importer: () => {} })
+
+    class FakeMigrate extends Migrate {
+      override async run() {
+        migrationRun = true
+      }
+    }
+
+    class FakeDbTruncate extends DbTruncate {
+      override async run() {
+        truncateRun = true
+      }
+    }
+
+    ace.addLoader(new ListLoader([FakeMigrate, FakeDbTruncate]))
+
+    const dbTestUtils = new DatabaseTestUtils(ace, getDb())
+    const truncate = await dbTestUtils.truncate()
+
+    await truncate()
+
+    assert.isTrue(migrationRun)
+    assert.isTrue(truncateRun)
+  })
+
+  test('truncate() with custom connectionName', async ({ fs, assert }) => {
+    assert.plan(2)
+
+    const ace = await new AceFactory().make(fs.baseUrl, { importer: () => {} })
+
+    class FakeMigrate extends Migrate {
+      override async run() {
+        assert.equal(this.connection, 'secondary')
+      }
+    }
+
+    class FakeDbTruncate extends DbTruncate {
+      override async run() {
+        assert.equal(this.connection, 'secondary')
+      }
+    }
+
+    ace.addLoader(new ListLoader([FakeMigrate, FakeDbTruncate]))
+
+    const dbTestUtils = new DatabaseTestUtils(ace, getDb(), 'secondary')
+    const truncate = await dbTestUtils.truncate()
+
+    await truncate()
+  })
+
+  test('seed() should run db:seed command', async ({ fs, assert }) => {
+    assert.plan(1)
+
+    const ace = await new AceFactory().make(fs.baseUrl, { importer: () => {} })
+
+    class FakeDbSeed extends DbSeed {
+      override async run() {
+        assert.isTrue(true)
+      }
+    }
+
+    ace.addLoader(new ListLoader([FakeDbSeed]))
+
+    const dbTestUtils = new DatabaseTestUtils(ace, getDb())
+    await dbTestUtils.seed()
+  })
+
+  test('seed() with custom connectionName', async ({ fs, assert }) => {
+    assert.plan(1)
+
+    const ace = await new AceFactory().make(fs.baseUrl, { importer: () => {} })
+
+    class FakeDbSeed extends DbSeed {
+      override async run() {
+        assert.equal(this.connection, 'secondary')
+      }
+    }
+
+    ace.addLoader(new ListLoader([FakeDbSeed]))
+
+    const dbTestUtils = new DatabaseTestUtils(ace, getDb(), 'secondary')
+    await dbTestUtils.seed()
+  })
+
+  test('migrate() should run migration:run and migration:rollback commands', async ({
+    fs,
+    assert,
+  }) => {
+    let migrationRun = false
+    let rollbackRun = false
+
+    const ace = await new AceFactory().make(fs.baseUrl, { importer: () => {} })
+
+    class FakeMigrate extends Migrate {
+      override async run() {
+        migrationRun = true
+      }
+    }
+
+    class FakeMigrationRollback extends Rollback {
+      override async run() {
+        rollbackRun = true
+      }
+    }
+
+    ace.addLoader(new ListLoader([FakeMigrate, FakeMigrationRollback]))
+
+    const dbTestUtils = new DatabaseTestUtils(ace, getDb())
+    const rollback = await dbTestUtils.migrate()
+
+    await rollback()
+
+    assert.isTrue(migrationRun)
+    assert.isTrue(rollbackRun)
+  })
+
+  test('migrate() with custom connectionName', async ({ fs, assert }) => {
+    assert.plan(2)
+
+    const ace = await new AceFactory().make(fs.baseUrl, { importer: () => {} })
+
+    class FakeMigrate extends Migrate {
+      override async run() {
+        assert.equal(this.connection, 'secondary')
+      }
+    }
+
+    class FakeMigrationRollback extends Rollback {
+      override async run() {
+        assert.equal(this.connection, 'secondary')
+      }
+    }
+
+    ace.addLoader(new ListLoader([FakeMigrate, FakeMigrationRollback]))
+
+    const dbTestUtils = new DatabaseTestUtils(ace, getDb(), 'secondary')
+    const rollback = await dbTestUtils.migrate()
+
+    await rollback()
+  })
+
+  test('should throw error when command has an exitCode = 1', async ({ fs }) => {
+    const ace = await new AceFactory().make(fs.baseUrl, { importer: () => {} })
+
+    class FakeMigrate extends Migrate {
+      override async run() {
+        this.exitCode = 1
+      }
+    }
+
+    ace.addLoader(new ListLoader([FakeMigrate]))
+
+    const dbTestUtils = new DatabaseTestUtils(ace, getDb())
+    await dbTestUtils.migrate()
+  }).throws('"migration:run" failed')
+
+  test('should re-use command.error message if available', async ({ fs }) => {
+    const ace = await new AceFactory().make(fs.baseUrl, { importer: () => {} })
+
+    class FakeMigrate extends Migrate {
+      override async run() {
+        this.exitCode = 1
+        this.error = new Error('Custom error message')
+      }
+    }
+
+    ace.addLoader(new ListLoader([FakeMigrate]))
+
+    const dbTestUtils = new DatabaseTestUtils(ace, getDb())
+    await dbTestUtils.migrate()
+  }).throws('Custom error message')
+
+  test('withGlobalTransaction should wrap and rollback a transaction', async ({ fs, assert }) => {
+    const db = getDb()
+    const ace = await new AceFactory().make(fs.baseUrl, { importer: () => {} })
+    const dbTestUtils = new DatabaseTestUtils(ace, db)
+    const rollback = await dbTestUtils.withGlobalTransaction()
+
+    assert.isDefined(db.connectionGlobalTransactions.get(db.primaryConnectionName))
+
+    await rollback()
+
+    assert.isUndefined(db.connectionGlobalTransactions.get(db.primaryConnectionName))
+  })
+})


### PR DESCRIPTION
## Changes

- Add a DatabaseTestUtils class. Works as before. 
	- `testUtils.db().migrate()`
	- `testUtils.db().truncate()`
	- `testUtils.db().seed()`, 
	We can also pass a custom connectionName like `testUtils.db('secondary').seed()`

- Also, let me know if we should not keep it, but though it would be cool to include a `testUtils.db().withGlobalTransaction()` method that can be used like this : 

	```ts
	import testUtils from '@adonisjs/core/services/test_utils'
	
	test.group('', (group) => {
	   group.each.setup(() => testUtils.db().withGlobalTransaction())
	})
	```
	
So every test in this group will be wrapped a transaction that will be reverted at the end of the test