### PR TITLE
fix(migrator): step option

### DIFF
--- a/src/migration/runner.ts
+++ b/src/migration/runner.ts
@@ -482,7 +482,7 @@ export class MigrationRunner extends EventEmitter {
     const collected = await this.migrationSource.getMigrations()
 
     if (step === undefined || step <= 0) {
-      step = 0
+      step = collected.length
     } else {
       batch = (await this.getLatestBatch()) - 1
     }
@@ -505,7 +505,8 @@ export class MigrationRunner extends EventEmitter {
       }
     })
 
-    const filesToMigrate = Object.keys(this.migratedFiles).slice(-step)
+    this.migratedFiles = Object.fromEntries(Object.entries(this.migratedFiles).slice(0, step))
+    const filesToMigrate = Object.keys(this.migratedFiles)
     for (let name of filesToMigrate) {
       await this.executeMigration(this.migratedFiles[name].file)
     }

--- a/test/migrations/migrator.spec.ts
+++ b/test/migrations/migrator.spec.ts
@@ -704,17 +704,12 @@ test.group('Migrator', (group) => {
     })
 
     assert.lengthOf(migrated, 1)
-    assert.isFalse(hasUsersTable)
-    assert.isTrue(hasAccountsTable)
+    assert.isTrue(hasUsersTable)
+    assert.isFalse(hasAccountsTable)
     assert.deepEqual(migratedFiles, [
       {
-        status: 'pending',
-        file: 'database/migrations/1_accounts_v6',
-        queries: [],
-      },
-      {
         status: 'completed',
-        file: 'database/migrations/0_users_v6',
+        file: 'database/migrations/1_accounts_v6',
         queries: [],
       },
     ])


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)

### 📚 Description

- Rollback the last migrations instead of rollback the firsts (that's make more sense)

- Patch a little display bug due to the non-adaptation of `this.migratedFiles` at the step option

bug:
![DeepinScreenshot_select-area_20240403171308](https://github.com/adonisjs/lucid/assets/57860498/162b8aeb-286a-4b2f-a92e-923db0449d62)

now:
![DeepinScreenshot_select-area_20240403171553](https://github.com/adonisjs/lucid/assets/57860498/a5f0e5ff-4b20-4ba6-b25f-667789447576)

