### PR TITLE
feat(preloader): add preloadOnce to preload a relationship only once

### DIFF
--- a/src/orm/preloader/index.ts
+++ b/src/orm/preloader/index.ts
@@ -129,6 +129,18 @@ export class Preloader implements PreloaderContract<LucidRow> {
   }
 
   /**
+   * Define a relationship to preload, but only if they are not
+   * already preloaded
+   */
+  preloadOnce(name: any): this {
+    if (!this.preloads[name]) {
+      return this.load(name)
+    }
+
+    return this
+  }
+
+  /**
    * Toggle query debugging
    */
   debug(debug: boolean) {

--- a/src/orm/query_builder/index.ts
+++ b/src/orm/query_builder/index.ts
@@ -653,6 +653,15 @@ export class ModelQueryBuilder
   }
 
   /**
+   * Define a relationship to preload, but only if they are not
+   * already preloaded
+   */
+  preloadOnce(relationName: any): this {
+    this.preloader.preloadOnce(relationName)
+    return this
+  }
+
+  /**
    * Perform update by incrementing value for a given column. Increments
    * can be clubbed with `update` as well
    */

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -42,6 +42,7 @@ import {
   WithAggregate,
   WithCount,
   PreloadWithoutCallback,
+  PreloadOnce,
 } from './relations.js'
 
 /**
@@ -481,6 +482,7 @@ export interface ModelQueryBuilderContract<Model extends LucidModel, Result = In
    * Define relationships to be preloaded
    */
   preload: Preload<InstanceType<Model>, this>
+  preloadOnce: PreloadOnce<InstanceType<Model>, this>
 
   /**
    * Aggregates

--- a/src/types/relations.ts
+++ b/src/types/relations.ts
@@ -1065,6 +1065,9 @@ export interface PreloadWithoutCallback<Model extends LucidRow, Builder> {
   <Name extends ExtractModelRelations<Model>>(relation: Name): Builder
 }
 
+export interface PreloadOnce<Model extends LucidRow, Builder>
+  extends PreloadWithoutCallback<Model, Builder> {}
+
 /**
  * Shape of the preloader to preload relationships
  */
@@ -1074,6 +1077,7 @@ export interface PreloaderContract<Model extends LucidRow> {
 
   load: Preload<Model, this>
   preload: Preload<Model, this>
+  preloadOnce: PreloadOnce<Model, this>
 
   debug(debug: boolean): this
   sideload(values: ModelObject): this


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue
Similar to PR https://github.com/adonisjs/lucid/pull/1052 by @RomainLanz 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
Added a preloadOnce method to the query building using the same logic as the loadOnce

<!-- Why is this change required? What problem does it solve? -->
In our use case we allow the client to preload field using a query parameter `$populate: string[]`
<img width="609" alt="Screenshot 2024-12-14 at 23 30 25" src="https://github.com/user-attachments/assets/3036b4c4-5500-496d-8068-df5222d3289f" />
> this method is in a https://github.com/lookinlab/adonis-lucid-filter file

While doing so we sometimes also use preload in our services
<img width="562" alt="Screenshot 2024-12-14 at 23 32 53" src="https://github.com/user-attachments/assets/4623824c-a94a-4c80-aa5c-94dc348437a3" />

If the client request `find` with the following payload
```json
{
	"$populate": ["tenant.settings"],
	"id": 1
}
```
#### Without `.preloadOnce`

1. The filter will call `query.preload("tenant", (subquery) => { subquery.preload('settings') })`
2. The service will call `query.preload("tenant")` and override the callback
3. `find` will return the data with the `tenant` populated but without the `tenant > settings`
4. 
#### With `.preloadOnce`

1. The filter will call `query.preload("tenant", (subquery) => { subquery.preload('settings') })`
2. The service will call `query.preloadOnce("tenant")` and nothing will happen as tenant is already queued for preloading
3. `find` will return the data with the `tenant` populated and also `tenant > settings` populated
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
