### PR TITLE
feat: add test for null nested BelongsTo relationship

### DIFF
--- a/test/orm/base-model.spec.ts
+++ b/test/orm/base-model.spec.ts
@@ -6083,6 +6083,94 @@ test.group('Base Model | toObject', (group) => {
       $extras: {},
     })
   })
+
+  // TODO: I'm not really checking the author, so can probably just remove...
+  test('add preloaded belongsTo relationship to toObject result', async ({ assert }) => {
+    class Category extends BaseModel {
+      @column()
+      public name: string
+
+      @column()
+      public parentId: number
+
+      @belongsTo(() => Category)
+      public parent: BelongsTo<typeof Category>
+    }
+
+    class Post extends BaseModel {
+      @column()
+      public title: string
+
+      @column()
+      public userId: number
+
+      @belongsTo(() => User)
+      public author: BelongsTo<typeof User>
+
+      @hasOne(() => Category)
+      public category: HasOne<typeof Category>
+    }
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
+      @column()
+      public username: string
+
+      @hasMany(() => Post)
+      public posts: HasMany<typeof Post>
+    }
+
+    const user = new User()
+    user.username = 'virk'
+
+    const category = new Category()
+    category.name = 'Tutorials'
+
+    const subCategory = new Category()
+    subCategory.name = 'Lucid'
+
+    const post = new Post()
+    post.title = 'Adonis 101'
+
+    // user.$setRelated('posts', [post])
+    post.$setRelated('author', user)
+    subCategory.$setRelated('parent', category)
+    post.$setRelated('category', subCategory)
+
+    assert.deepEqual(subCategory.toObject(), {
+      name: 'Lucid',
+      parent: {
+        name: 'Tutorials',
+        $extras: {},
+      },
+      $extras: {},
+    })
+
+    assert.deepEqual(category.toObject(), {
+      name: 'Tutorials',
+      parent: null,
+      $extras: {},
+    })
+
+    // assert.deepEqual(post.toObject(), {
+    //   title: 'Adonis 101',
+    //   author: {
+    //     username: 'virk',
+    //     $extras: {},
+    //   },
+    //   category: {
+    //     name: 'Lucid',
+    //     parent: {
+    //       name: 'Tutorials',
+    //       $extras: {},
+    //     },
+    //     $extras: {},
+    //   },
+    //   $extras: {},
+    // })
+  }).pin()
 })
 
 test.group('Base model | inheritance', (group) => {

--- a/test/orm/base-model.spec.ts
+++ b/test/orm/base-model.spec.ts
@@ -6087,11 +6087,14 @@ test.group('Base Model | toObject', (group) => {
   // TODO: I'm not really checking the author, so can probably just remove...
   test('add preloaded belongsTo relationship to toObject result', async ({ assert }) => {
     class Category extends BaseModel {
+      @column({ isPrimary: true })
+      public id: number
+
       @column()
       public name: string
 
       @column()
-      public parentId: number
+      public parentId: number | null
 
       @belongsTo(() => Category)
       public parent: BelongsTo<typeof Category>
@@ -6104,45 +6107,34 @@ test.group('Base Model | toObject', (group) => {
       @column()
       public userId: number
 
-      @belongsTo(() => User)
-      public author: BelongsTo<typeof User>
-
       @hasOne(() => Category)
       public category: HasOne<typeof Category>
     }
 
-    class User extends BaseModel {
-      @column({ isPrimary: true })
-      public id: number
-
-      @column()
-      public username: string
-
-      @hasMany(() => Post)
-      public posts: HasMany<typeof Post>
-    }
-
-    const user = new User()
-    user.username = 'virk'
-
     const category = new Category()
     category.name = 'Tutorials'
+    category.id = 1
+    category.parentId = null
 
     const subCategory = new Category()
     subCategory.name = 'Lucid'
+    subCategory.id = 2
+    category.parentId = category.id
 
     const post = new Post()
     post.title = 'Adonis 101'
 
-    // user.$setRelated('posts', [post])
-    post.$setRelated('author', user)
     subCategory.$setRelated('parent', category)
     post.$setRelated('category', subCategory)
 
     assert.deepEqual(subCategory.toObject(), {
       name: 'Lucid',
+      id: 2,
+      parentId: 1,
       parent: {
         name: 'Tutorials',
+        id: 1,
+        parentId: null,
         $extras: {},
       },
       $extras: {},
@@ -6150,26 +6142,11 @@ test.group('Base Model | toObject', (group) => {
 
     assert.deepEqual(category.toObject(), {
       name: 'Tutorials',
+      id: 1,
+      parentId: null,
       parent: null,
       $extras: {},
     })
-
-    // assert.deepEqual(post.toObject(), {
-    //   title: 'Adonis 101',
-    //   author: {
-    //     username: 'virk',
-    //     $extras: {},
-    //   },
-    //   category: {
-    //     name: 'Lucid',
-    //     parent: {
-    //       name: 'Tutorials',
-    //       $extras: {},
-    //     },
-    //     $extras: {},
-    //   },
-    //   $extras: {},
-    // })
   }).pin()
 })
 

--- a/test/orm/base-model.spec.ts
+++ b/test/orm/base-model.spec.ts
@@ -6143,7 +6143,7 @@ test.group('Base Model | toObject', (group) => {
       parent: null,
       $extras: {},
     })
-  }).pin()
+  })
 })
 
 test.group('Base model | inheritance', (group) => {

--- a/test/orm/base-model.spec.ts
+++ b/test/orm/base-model.spec.ts
@@ -6084,7 +6084,6 @@ test.group('Base Model | toObject', (group) => {
     })
   })
 
-  // TODO: I'm not really checking the author, so can probably just remove...
   test('add preloaded belongsTo relationship to toObject result', async ({ assert }) => {
     class Category extends BaseModel {
       @column({ isPrimary: true })
@@ -6103,9 +6102,6 @@ test.group('Base Model | toObject', (group) => {
     class Post extends BaseModel {
       @column()
       public title: string
-
-      @column()
-      public userId: number
 
       @hasOne(() => Category)
       public category: HasOne<typeof Category>


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

#1008 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This adds a test for nested belongsTo relationships, and checks for nulls. Right now `BaseModel.toObject()` throws an error when the model has a null preloaded relationship. 
```
TypeError: Cannot read properties of null (reading 'toObject')
    at /app/node_modules/@adonisjs/lucid/build/src/Orm/BaseModel/index.js:1507:93
    at Array.reduce (<anonymous>)
    at Proxy.toObject (/app/node_modules/@adonisjs/lucid/build/src/Orm/BaseModel/index.js:1505:56)
    at /app/node_modules/@adonisjs/lucid/build/src/Orm/BaseModel/index.js:1507:93
    at Array.reduce (<anonymous>)
    at Proxy.toObject (/app/node_modules/@adonisjs/lucid/build/src/Orm/BaseModel/index.js:1505:56)
    at /app/node_modules/@adonisjs/lucid/build/src/Orm/BaseModel/index.js:1507:93
    at Array.reduce (<anonymous>)
    at Proxy.toObject (/app/node_modules/@adonisjs/lucid/build/src/Orm/BaseModel/index.js:1505:56)
    at new AdObject (/app/app/Libraries/Algolia/classes/AdObject.ts:16:25)
```
Should I add the fix in this PR as well? It will resolve #1008 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
