### PR TITLE
added decimalNumbers config to connection properties for compatibility to mysql

### DIFF
--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -411,10 +411,18 @@ type MysqlConnectionNode = {
   flags?: string
   ssl?: any
 }
+
+/**
+ * mysql2 options for compatibility to mysql
+ */
+type Mysql2AdditionalOptions = {
+  decimalNumbers?: boolean
+}
+
 export type MysqlConfig = SharedConfigNode & {
   client: 'mysql' | 'mysql2'
   version?: string
-  connection?: SharedConnectionNode & MysqlConnectionNode
+  connection?: SharedConnectionNode & MysqlConnectionNode & Mysql2AdditionalOptions
   replicas?: {
     write: {
       connection: MysqlConfig['connection']


### PR DESCRIPTION




### ❓ Type of change
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Added type decimalNumbers config option to mysql connection properties.
This fixes decimal numbers being returned as strings if someone switches from mysql to mysql2.

https://sidorares.github.io/node-mysql2/docs/documentation#known-incompatibilities-with-node-mysql
