### PR TITLE
feat(base_model): add findManyBy method

### DIFF
--- a/src/orm/base_model/index.ts
+++ b/src/orm/base_model/index.ts
@@ -1984,8 +1984,8 @@ class BaseModelImpl implements LucidRow {
       result[relation.serializeAs] = Array.isArray(value)
         ? value.map((one) => one.serialize(relationOptions))
         : value === null
-        ? null
-        : value.serialize(relationOptions)
+          ? null
+          : value.serialize(relationOptions)
 
       return result
     }, {})

--- a/src/orm/base_model/index.ts
+++ b/src/orm/base_model/index.ts
@@ -722,6 +722,29 @@ class BaseModelImpl implements LucidRow {
   }
 
   /**
+   * Find multiple models instance using a key/value pair
+   */
+  // @ts-expect-error - Return type should be inferred when used in a model
+  static findManyBy(clause: Record<string, unknown>, options?: ModelAdapterOptions)
+  // @ts-expect-error - Return type should be inferred when used in a model
+  static findManyBy(key: string, value: any[], options?: ModelAdapterOptions)
+  static findManyBy(
+    key: string | Record<string, unknown>,
+    value?: any[] | ModelAdapterOptions,
+    options?: ModelAdapterOptions
+  ) {
+    if (typeof key === 'object') {
+      return this.query(value as ModelAdapterOptions).where(key)
+    }
+
+    if (value === undefined) {
+      throw new Exception('"findManyBy" expects a value. Received undefined')
+    }
+
+    return this.query(options).where(key, value)
+  }
+
+  /**
    * Same as `query().first()`
    */
   static async first(options?: ModelAdapterOptions) {

--- a/src/orm/base_model/index.ts
+++ b/src/orm/base_model/index.ts
@@ -734,14 +734,16 @@ class BaseModelImpl implements LucidRow {
     options?: ModelAdapterOptions
   ) {
     if (typeof key === 'object') {
-      return this.query(value as ModelAdapterOptions).where(key)
+      return this.query(value as ModelAdapterOptions)
+        .where(key)
+        .exec()
     }
 
     if (value === undefined) {
       throw new Exception('"findManyBy" expects a value. Received undefined')
     }
 
-    return this.query(options).where(key, value)
+    return this.query(options).where(key, value).exec()
   }
 
   /**
@@ -1982,8 +1984,8 @@ class BaseModelImpl implements LucidRow {
       result[relation.serializeAs] = Array.isArray(value)
         ? value.map((one) => one.serialize(relationOptions))
         : value === null
-          ? null
-          : value.serialize(relationOptions)
+        ? null
+        : value.serialize(relationOptions)
 
       return result
     }, {})

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -996,6 +996,23 @@ export interface LucidModel {
   ): Promise<InstanceType<T>>
 
   /**
+   * Find multiple models instance using a key/value pair
+   */
+  findManyBy<T extends LucidModel>(
+    clause: Record<string, unknown>,
+    options?: ModelAdapterOptions
+  ): Promise<InstanceType<T>[]>
+
+  /**
+   * Find multiple models instance using a key/value pair
+   */
+  findManyBy<T extends LucidModel>(
+    key: string,
+    value: any,
+    options?: ModelAdapterOptions
+  ): Promise<InstanceType<T>[]>
+
+  /**
    * Same as `query().first()`
    */
   first<T extends LucidModel>(

--- a/test/orm/base_model.spec.ts
+++ b/test/orm/base_model.spec.ts
@@ -3780,6 +3780,66 @@ test.group('Base Model | fetch', (group) => {
     assert.equal(users[1].$primaryKeyValue, 1)
   })
 
+  test('find many using a clause', async ({ fs, assert }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+
+    const BaseModel = getBaseModel(adapter)
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare username: string
+
+      @column()
+      declare email: string
+    }
+
+    await db
+      .insertQuery()
+      .table('users')
+      .multiInsert([{ username: 'virk' }, { username: 'nikk' }])
+
+    const users = await User.findManyBy({ points: 0 })
+    assert.lengthOf(users, 2)
+    assert.equal(users[0].$primaryKeyValue, 1)
+    assert.equal(users[1].$primaryKeyValue, 2)
+  })
+
+  test('find many using a key/value pair', async ({ fs, assert }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+
+    const BaseModel = getBaseModel(adapter)
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare username: string
+
+      @column()
+      declare email: string
+    }
+
+    await db
+      .insertQuery()
+      .table('users')
+      .multiInsert([{ username: 'virk' }, { username: 'nikk' }])
+
+    const users = await User.findManyBy('points', 0)
+    assert.lengthOf(users, 2)
+    assert.equal(users[0].$primaryKeyValue, 1)
+    assert.equal(users[1].$primaryKeyValue, 2)
+  })
+
   test('return the existing row when search criteria matches', async ({ fs, assert }) => {
     const app = new AppFactory().create(fs.baseUrl, () => {})
     await app.init()


### PR DESCRIPTION
Hey there! 👋🏻 

This PR adds a `findManyBy` method to the ORM.
Since we already have helpful static methods for most use cases, we were missing one that could fetch multiple records with a condition.

The method `findManyBy` can be used in two ways:
```ts
// Using an object 
User.findManyBy({ status: 'active'})

// Using two arguments
User.findManyBy('status', 'active')
```

If this PR is accepted, I will create another one to add the object syntax override to the `findBy` method.
