### PR TITLE
feat(base_model): add clause variant to findBy method 

### DIFF
--- a/src/orm/base_model/index.ts
+++ b/src/orm/base_model/index.ts
@@ -703,7 +703,21 @@ class BaseModelImpl implements LucidRow {
   /**
    * Find model instance using a key/value pair
    */
-  static async findBy(key: string, value: any, options?: ModelAdapterOptions) {
+  // @ts-expect-error - Return type should be inferred when used in a model
+  static findBy(clause: Record<string, unknown>, options?: ModelAdapterOptions)
+  // @ts-expect-error - Return type should be inferred when used in a model
+  static findBy(key: string, value: any, options?: ModelAdapterOptions)
+  static async findBy(
+    key: string | Record<string, unknown>,
+    value?: any | ModelAdapterOptions,
+    options?: ModelAdapterOptions
+  ) {
+    if (typeof key === 'object') {
+      return this.query(value as ModelAdapterOptions)
+        .where(key)
+        .first()
+    }
+
     if (value === undefined) {
       throw new Exception('"findBy" expects a value. Received undefined')
     }
@@ -714,10 +728,25 @@ class BaseModelImpl implements LucidRow {
   /**
    * Find model instance using a key/value pair
    */
-  static async findByOrFail(key: string, value: any, options?: ModelAdapterOptions) {
+  // @ts-expect-error - Return type should be inferred when used in a model
+  static findByOrFail(clause: Record<string, unknown>, options?: ModelAdapterOptions)
+  // @ts-expect-error - Return type should be inferred when used in a model
+  static findByOrFail(key: string, value: any, options?: ModelAdapterOptions)
+  static async findByOrFail(
+    key: string | Record<string, unknown>,
+    value?: any | ModelAdapterOptions,
+    options?: ModelAdapterOptions
+  ) {
+    if (typeof key === 'object') {
+      return this.query(value as ModelAdapterOptions)
+        .where(key)
+        .firstOrFail()
+    }
+
     if (value === undefined) {
       throw new Exception('"findByOrFail" expects a value. Received undefined')
     }
+
     return this.query(options).where(key, value).firstOrFail()
   }
 

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -976,6 +976,15 @@ export interface LucidModel {
   ): Promise<InstanceType<T>>
 
   /**
+   * Find one using a clause
+   */
+  findBy<T extends LucidModel>(
+    this: T,
+    clause: Record<string, unknown>,
+    options?: ModelAdapterOptions
+  ): Promise<null | InstanceType<T>>
+
+  /**
    * Find one using a key-value pair
    */
   findBy<T extends LucidModel>(
@@ -984,6 +993,15 @@ export interface LucidModel {
     value: any,
     options?: ModelAdapterOptions
   ): Promise<null | InstanceType<T>>
+
+  /**
+   * Find one using a clause or fail
+   */
+  findByOrFail<T extends LucidModel>(
+    this: T,
+    clause: Record<string, unknown>,
+    options?: ModelAdapterOptions
+  ): Promise<InstanceType<T>>
 
   /**
    * Find one using a key-value pair or fail
@@ -996,7 +1014,7 @@ export interface LucidModel {
   ): Promise<InstanceType<T>>
 
   /**
-   * Find multiple models instance using a key/value pair
+   * Find multiple models instance using a clause
    */
   findManyBy<T extends LucidModel>(
     clause: Record<string, unknown>,

--- a/test/orm/base_model.spec.ts
+++ b/test/orm/base_model.spec.ts
@@ -3780,6 +3780,64 @@ test.group('Base Model | fetch', (group) => {
     assert.equal(users[1].$primaryKeyValue, 1)
   })
 
+  test('findBy using a clause', async ({ fs, assert }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+
+    const BaseModel = getBaseModel(adapter)
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare username: string
+
+      @column()
+      declare email: string
+    }
+
+    await db
+      .insertQuery()
+      .table('users')
+      .multiInsert([{ username: 'virk' }, { username: 'nikk' }])
+
+    const user = await User.findBy({ username: 'virk' })
+    assert.isDefined(user)
+    assert.equal(user?.username, 'virk')
+  })
+
+  test('findBy using a key/value pair', async ({ fs, assert }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+
+    const BaseModel = getBaseModel(adapter)
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare username: string
+
+      @column()
+      declare email: string
+    }
+
+    await db
+      .insertQuery()
+      .table('users')
+      .multiInsert([{ username: 'virk' }, { username: 'nikk' }])
+
+    const user = await User.findBy('username', 'virk')
+    assert.isDefined(user)
+    assert.equal(user?.username, 'virk')
+  })
+
   test('find many using a clause', async ({ fs, assert }) => {
     const app = new AppFactory().create(fs.baseUrl, () => {})
     await app.init()


### PR DESCRIPTION
Hey! 👋🏻 

Same as https://github.com/adonisjs/lucid/pull/1010.

Adding the `clause` variant to `findBy` and `findByOrFail`.