### PR TITLE
feat(query_builder): add orderByRandom

### DIFF
--- a/src/database/query_builder/chainable.ts
+++ b/src/database/query_builder/chainable.ts
@@ -17,6 +17,7 @@ import { RawQueryBuilder } from './raw.js'
 import { RawBuilder } from '../static_builder/raw.js'
 import { ReferenceBuilder } from '../static_builder/reference.js'
 import type { DialectContract } from '../../types/database.js'
+import * as errors from '../../errors.js'
 
 /**
  * The chainable query builder to construct SQL queries for selecting, updating and
@@ -1706,7 +1707,7 @@ export abstract class Chainable extends Macroable implements ChainableContract {
   /**
    * Order results by random value.
    */
-  orderByRandom(seed = '') {
+  orderByRandom(seed?: number) {
     switch (this.dialect.name) {
       case 'sqlite3':
       case 'better-sqlite3':
@@ -1714,7 +1715,15 @@ export abstract class Chainable extends Macroable implements ChainableContract {
       case 'redshift':
         return this.orderByRaw('RANDOM()')
       case 'mysql':
-        return this.orderByRaw(`RAND(${seed})`)
+        if (seed === undefined) {
+          return this.orderByRaw('RAND()')
+        }
+
+        if (!Number.isFinite(seed)) {
+          throw new errors.E_INVALID_ORDER_BY_RANDOM_SEED()
+        }
+
+        return this.orderByRaw('RAND(?)', [seed])
       case 'mssql':
         return this.orderByRaw('NEWID()')
       case 'oracledb':

--- a/src/database/query_builder/database.ts
+++ b/src/database/query_builder/database.ts
@@ -282,6 +282,27 @@ export class DatabaseQueryBuilder extends Chainable implements DatabaseQueryBuil
   }
 
   /**
+   * Order results by random value.
+   */
+  orderByRandom(seed = '') {
+    switch (this.client.dialect.name) {
+      case 'sqlite3':
+      case 'better-sqlite3':
+      case 'postgres':
+      case 'redshift':
+        return this.orderByRaw('RANDOM()')
+      case 'mysql':
+        return this.orderByRaw(`RAND(${seed})`)
+      case 'mssql':
+        return this.orderByRaw('NEWID()')
+      case 'oracledb':
+        return this.orderByRaw('dbms_random.value')
+      default:
+        throw new Error(`Cannot order by random for the given dialect ${this.client.dialect.name}`)
+    }
+  }
+
+  /**
    * Executes the query
    */
   async exec(): Promise<any> {

--- a/src/database/query_builder/database.ts
+++ b/src/database/query_builder/database.ts
@@ -70,7 +70,7 @@ export class DatabaseQueryBuilder extends Chainable implements DatabaseQueryBuil
     public client: QueryClientContract,
     public keysResolver?: (columnName: string) => string
   ) {
-    super(builder, queryCallback, keysResolver)
+    super(builder, queryCallback, client.dialect, keysResolver)
     this.debugQueries = this.client.debug
   }
 
@@ -279,27 +279,6 @@ export class DatabaseQueryBuilder extends Chainable implements DatabaseQueryBuil
   useTransaction(transaction: TransactionClientContract): this {
     this.knexQuery.transacting(transaction.knexClient)
     return this
-  }
-
-  /**
-   * Order results by random value.
-   */
-  orderByRandom(seed = '') {
-    switch (this.client.dialect.name) {
-      case 'sqlite3':
-      case 'better-sqlite3':
-      case 'postgres':
-      case 'redshift':
-        return this.orderByRaw('RANDOM()')
-      case 'mysql':
-        return this.orderByRaw(`RAND(${seed})`)
-      case 'mssql':
-        return this.orderByRaw('NEWID()')
-      case 'oracledb':
-        return this.orderByRaw('dbms_random.value')
-      default:
-        throw new Error(`Cannot order by random for the given dialect ${this.client.dialect.name}`)
-    }
   }
 
   /**

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -104,3 +104,9 @@ export const E_UNSUPPORTED_CLIENT = createError<[string]>(
   'E_UNSUPPORTED_CLIENT',
   500
 )
+
+export const E_INVALID_ORDER_BY_RANDOM_SEED = createError(
+  '".orderByRandom" expects seed to be a finite number',
+  'E_INVALID_ORDER_BY_RANDOM_SEED',
+  500
+)

--- a/src/orm/query_builder/index.ts
+++ b/src/orm/query_builder/index.ts
@@ -650,6 +650,27 @@ export class ModelQueryBuilder
   }
 
   /**
+   * Order results by random value.
+   */
+  orderByRandom(seed = '') {
+    switch (this.client.dialect.name) {
+      case 'sqlite3':
+      case 'better-sqlite3':
+      case 'postgres':
+      case 'redshift':
+        return this.orderByRaw('RANDOM()')
+      case 'mysql':
+        return this.orderByRaw(`RAND(${seed})`)
+      case 'mssql':
+        return this.orderByRaw('NEWID()')
+      case 'oracledb':
+        return this.orderByRaw('dbms_random.value')
+      default:
+        throw new Error(`Cannot order by random for the given dialect ${this.client.dialect.name}`)
+    }
+  }
+
+  /**
    * Define a relationship to be preloaded
    */
   preload(relationName: any, userCallback?: any): this {

--- a/src/orm/query_builder/index.ts
+++ b/src/orm/query_builder/index.ts
@@ -150,6 +150,7 @@ export class ModelQueryBuilder
     super(
       builder,
       customFn,
+      client.dialect,
       model.$keys.attributesToColumns.resolve.bind(model.$keys.attributesToColumns)
     )
 
@@ -647,27 +648,6 @@ export class ModelQueryBuilder
    */
   andDoesntHave(relationName: any, operator?: string, value?: any): this {
     return this.addWhereHas(relationName, 'not', operator, value)
-  }
-
-  /**
-   * Order results by random value.
-   */
-  orderByRandom(seed = '') {
-    switch (this.client.dialect.name) {
-      case 'sqlite3':
-      case 'better-sqlite3':
-      case 'postgres':
-      case 'redshift':
-        return this.orderByRaw('RANDOM()')
-      case 'mysql':
-        return this.orderByRaw(`RAND(${seed})`)
-      case 'mssql':
-        return this.orderByRaw('NEWID()')
-      case 'oracledb':
-        return this.orderByRaw('dbms_random.value')
-      default:
-        throw new Error(`Cannot order by random for the given dialect ${this.client.dialect.name}`)
-    }
   }
 
   /**

--- a/src/types/querybuilder.ts
+++ b/src/types/querybuilder.ts
@@ -651,6 +651,7 @@ export interface ChainableContract {
 
   orderBy: OrderBy<this>
   orderByRaw: RawQueryFn<this>
+  orderByRandom: (seed?: string) => this
 
   union: Union<this>
   unionAll: UnionAll<this>

--- a/src/types/querybuilder.ts
+++ b/src/types/querybuilder.ts
@@ -651,7 +651,7 @@ export interface ChainableContract {
 
   orderBy: OrderBy<this>
   orderByRaw: RawQueryFn<this>
-  orderByRandom: (seed?: string) => this
+  orderByRandom: (seed?: number) => this
 
   union: Union<this>
   unionAll: UnionAll<this>

--- a/test/database/query_builder.spec.ts
+++ b/test/database/query_builder.spec.ts
@@ -5439,6 +5439,49 @@ test.group('Query Builder | orderByRaw', (group) => {
   })
 })
 
+test.group('Query Builder | orderByRandom', (group) => {
+  group.setup(async () => {
+    await setup()
+  })
+
+  group.teardown(async () => {
+    await cleanup()
+  })
+
+  group.each.teardown(async () => {
+    await resetTables()
+  })
+
+  test('define order by random value', async ({ assert }) => {
+    const connection = new Connection('primary', getConfig(), logger)
+    connection.connect()
+
+    const db = getQueryBuilder(getQueryClient(connection))
+    await getInsertBuilder(getQueryClient(connection))
+      .table('users')
+      .multiInsert([
+        {
+          username: 'virk',
+          email: 'virk@adonisjs.com',
+        },
+        {
+          username: 'romain',
+          email: 'romain@adonisjs.com',
+        },
+        {
+          username: 'nikk',
+          email: 'nikk@adonisjs.com',
+        },
+      ])
+
+    const users = await db.from('users').orderByRandom()
+    const users2 = await db.from('users').orderByRandom()
+
+    assert.notEqual(users[0].id, users2[0].id)
+    await connection.disconnect()
+  }).retry(3)
+})
+
 test.group('Query Builder | offset', (group) => {
   group.setup(async () => {
     await setup()

--- a/test/database/query_builder.spec.ts
+++ b/test/database/query_builder.spec.ts
@@ -5474,12 +5474,18 @@ test.group('Query Builder | orderByRandom', (group) => {
         },
       ])
 
-    const users = await db.from('users').orderByRandom()
-    const users2 = await db.from('users').orderByRandom()
+    const users = []
 
-    assert.notEqual(users[0].id, users2[0].id)
+    for (let i = 0; i < 10; i++) {
+      const result = await db.from('users').orderByRandom()
+
+      users.push(result.map((user) => user.id))
+    }
+
+    // TODO: Check which assertion is better to use
+
     await connection.disconnect()
-  }).retry(3)
+  })
 })
 
 test.group('Query Builder | offset', (group) => {

--- a/test/database/query_builder.spec.ts
+++ b/test/database/query_builder.spec.ts
@@ -5474,15 +5474,15 @@ test.group('Query Builder | orderByRandom', (group) => {
         },
       ])
 
-    const users = []
+    const userResults: number[][] = []
 
     for (let i = 0; i < 10; i++) {
       const result = await db.from('users').orderByRandom()
 
-      users.push(result.map((user) => user.id))
+      userResults.push(result.map((user) => user.id))
     }
 
-    // TODO: Check which assertion is better to use
+    assert.isTrue(userResults.some((users) => userResults[0] !== users))
 
     await connection.disconnect()
   })

--- a/test/database/query_builder.spec.ts
+++ b/test/database/query_builder.spec.ts
@@ -5457,36 +5457,59 @@ test.group('Query Builder | orderByRandom', (group) => {
     connection.connect()
 
     const client = getQueryClient(connection)
-    await getInsertBuilder(client)
-      .table('users')
-      .multiInsert([
-        {
-          username: 'virk',
-          email: 'virk@adonisjs.com',
-        },
-        {
-          username: 'romain',
-          email: 'romain@adonisjs.com',
-        },
-        {
-          username: 'nikk',
-          email: 'nikk@adonisjs.com',
-        },
-      ])
+    const { sql, bindings } = getQueryBuilder(client).from('users').orderByRandom().toSQL()
+    const normalizedSql = sql.toLowerCase()
 
-    const userResults: number[][] = []
-
-    for (let i = 0; i < 10; i++) {
-      const result = await getQueryBuilder(client).from('users').orderByRandom()
-
-      userResults.push(result.map((user) => user.id))
+    switch (client.dialect.name) {
+      case 'sqlite3':
+      case 'better-sqlite3':
+      case 'postgres':
+      case 'redshift':
+        assert.include(normalizedSql, 'random()')
+        break
+      case 'mysql':
+        assert.include(normalizedSql, 'rand()')
+        break
+      case 'mssql':
+        assert.include(normalizedSql, 'newid()')
+        break
+      case 'oracledb':
+        assert.include(normalizedSql, 'dbms_random.value')
+        break
+      default:
+        throw new Error(`Unsupported dialect "${client.dialect.name}" for test assertions`)
     }
 
-    const firstResult = userResults[0].join(',')
-    assert.isTrue(userResults.some((users) => users.join(',') !== firstResult))
+    assert.deepEqual(bindings, [])
 
     await connection.disconnect()
   })
+
+  test('define order by random value with seed', async ({ assert }) => {
+    const connection = new Connection('primary', getConfig(), logger)
+    connection.connect()
+
+    const db = getQueryBuilder(getQueryClient(connection))
+    const { sql, bindings } = db.from('users').orderByRandom(10).toSQL()
+    assert.include(sql.toLowerCase(), 'rand(?)')
+    assert.deepEqual(bindings, [10])
+
+    await connection.disconnect()
+  }).skip(!['mysql', 'mysql_legacy'].includes(process.env.DB!), 'Only for MySQL')
+
+  test('reject non numeric seed for orderByRandom', async ({ assert }) => {
+    const connection = new Connection('primary', getConfig(), logger)
+    connection.connect()
+
+    const db = getQueryBuilder(getQueryClient(connection))
+
+    assert.throws(
+      () => db.from('users').orderByRandom('0) DESC; --' as any),
+      '".orderByRandom" expects seed to be a finite number'
+    )
+
+    await connection.disconnect()
+  }).skip(!['mysql', 'mysql_legacy'].includes(process.env.DB!), 'Only for MySQL')
 })
 
 test.group('Query Builder | offset', (group) => {

--- a/test/database/query_builder.spec.ts
+++ b/test/database/query_builder.spec.ts
@@ -5456,8 +5456,8 @@ test.group('Query Builder | orderByRandom', (group) => {
     const connection = new Connection('primary', getConfig(), logger)
     connection.connect()
 
-    const db = getQueryBuilder(getQueryClient(connection))
-    await getInsertBuilder(getQueryClient(connection))
+    const client = getQueryClient(connection)
+    await getInsertBuilder(client)
       .table('users')
       .multiInsert([
         {
@@ -5477,12 +5477,13 @@ test.group('Query Builder | orderByRandom', (group) => {
     const userResults: number[][] = []
 
     for (let i = 0; i < 10; i++) {
-      const result = await db.from('users').orderByRandom()
+      const result = await getQueryBuilder(client).from('users').orderByRandom()
 
       userResults.push(result.map((user) => user.id))
     }
 
-    assert.isTrue(userResults.some((users) => userResults[0] !== users))
+    const firstResult = userResults[0].join(',')
+    assert.isTrue(userResults.some((users) => users.join(',') !== firstResult))
 
     await connection.disconnect()
   })


### PR DESCRIPTION
Hey there! 👋🏻 

This PR adds a `orderByRandom` method to retrieve records in a random order.
It defines the right keyword for each dialect.

The test may be flaky, I have set it up to run 3 times in case it fails.

A `seed` can be pass when using MySQL (same as Laravel implementation).