### PR TITLE
Clone the preloader when cloning the query builder

### DIFF
--- a/src/orm/preloader/index.ts
+++ b/src/orm/preloader/index.ts
@@ -146,6 +146,19 @@ export class Preloader implements PreloaderContract<LucidRow> {
   }
 
   /**
+   * Clone preloader instance
+   */
+  clone() {
+    const clone = new Preloader(this.model)
+
+    clone.preloads = Object.assign({}, this.preloads)
+    clone.sideloaded = Object.assign({}, this.sideloaded)
+    clone.debugQueries = this.debugQueries
+
+    return clone
+  }
+
+  /**
    * Process of all the preloaded relationships for a single parent
    */
   async processAllForOne(parent: LucidRow, client: QueryClientContract) {

--- a/src/orm/query_builder/index.ts
+++ b/src/orm/query_builder/index.ts
@@ -357,6 +357,7 @@ export class ModelQueryBuilder
     const clonedQuery = new ModelQueryBuilder(this.knexQuery.clone(), this.model, this.client)
     this.applyQueryFlags(clonedQuery)
 
+    clonedQuery.usePreloader(this.preloader.clone())
     clonedQuery.sideloaded = Object.assign({}, this.sideloaded)
     clonedQuery.debug(this.debugQueries)
     clonedQuery.reporterData(this.customReporterData)

--- a/src/types/relations.ts
+++ b/src/types/relations.ts
@@ -1070,4 +1070,5 @@ export interface PreloaderContract<Model extends LucidRow> {
 
   debug(debug: boolean): this
   sideload(values: ModelObject): this
+  clone(): PreloaderContract<Model>
 }

--- a/test/orm/model_query_builder.spec.ts
+++ b/test/orm/model_query_builder.spec.ts
@@ -10,7 +10,7 @@
 import { test } from '@japa/runner'
 import { AppFactory } from '@adonisjs/core/factories/app'
 
-import { column } from '../../src/orm/decorators/index.js'
+import { column, hasMany } from '../../src/orm/decorators/index.js'
 import { scope } from '../../src/orm/base_model/index.js'
 import { ModelQueryBuilder } from '../../src/orm/query_builder/index.js'
 import {
@@ -21,6 +21,7 @@ import {
   resetTables,
   getBaseModel,
 } from '../../test-helpers/index.js'
+import type { HasMany } from '../../src/types/relations.js'
 
 test.group('Model query builder', (group) => {
   group.setup(async () => {
@@ -343,6 +344,48 @@ test.group('Model query builder', (group) => {
     const query = User.query().sideload({ username: 'virk' })
     const user = await query.clone().firstOrFail()
     assert.deepEqual(user.$sideloaded, { username: 'virk' })
+  })
+
+  test('clone query builder with preload', async ({ fs, assert }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    class Post extends BaseModel {
+      @column()
+      declare id: number
+
+      @column()
+      declare userId: number
+
+      @column()
+      declare title: string
+    }
+    Post.boot()
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare username: string
+
+      @hasMany(() => Post)
+      declare posts: HasMany<typeof Post>
+    }
+    User.boot()
+
+    const user = await User.create({ username: 'virk' })
+    const posts = await user
+      .related('posts')
+      .createMany([{ title: 'Adonis 101' }, { title: 'Lucid 101' }])
+
+    const query = User.query().preload('posts')
+    const clone = await query.clone().firstOrFail()
+    assert.isArray(clone.posts)
+    assert.equal(clone.posts.length, posts.length)
   })
 
   test('apply scopes', async ({ fs, assert }) => {

--- a/test/orm/model_query_builder.spec.ts
+++ b/test/orm/model_query_builder.spec.ts
@@ -23,7 +23,6 @@ import {
 } from '../../test-helpers/index.js'
 import type { HasMany } from '../../src/types/relations.js'
 
-
 test.group('Model query builder', (group) => {
   group.setup(async () => {
     await setup()


### PR DESCRIPTION
Hey there! 👋🏻 

Follow up on this failing test: https://github.com/adonisjs/lucid/pull/1041


This PR adds a method to the `Preloader` class to allow cloning. We use this method when cloning the query to also clone the preloader.

Closes https://github.com/adonisjs/lucid/pull/1041
Closes https://github.com/adonisjs/lucid/issues/1033