### PR TITLE
feat(orm): add quiet variant for CRUD method

### DIFF
--- a/src/orm/base_model/index.ts
+++ b/src/orm/base_model/index.ts
@@ -690,6 +690,15 @@ class BaseModelImpl implements LucidRow {
   }
 
   /**
+   * Same as [[BaseModel.create]] without invoking hooks.
+   */
+  static async createQuietly(values: any, options?: ModelAssignOptions): Promise<any> {
+    const instance = this.newUpWithOptions(values, options, options?.allowExtraProperties)
+    await instance.saveQuietly()
+    return instance
+  }
+
+  /**
    * Same as [[BaseModel.create]], but persists multiple instances. The create
    * many call will be wrapped inside a managed transaction for consistency.
    * If required, you can also pass a transaction client and the method
@@ -707,6 +716,28 @@ class BaseModelImpl implements LucidRow {
 
       for (let row of values) {
         const modelInstance = await this.create(row, createOptions)
+        modelInstances.push(modelInstance)
+      }
+
+      return modelInstances
+    })
+  }
+
+  /**
+   * Same as [[BaseModel.createMany]] without invoking hooks.
+   */
+  static async createManyQuietly(values: any, options?: ModelAssignOptions): Promise<any[]> {
+    const client = this.$adapter.modelConstructorClient(this, options)
+
+    return managedTransaction(client, async (trx) => {
+      const modelInstances: LucidRow[] = []
+      const createOptions = {
+        client: trx,
+        allowExtraProperties: options?.allowExtraProperties,
+      }
+
+      for (let row of values) {
+        const modelInstance = await this.createQuietly(row, createOptions)
         modelInstances.push(modelInstance)
       }
 
@@ -1958,7 +1989,7 @@ class BaseModelImpl implements LucidRow {
   }
 
   /**
-   * Perform save on the model without invoking hooks.
+   * Same as [[BaseModel.save]] without invoking hooks.
    */
   async saveQuietly(): Promise<this> {
     this.ensureIsntDeleted()
@@ -2044,6 +2075,17 @@ class BaseModelImpl implements LucidRow {
     this.$isDeleted = true
 
     await Model.$hooks.runner('after:delete').run(this)
+  }
+
+  /**
+   * Same as [[BaseModel.delete]] without invoking hooks.
+   */
+  async deleteQuietly() {
+    this.ensureIsntDeleted()
+    const Model = this.constructor as typeof BaseModel
+
+    await Model.$adapter.delete(this)
+    this.$isDeleted = true
   }
 
   /**

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -652,6 +652,11 @@ export interface LucidRow {
   delete(): Promise<void>
 
   /**
+   * Same as [[BaseModel.delete]] without invoking hooks
+   */
+  deleteQuietly(): Promise<void>
+
+  /**
    * Reload/Refresh the model instance
    */
   refresh(): Promise<this>

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -978,9 +978,27 @@ export interface LucidModel {
   ): Promise<InstanceType<T>>
 
   /**
+   * Same as [[BaseModel.create]] but without invoking hooks
+   */
+  createQuietly<T extends LucidModel>(
+    this: T,
+    values: Partial<ModelAttributes<InstanceType<T>>>,
+    options?: ModelAssignOptions
+  ): Promise<InstanceType<T>>
+
+  /**
    * Create many of model instances
    */
   createMany<T extends LucidModel>(
+    this: T,
+    values: Partial<ModelAttributes<InstanceType<T>>>[],
+    options?: ModelAssignOptions
+  ): Promise<InstanceType<T>[]>
+
+  /**
+   * Same as [[BaseModel.createMany]] but without invoking hooks
+   */
+  createManyQuietly<T extends LucidModel>(
     this: T,
     values: Partial<ModelAttributes<InstanceType<T>>>[],
     options?: ModelAssignOptions

--- a/test/orm/base_model.spec.ts
+++ b/test/orm/base_model.spec.ts
@@ -5272,6 +5272,42 @@ test.group('Base Model | hooks', (group) => {
     ])
   })
 
+  test('do not invoke before and after create hooks with quiet variant', async ({ fs, assert }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+
+    const BaseModel = getBaseModel(adapter)
+
+    const stack: string[] = []
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare username: string
+
+      @column()
+      declare email: string
+
+      @beforeCreate()
+      static beforeCreateHook() {
+        stack.push('beforeCreateHook')
+      }
+
+      @afterCreate()
+      static afterCreateHook() {
+        stack.push('afterCreateHook')
+      }
+    }
+
+    await User.createQuietly({ username: 'virk' })
+
+    assert.deepEqual(stack, [])
+  })
+
   test('abort create when before hook raises exception', async ({ fs, assert }) => {
     assert.plan(3)
 
@@ -5571,6 +5607,46 @@ test.group('Base Model | hooks', (group) => {
 
     const usersCount = await db.from('users').count('*', 'total')
     assert.equal(usersCount[0].total, 0)
+  })
+
+  test('do not invoke before and after delete hooks with quiet variant', async ({ fs, assert }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+
+    const stack: string[] = []
+
+    const BaseModel = getBaseModel(adapter)
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare username: string
+
+      @column()
+      declare email: string
+
+      @beforeDelete()
+      static beforeDeleteHook() {
+        stack.push('beforeDeleteHook')
+      }
+
+      @afterDelete()
+      static afterDeleteHook() {
+        stack.push('afterDeleteHook')
+      }
+    }
+
+    await db.insertQuery().table('users').insert({ username: 'virk' })
+    const user = await User.findOrFail(1)
+    await user.deleteQuietly()
+
+    const usersCount = await db.from('users').count('*', 'total')
+    assert.equal(usersCount[0].total, 0)
+    assert.lengthOf(stack, 0)
   })
 
   test('abort delete when before hook raises exception', async ({ fs, assert }) => {


### PR DESCRIPTION
Hey there! 👋🏻 

Follow up of https://github.com/adonisjs/lucid/pull/1093

This PR adds more quiet variant, especially for `delete` and `create`.