### PR TITLE
feat(orm): add saveQuietly

### DIFF
--- a/src/orm/base_model/index.ts
+++ b/src/orm/base_model/index.ts
@@ -1958,6 +1958,56 @@ class BaseModelImpl implements LucidRow {
   }
 
   /**
+   * Perform save on the model without invoking hooks.
+   */
+  async saveQuietly(): Promise<this> {
+    this.ensureIsntDeleted()
+    const Model = this.constructor as typeof BaseModel
+
+    /**
+     * Persist the model when it's not persisted already
+     */
+    if (!this.$isPersisted) {
+      this.initiateAutoCreateColumns()
+      await Model.$adapter.insert(this, this.prepareForAdapter(this.$attributes))
+
+      this.$hydrateOriginals()
+      this.$isPersisted = true
+
+      return this
+    }
+
+    /**
+     * Call hooks beforehand, so that they have the chance
+     * to make mutations that produces one or more `$dirty`
+     * fields.
+     */
+    const forceUpdate = this.forceUpdate
+    this.forceUpdate = false
+
+    /**
+     * Do not issue updates when model doesn't have any mutations
+     */
+    if (!this.$isDirty && !forceUpdate) {
+      return this
+    }
+
+    /**
+     * Perform update
+     */
+    this.initiateAutoUpdateColumns()
+
+    const updatePayload = this.prepareForAdapter(this.$dirty)
+    if (Object.keys(updatePayload).length > 0) {
+      await Model.$adapter.update(this, updatePayload)
+    }
+
+    this.$hydrateOriginals()
+
+    return this
+  }
+
+  /**
    * The lockForUpdate method re-fetches the model instance from
    * the database and locks the row to perform an update. The
    * provided callback receives a fresh user instance and should

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -634,6 +634,11 @@ export interface LucidRow {
   save(): Promise<this>
 
   /**
+   * Perform save on the model without invoking hooks.
+   */
+  saveQuietly(): Promise<this>
+
+  /**
    * The lockForUpdate method re-fetches the model instance from
    * the database and locks the row to perform an update. The
    * provided callback receives a fresh user instance and should

--- a/test/orm/base_model.spec.ts
+++ b/test/orm/base_model.spec.ts
@@ -1,5 +1,5 @@
 /*
- * @poppinss/data-models
+ * @adonisjs/lucid
  *
  * (c) Harminder Virk <virk@adonisjs.com>
  *
@@ -898,6 +898,59 @@ test.group('Base Model | persist', (group) => {
 
     assert.deepEqual(user.$attributes, { username: 'virk', fullName: 'H virk', id: 1 })
     assert.deepEqual(user.$original, { username: 'virk', fullName: 'H virk', id: 1 })
+  })
+
+  test('do not invoke before and after create hooks when saving quietly', async ({
+    fs,
+    assert,
+  }) => {
+    assert.plan(1)
+
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+
+    const BaseModel = getBaseModel(adapter)
+
+    const stack: string[] = []
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare username: string
+
+      @column()
+      declare email: string
+
+      @beforeCreate()
+      static beforeCreateHook() {
+        stack.push('beforeCreateHook')
+      }
+
+      @beforeSave()
+      static beforeSaveHook() {
+        stack.push('beforeSaveHook')
+      }
+
+      @afterCreate()
+      static afterCreateHook() {
+        stack.push('afterCreateHook')
+      }
+
+      @afterSave()
+      static afterSaveHook() {
+        stack.push('afterSaveHook')
+      }
+    }
+
+    const user = new User()
+    user.username = 'virk'
+    await user.saveQuietly()
+
+    assert.deepEqual(stack, [])
   })
 
   test('merge adapter insert return value with attributes', async ({ fs, assert }) => {


### PR DESCRIPTION
Hey there! 👋🏻 

This PR adds a `saveQuietly` variant that do not trigger any event when saving.
It is useful when you want to save again the model inside a hook/observer but don´t want to create an infinite loop.