### PR TITLE
Add missing instanceName to the MssqlConnectionNode type

### DIFF
--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -527,6 +527,7 @@ type MssqlConnectionNode = {
     appName?: string
     abortTransactionOnError?: boolean
     trustedConnection?: boolean
+    instanceName?: string
     enableArithAbort?: boolean
     isolationLevel?:
       | 'READ_UNCOMMITTED'


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue
https://github.com/adonisjs/lucid/issues/916

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Add missing instanceName option in the MssqlConnectionNode type, which is required to setup if MSSQL is running using instance.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
