### PR TITLE
fix(vinejs): add `exists` and `unique` bindings to `VineNumber`

### DIFF
--- a/providers/database_provider.ts
+++ b/providers/database_provider.ts
@@ -39,7 +39,7 @@ declare module '@adonisjs/core/test_utils' {
  * Extending VineJS schema types
  */
 declare module '@vinejs/vine' {
-  export interface VineString {
+  interface VineLucidBindings {
     /**
      * Ensure the value is unique inside the database by self
      * executing a query.
@@ -58,6 +58,10 @@ declare module '@vinejs/vine' {
      */
     exists(callback: (db: Database, value: string, field: FieldContext) => Promise<boolean>): this
   }
+
+  interface VineNumber extends VineLucidBindings {}
+
+  interface VineString extends VineLucidBindings {}
 }
 
 /**

--- a/src/bindings/vinejs.ts
+++ b/src/bindings/vinejs.ts
@@ -7,7 +7,7 @@
  * file that was distributed with this source code.
  */
 
-import vine, { VineString } from '@vinejs/vine'
+import vine, { VineNumber, VineString } from '@vinejs/vine'
 import type { Database } from '../database/main.js'
 
 /**
@@ -15,7 +15,7 @@ import type { Database } from '../database/main.js'
  * VineJS.
  */
 export function defineValidationRules(db: Database) {
-  const uniqueRule = vine.createRule<Parameters<VineString['unique']>[0]>(
+  const uniqueRule = vine.createRule<Parameters<VineString['unique'] | VineNumber['unique']>[0]>(
     async (value, checker, field) => {
       if (!field.isValid) {
         return
@@ -28,7 +28,7 @@ export function defineValidationRules(db: Database) {
     }
   )
 
-  const existsRule = vine.createRule<Parameters<VineString['exists']>[0]>(
+  const existsRule = vine.createRule<Parameters<VineString['exists'] | VineNumber['exists']>[0]>(
     async (value, checker, field) => {
       if (!field.isValid) {
         return
@@ -45,6 +45,12 @@ export function defineValidationRules(db: Database) {
     return this.use(uniqueRule(checker))
   })
   VineString.macro('exists', function (this: VineString, checker) {
+    return this.use(existsRule(checker))
+  })
+  VineNumber.macro('unique', function (this: VineNumber, checker) {
+    return this.use(uniqueRule(checker))
+  })
+  VineNumber.macro('exists', function (this: VineNumber, checker) {
     return this.use(existsRule(checker))
   })
 }


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/adonisjs/lucid/issues/997

### ❓ Type of change

- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Resolves #997 by injecting `exists` and `unique` in `VineNumber` as well.

It also adds it to the type augmentation declaration.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
