### PR TITLE
Model merge attributes fix

### DIFF
--- a/src/orm/base_model/index.ts
+++ b/src/orm/base_model/index.ts
@@ -1742,6 +1742,11 @@ class BaseModelImpl implements LucidRow {
      * Merge values with the attributes
      */
     if (isObject(values)) {
+
+      if(values instanceof BaseModel){
+        values = values.$attributes
+      }
+      
       Object.keys(values).forEach((key) => {
         const value = values[key]
 

--- a/test/orm/base_model.spec.ts
+++ b/test/orm/base_model.spec.ts
@@ -601,7 +601,7 @@ test.group('Base Model | getter-setters', (group) => {
     assert.equal(mergedUser.email, 'virk@adonisjs.com')
   })
 
-  test('merge mutiple model instances', async ({ fs, assert }) => {
+  test('merge multiple model instances', async ({ fs, assert }) => {
     const app = new AppFactory().create(fs.baseUrl, () => {})
     await app.init()
     const db = getDb()


### PR DESCRIPTION
Type: Bug fix (a non-breaking change that fixes an issue)
Fixes: #1076 

# Overview

The merge method was not correctly merging attributes from one model into an existing model. 

# Issue

For example, we can merge attributes from a model into an existing model, like so:

```ts
import User from '#models/user' 

// Create the current user
const currentUser = new User()
currentUser.username = 'virk'
currentUser.email = 'virk@adonisjs.com'
await currentUser.save()

// Create new user instance
const user = new User()
user.username = 'nikk'

// Merge the new user instance into the current user
const mergedUser = currentUser.merge(user)
```

However, if we try to use `updateOrCreate` or `updateOrCreateMany`:

```ts
// Run 1
await User.updateOrCreateMany('email', [
  new User().fill({ username: 'nikk', email: 'nikk@adonisjs.com' }),
  new User().fill({ username: 'virk', email: 'virk@adonisjs.com' }),
])

// Run 2
await User.updateOrCreateMany('email', [
  new User().fill({ username: 'nikk-new', email: 'nikk@adonisjs.com' }),
  new User().fill({ username: 'virk-new', email: 'virk@adonisjs.com' }),
])
```

It tries to insert the users that already exist. 

# Reason

The `updateOrCreateMany` passes the unique keys, payload, and existing rows in the database to the `newUpIfMissing` method.  

https://github.com/adonisjs/lucid/blob/ca67d8d4b5c8cd036e8396b47c1eaffb4c71ec04/src/orm/base_model/index.ts#L1052-L1099

The `newUpIfMissing` method will try to match each payload to an existing row. If it finds a match, it merges the values. If not, it runs `newUpWithOptions`. 

https://github.com/adonisjs/lucid/blob/ca67d8d4b5c8cd036e8396b47c1eaffb4c71ec04/src/orm/base_model/index.ts#L202-L239

On "Run 2", in the above example, the `newUpIfMissing` method correctly finds the existing row and will try to merge it:

https://github.com/adonisjs/lucid/blob/ca67d8d4b5c8cd036e8396b47c1eaffb4c71ec04/src/orm/base_model/index.ts#L229

But the merge will instead replace the existing row with the `rowObject`. 

This will force Lucid to always insert a new row when it tries to save it:

https://github.com/adonisjs/lucid/blob/ca67d8d4b5c8cd036e8396b47c1eaffb4c71ec04/src/orm/base_model/index.ts#L1094

# Fix

I found that if we check if the object is an instance of a model, we can merge just the attributes:

https://github.com/adonisjs/lucid/blob/4320d1c5797368c771b6dbf4d20afd4ac0a10cf0/src/orm/base_model/index.ts#L1746-L1748