### PR TITLE
refactor: change sqlite dropAllTables implementation

### DIFF
--- a/test-helpers/index.ts
+++ b/test-helpers/index.ts
@@ -74,12 +74,6 @@ export function getConfig(): ConnectionConfig {
         },
         useNullAsDefault: true,
         debug: !!process.env.DEBUG,
-        pool: {
-          afterCreate(connection, done) {
-            connection.unsafeMode(true)
-            done()
-          },
-        },
       }
     case 'mysql':
       return {

--- a/test/database/drop_tables.spec.ts
+++ b/test/database/drop_tables.spec.ts
@@ -122,9 +122,8 @@ test.group('Query client | drop tables', (group) => {
     })
 
     await connection.client?.table('temp_users').insert({})
-    await connection.client
-      ?.table('temp_posts')
-      .insert({ temp_users_id: await connection.client?.table('temp_users').select('id').first() })
+    const user = await connection.client?.table('temp_users').select('id').first()
+    await connection.client?.table('temp_posts').insert({ temp_users_id: user!.id })
 
     const client = new QueryClient('dual', connection, createEmitter())
     await client.dialect.dropAllTables(['public'])

--- a/test/database/drop_tables.spec.ts
+++ b/test/database/drop_tables.spec.ts
@@ -121,8 +121,10 @@ test.group('Query client | drop tables', (group) => {
       table.integer('temp_users_id').unsigned().references('id').inTable('temp_users')
     })
 
-    await connection.client?.table('temp_users').insert({ id: 1 })
-    await connection.client?.table('temp_posts').insert({ id: 1, temp_users_id: 1 })
+    await connection.client?.table('temp_users').insert({})
+    await connection.client
+      ?.table('temp_posts')
+      .insert({ temp_users_id: await connection.client?.table('temp_users').select('id').first() })
 
     const client = new QueryClient('dual', connection, createEmitter())
     await client.dialect.dropAllTables(['public'])

--- a/test/database/drop_tables.spec.ts
+++ b/test/database/drop_tables.spec.ts
@@ -107,4 +107,30 @@ test.group('Query client | drop tables', (group) => {
 
     await connection.disconnect()
   })
+
+  test('drop tables with foreign keys constraint', async ({ assert }) => {
+    const connection = new Connection('primary', getConfig(), logger)
+    connection.connect()
+
+    await connection.client!.schema.createTableIfNotExists('temp_users', (table) => {
+      table.increments('id')
+    })
+
+    await connection.client!.schema.createTableIfNotExists('temp_posts', (table) => {
+      table.increments('id')
+      table.integer('temp_users_id').unsigned().references('id').inTable('temp_users')
+    })
+
+
+    await connection.client?.table('temp_users').insert({ id: 1 })
+    await connection.client?.table('temp_posts').insert({ id: 1, temp_users_id: 1 })
+
+    const client = new QueryClient('dual', connection, createEmitter())
+    await client.dialect.dropAllTables(['public'])
+
+    assert.isFalse(await connection.client!.schema.hasTable('temp_users'))
+    assert.isFalse(await connection.client!.schema.hasTable('temp_posts'))
+
+    await connection.disconnect()
+  })
 })

--- a/test/database/drop_tables.spec.ts
+++ b/test/database/drop_tables.spec.ts
@@ -121,7 +121,6 @@ test.group('Query client | drop tables', (group) => {
       table.integer('temp_users_id').unsigned().references('id').inTable('temp_users')
     })
 
-
     await connection.client?.table('temp_users').insert({ id: 1 })
     await connection.client?.table('temp_posts').insert({ id: 1, temp_users_id: 1 })
 
@@ -133,4 +132,33 @@ test.group('Query client | drop tables', (group) => {
 
     await connection.disconnect()
   })
+
+  if (['better-sqlite', 'sqlite'].includes(process.env.DB!)) {
+    test('drop tables when PRAGMA foreign_keys is enabled', async ({ assert }) => {
+      const connection = new Connection('primary', getConfig(), logger)
+      connection.connect()
+
+      await connection.client!.schema.createTable('temp_posts', (table) => {
+        table.increments('id')
+      })
+
+      await connection.client!.schema.createTableIfNotExists('temp_users', (table) => {
+        table.increments('id')
+        table.integer('temp_posts_id').unsigned().references('id').inTable('temp_posts')
+      })
+
+      await connection.client?.table('temp_posts').insert({ id: 1 })
+      await connection.client?.table('temp_users').insert({ id: 1, temp_posts_id: 1 })
+
+      const client = new QueryClient('dual', connection, createEmitter())
+
+      await client.rawQuery('PRAGMA foreign_keys = ON;')
+      await client.dialect.dropAllTables(['public'])
+
+      assert.isFalse(await connection.client!.schema.hasTable('temp_users'))
+      assert.isFalse(await connection.client!.schema.hasTable('temp_posts'))
+
+      await connection.disconnect()
+    })
+  }
 })


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

Fix https://github.com/adonisjs/lucid/issues/999

I have updated the implementation of `dropAllTables` for `better-sqlite3` and `sqlite` : 

- The implementation was causing problems for `better-sqlite3` as explained in the linked issue. i also preferred to modify the implementation for `sqlite` by modifying the `BaseSqlite` class so that we don't have two different methods to maintain

- The problem is linked to the `unsafeMode` explained here: https://github.com/WiseLibs/better-sqlite3/blob/master/docs/unsafe.md and therefore to our use of `PRAGMA writable_schema`. 
![image](https://github.com/adonisjs/lucid/assets/8337858/b2952b64-b26a-43b6-9a16-3959bd152580)

As a result, I've decided to drop all tables with multiples queries rather than modifying `sqlite_master` directly. this way, we don't need to activate the unsafe mode. the method is probably slower, but imo it doesn't matter at all

indexes and triggers are automatically deleted if linked to a deleted table