### PR TITLE
Remove unnecessary override for strtok3

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,9 +139,6 @@
   "bugs": {
     "url": "https://github.com/adonisjs/lucid/issues"
   },
-  "overrides": {
-    "strtok3": "8.0.1"
-  },
   "prettier": "@adonisjs/prettier-config",
   "commitlint": {
     "extends": [


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

This wasn't from an issue, but from an [interesting bug](https://discord.com/channels/423256550564691970/1348981466532675626) found by a discord member. Essentially they had conflicting versions of strtok3 installed, and this caused file uploads via `@adonisjs/bodyparser` to fail, but seemingly only when it was a `.docx` file (which sounds like ghosts in the computer tbh).

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This removes the override for strtok3 which was causing in some applications an outdated version of strtok3 to be installed. Lucid doesn't seem to directly depend on strtok3, so I'm guessing this was necessary for something in the broader adonisjs ecosystem, the [original commit](https://github.com/ThisIsMissEm/lucid/commit/0699d06c40aacae8cdbea482b6593852e7abf7f2) doesn't give much in the way of details.

The current version of strtok3 that gets installed with adonisjs 6.17.2 is strtok3 10.2.1, but lucid was causing it to be overridden sometimes with strtok3 8.0.1 (I saw this with npm but not with pnpm)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

Neither are applicable, but I have run the full test suite before and after this change, removing the node_modules folder in between.