### PR TITLE
feat(orm): add loadOnce

### DIFF
--- a/src/orm/base_model/index.ts
+++ b/src/orm/base_model/index.ts
@@ -1803,6 +1803,22 @@ class BaseModelImpl implements LucidRow {
   }
 
   /**
+   * Load relationships onto the instance, but only if they are not
+   * already preloaded
+   */
+  async loadOnce(relationName: any) {
+    this.ensureIsntDeleted()
+
+    if (!this.$isPersisted) {
+      throw new Exception('Cannot lazy load relationship for an unpersisted model instance')
+    }
+
+    if (!this.$preloaded[relationName]) {
+      return this.load(relationName)
+    }
+  }
+
+  /**
    * @deprecated
    */
   async preload(relationName: any, callback?: any) {

--- a/src/orm/base_model/index.ts
+++ b/src/orm/base_model/index.ts
@@ -1807,12 +1807,6 @@ class BaseModelImpl implements LucidRow {
    * already preloaded
    */
   async loadOnce(relationName: any) {
-    this.ensureIsntDeleted()
-
-    if (!this.$isPersisted) {
-      throw new Exception('Cannot lazy load relationship for an unpersisted model instance')
-    }
-
     if (!this.$preloaded[relationName]) {
       return this.load(relationName)
     }

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -36,6 +36,7 @@ import {
   WhereHas,
   WithAggregate,
   WithCount,
+  PreloadWithoutCallback,
 } from './relations.js'
 
 /**
@@ -313,6 +314,9 @@ export type ModelAssignOptions = ModelAdapterOptions & {
 export interface LucidRowPreload<Model extends LucidRow> extends Preload<Model, Promise<void>> {
   (callback: (preloader: PreloaderContract<Model>) => void): Promise<void>
 }
+
+export interface LucidRowPreloadOnce<Model extends LucidRow>
+  extends PreloadWithoutCallback<Model, Promise<void>> {}
 
 export interface LucidRowAggregate<Model extends LucidRow> extends Preload<Model, Promise<void>> {
   (callback: (preloader: PreloaderContract<Model>) => void): Promise<void>
@@ -642,6 +646,12 @@ export interface LucidRow {
    * Load relationships onto the instance
    */
   load: LucidRowPreload<this>
+
+  /**
+   * Load relationships onto the instance, but only if they are not
+   * already preloaded
+   */
+  loadOnce: LucidRowPreloadOnce<this>
 
   /**
    * Alias for "load"

--- a/src/types/relations.ts
+++ b/src/types/relations.ts
@@ -1058,6 +1058,10 @@ export interface Preload<Model extends LucidRow, Builder> {
   ): Builder
 }
 
+export interface PreloadWithoutCallback<Model extends LucidRow, Builder> {
+  <Name extends ExtractModelRelations<Model>>(relation: Name): Builder
+}
+
 /**
  * Shape of the preloader to preload relationships
  */


### PR DESCRIPTION
Hey there! 👋🏻 

This PR adds the `loadOnce` helper.

This helper is particularly useful when you're unsure whether a relation is already loaded and want to avoid unnecessary database calls if the data is already in memory.

Currently, `loadOnce` does not accept a callback like `load` does, as it's designed to avoid altering the query.

If you need to load nested relationships, you can do so like this:

```ts
await user.loadOnce('profile')
await user.profile.loadOnce('country')
// ...
```