### PR TITLE
fix: skip undefined values in merge

### DIFF
--- a/src/orm/base_model/index.ts
+++ b/src/orm/base_model/index.ts
@@ -1707,61 +1707,67 @@ class BaseModelImpl implements LucidRow {
   merge(values: any, allowExtraProperties: boolean = false): this {
     const Model = this.constructor as typeof BaseModel
 
+    if (!isObject(values)) {
+      return this
+    }
+
     /**
      * Merge values with the attributes
      */
-    if (isObject(values)) {
-      Object.keys(values).forEach((key) => {
-        const value = values[key]
+    Object.keys(values).forEach((key) => {
+      const value = values[key]
 
-        /**
-         * Set as column
-         */
-        if (Model.$hasColumn(key)) {
-          ;(this as any)[key] = value
-          return
-        }
+      if (value === undefined) {
+        return
+      }
 
-        /**
-         * Resolve the attribute name from the column names. Since people
-         * usually define the column names directly as well by
-         * accepting them directly from the API.
-         */
-        const attributeName = Model.$keys.columnsToAttributes.get(key)
-        if (attributeName) {
-          ;(this as any)[attributeName] = value
-          return
-        }
+      /**
+       * Set as column
+       */
+      if (Model.$hasColumn(key)) {
+        ;(this as any)[key] = value
+        return
+      }
 
-        /**
-         * If key is defined as a relation, then ignore it, since one
-         * must pass a qualified model to `this.$setRelated()`
-         */
-        if (Model.$relationsDefinitions.has(key)) {
-          return
-        }
+      /**
+       * Resolve the attribute name from the column names. Since people
+       * usually define the column names directly as well by
+       * accepting them directly from the API.
+       */
+      const attributeName = Model.$keys.columnsToAttributes.get(key)
+      if (attributeName) {
+        ;(this as any)[attributeName] = value
+        return
+      }
 
-        /**
-         * If the property already exists on the model, then set it
-         * as it is vs defining it as an extra property
-         */
-        if (this.hasOwnProperty(key)) {
-          ;(this as any)[key] = value
-          return
-        }
+      /**
+       * If key is defined as a relation, then ignore it, since one
+       * must pass a qualified model to `this.$setRelated()`
+       */
+      if (Model.$relationsDefinitions.has(key)) {
+        return
+      }
 
-        /**
-         * Raise error when not instructed to ignore non-existing properties.
-         */
-        if (!allowExtraProperties) {
-          throw new Error(
-            `Cannot define "${key}" on "${Model.name}" model, since it is not defined as a model property`
-          )
-        }
+      /**
+       * If the property already exists on the model, then set it
+       * as it is vs defining it as an extra property
+       */
+      if (this.hasOwnProperty(key)) {
+        ;(this as any)[key] = value
+        return
+      }
 
-        this.$extras[key] = value
-      })
-    }
+      /**
+       * Raise error when not instructed to ignore non-existing properties.
+       */
+      if (!allowExtraProperties) {
+        throw new Error(
+          `Cannot define "${key}" on "${Model.name}" model, since it is not defined as a model property`
+        )
+      }
+
+      this.$extras[key] = value
+    })
 
     return this
   }

--- a/test/orm/base_model.spec.ts
+++ b/test/orm/base_model.spec.ts
@@ -3006,6 +3006,37 @@ test.group('BaseModel | fill/merge', (group) => {
     assert.deepEqual(user.$attributes, { username: 'virk', age: 22 })
     assert.equal(user.foo, 'bar')
   })
+
+  test('ensure merge skips undefined values', async ({ fs, assert }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const adapter = new FakeAdapter()
+
+    const BaseModel = getBaseModel(adapter)
+
+    class User extends BaseModel {
+      @column()
+      declare username: string
+
+      @column()
+      declare email: string
+    }
+
+    const email = 'virk@adonisjs.com'
+
+    const user = new User()
+    user.merge({
+      username: 'virk',
+      email,
+    })
+
+    user.merge({
+      username: 'nikk',
+      email: undefined,
+    })
+
+    assert.equal(user.email, email)
+  })
 })
 
 test.group('Base | apdater', (group) => {


### PR DESCRIPTION
### 🔗 Linked issue

#1066 

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

Resolves #1066 .

PS: It seems like a lot of changes in the PR but I just moved the condition to top:
```ts
if (!isObject(values)) {
  return this
}
```
so it's more readable.

And added:
```ts
if (value === undefined) {
  return
}
```

### 📝 Checklist

- [x] I have linked an issue or discussion.
