### PR TITLE
feat: add isDirty method

### DIFF
--- a/src/orm/base_model/index.ts
+++ b/src/orm/base_model/index.ts
@@ -1767,6 +1767,19 @@ class BaseModelImpl implements LucidRow {
   }
 
   /**
+   * Returns whether any of the fields have been modified
+   */
+  isDirty(fields?: any): boolean {
+    const keys = Array.isArray(fields) ? fields : fields ? [fields] : []
+
+    if (keys.length === 0) {
+      return this.$isDirty
+    }
+
+    return keys.some((key) => key in this.$dirty)
+  }
+
+  /**
    * Enable force update even when no attributes
    * are dirty
    */

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -613,6 +613,8 @@ export interface LucidRow {
   fill(value: Partial<ModelAttributes<this>>, allowExtraProperties?: boolean): this
   merge(value: Partial<ModelAttributes<this>>, allowExtraProperties?: boolean): this
 
+  isDirty(fields?: keyof ModelAttributes<this> | (keyof ModelAttributes<this>)[]): boolean
+
   /**
    * Enable force update even when no attributes
    * are dirty

--- a/test/orm/base_model.spec.ts
+++ b/test/orm/base_model.spec.ts
@@ -813,6 +813,35 @@ test.group('Base Model | dirty', (group) => {
     user.location.isDirty = true
     assert.deepEqual(user.$dirty, { location: { state: 'goa', country: 'India', isDirty: true } })
   })
+
+  test('isDirty returns whether field is dirty', async ({ fs, assert }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+
+    const BaseModel = getBaseModel(adapter)
+
+    class User extends BaseModel {
+      @column()
+      declare username: string
+
+      @column()
+      declare email: string
+    }
+
+    const user = new User()
+
+    assert.isFalse(user.isDirty())
+    assert.isFalse(user.isDirty('username'))
+
+    user.username = 'virk'
+
+    assert.isTrue(user.isDirty())
+    assert.isTrue(user.isDirty('username'))
+    assert.isFalse(user.isDirty('email'))
+    assert.isTrue(user.isDirty(['username', 'email']))
+  })
 })
 
 test.group('Base Model | persist', (group) => {


### PR DESCRIPTION
### ❓ Type of change

- [x] 👌 Enhancement (improving an existing functionality like performance)

### 📚 Description

This PR adds `isDirty(fields)` method for easier checking whether field has changed. Which could be replacement for `.$isDirty`

```ts
// isDirty(fields?: keyof ModelAttributes<this> | (keyof ModelAttributes<this>)[]): boolean

const user = new User()
user.username = 'test'

user.isDirty('username') // true
user.isDirty(['username']) // true
user.isDirty() // true
```

Which is easier to type and type-safe vs `'username' in user.$dirty` and more convenient when checking multiple fields, if any is dirty.
