### PR TITLE
replaced Promise.all with for loop

### DIFF
--- a/commands/db_truncate.ts
+++ b/commands/db_truncate.ts
@@ -59,7 +59,9 @@ export default class DbTruncate extends BaseCommand {
     let tables = await client.getAllTables(schemas)
     tables = tables.filter((table) => !['adonis_schema', 'adonis_schema_versions'].includes(table))
 
-    await Promise.all(tables.map((table) => client.truncate(table, true)))
+    for (const table of tables) {
+      await client.truncate(table, true)
+    }
     this.logger.success('Truncated tables successfully')
   }
 


### PR DESCRIPTION
the `Promise.all` creates the  deadlock causing the command `db:truncate` to throw error deadlock detected

<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

 #1027 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Replaced `Promise.all` with `for loop` in `db_truncate.ts` resolves #1027 

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
