### PR TITLE
feat: allow optional relation types

### DIFF
--- a/bin/test.ts
+++ b/bin/test.ts
@@ -1,5 +1,6 @@
 import { assert } from '@japa/assert'
 import { fileSystem } from '@japa/file-system'
+import { expectTypeOf } from '@japa/expect-type'
 import { processCLIArgs, configure, run } from '@japa/runner'
 
 /*
@@ -20,6 +21,7 @@ configure({
   files: ['test/**/*.spec.ts'],
   plugins: [
     assert(),
+    expectTypeOf(),
     fileSystem({ basePath: new URL('../test-helpers/fs-plugin/', import.meta.url) }),
   ],
 })

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@adonisjs/prettier-config": "^1.4.4",
     "@adonisjs/tsconfig": "^1.4.0",
     "@japa/assert": "^4.0.1",
+    "@japa/expect-type": "^2.0.3",
     "@japa/file-system": "^2.3.2",
     "@japa/runner": "^4.2.0",
     "@libsql/sqlite3": "^0.3.1",

--- a/src/types/relations.ts
+++ b/src/types/relations.ts
@@ -23,7 +23,7 @@ import {
   ModelAttributes,
   ModelObject,
   ModelQueryBuilderContract,
-  TypedDecorator,
+  OptionalTypedDecorator,
 } from './model.js'
 
 /**
@@ -36,7 +36,11 @@ import {
  * Extracts relationship attributes from the model
  */
 export type ExtractModelRelations<Model extends LucidRow> = {
-  [Key in keyof Model]: Model[Key] extends ModelRelations<LucidModel, LucidModel> ? Key : never
+  [Key in keyof Model]: Model[Key] extends undefined | null
+    ? never
+    : NonNullable<Model[Key]> extends ModelRelations<LucidModel, LucidModel>
+      ? Key
+      : never
 }[keyof Model]
 
 /**
@@ -117,7 +121,7 @@ export type ThroughRelationOptions<
 export type HasOneDecorator = <RelatedModel extends LucidModel>(
   model: () => RelatedModel,
   options?: RelationOptions<RelatedModel, LucidModel, HasOne<RelatedModel, LucidModel>>
-) => TypedDecorator<HasOne<RelatedModel> | null>
+) => OptionalTypedDecorator<HasOne<RelatedModel> | null>
 
 /**
  * Decorator signature to define has many relationship
@@ -125,7 +129,7 @@ export type HasOneDecorator = <RelatedModel extends LucidModel>(
 export type HasManyDecorator = <RelatedModel extends LucidModel>(
   model: () => RelatedModel,
   options?: RelationOptions<RelatedModel, LucidModel, HasOne<RelatedModel, LucidModel>>
-) => TypedDecorator<HasMany<RelatedModel>>
+) => OptionalTypedDecorator<HasMany<RelatedModel>>
 
 /**
  * Decorator signature to define belongs to relationship
@@ -133,7 +137,7 @@ export type HasManyDecorator = <RelatedModel extends LucidModel>(
 export type BelongsToDecorator = <RelatedModel extends LucidModel>(
   model: () => RelatedModel,
   options?: RelationOptions<RelatedModel, LucidModel, HasOne<RelatedModel, LucidModel>>
-) => TypedDecorator<BelongsTo<RelatedModel> | null>
+) => OptionalTypedDecorator<BelongsTo<RelatedModel> | null>
 
 /**
  * Decorator signature to define many to many relationship
@@ -141,7 +145,7 @@ export type BelongsToDecorator = <RelatedModel extends LucidModel>(
 export type ManyToManyDecorator = <RelatedModel extends LucidModel>(
   model: () => RelatedModel,
   column?: ManyToManyRelationOptions<ManyToMany<RelatedModel>>
-) => TypedDecorator<ManyToMany<RelatedModel>>
+) => OptionalTypedDecorator<ManyToMany<RelatedModel>>
 
 /**
  * Decorator signature to define has many through relationship
@@ -152,7 +156,7 @@ export type HasManyThroughDecorator = <RelatedModel extends LucidModel>(
     ThroughRelationOptions<RelatedModel, LucidModel, HasManyThrough<RelatedModel>>,
     'throughModel'
   >
-) => TypedDecorator<HasManyThrough<RelatedModel>>
+) => OptionalTypedDecorator<HasManyThrough<RelatedModel>>
 
 /**
  * ------------------------------------------------------

--- a/test/orm/model_belongs_to.spec.ts
+++ b/test/orm/model_belongs_to.spec.ts
@@ -8,7 +8,7 @@
  */
 
 import { test } from '@japa/runner'
-import type { BelongsTo } from '../../src/types/relations.js'
+import type { BelongsTo, ExtractModelRelations } from '../../src/types/relations.js'
 import { scope } from '../../src/orm/base_model/index.js'
 
 import { column, belongsTo } from '../../src/orm/decorators/index.js'
@@ -223,6 +223,26 @@ test.group('Model | BelongsTo | Options', (group) => {
     assert.deepEqual(Profile.$getRelation('user')!.relatedModel(), User)
     assert.deepEqual(Profile.$getRelation('user')!.model, Profile)
     assert.equal(Profile.$getRelation('user')!['foreignKey'], 'userUid')
+  })
+
+  test('allow nullable or optional relation', async ({ fs, expectTypeOf }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+    }
+
+    class Profile extends BaseModel {
+      @belongsTo(() => User)
+      declare user?: BelongsTo<typeof User> | null
+    }
+
+    expectTypeOf<ExtractModelRelations<Profile>>().toEqualTypeOf<'user' | undefined>()
   })
 })
 

--- a/test/orm/model_has_many.spec.ts
+++ b/test/orm/model_has_many.spec.ts
@@ -9,7 +9,7 @@
 
 import { test } from '@japa/runner'
 import { DateTime } from 'luxon'
-import type { HasMany } from '../../src/types/relations.js'
+import type { ExtractModelRelations, HasMany } from '../../src/types/relations.js'
 
 import { scope } from '../../src/orm/base_model/index.js'
 import { column, hasMany } from '../../src/orm/decorators/index.js'
@@ -227,6 +227,29 @@ test.group('Model | HasMany | Options', (group) => {
 
     assert.deepEqual(User.$getRelation('posts')!.model, User)
     assert.equal(User.$getRelation('posts')!['foreignKey'], 'userUid')
+  })
+
+  test('allow optional relation', async ({ fs, expectTypeOf }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    class Post extends BaseModel {
+      @column()
+      declare userId: number
+    }
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @hasMany(() => Post)
+      declare posts?: HasMany<typeof Post>
+    }
+
+    expectTypeOf<ExtractModelRelations<User>>().toEqualTypeOf<'posts' | undefined>()
   })
 })
 

--- a/test/orm/model_has_many_through.spec.ts
+++ b/test/orm/model_has_many_through.spec.ts
@@ -8,7 +8,7 @@
  */
 
 import { test } from '@japa/runner'
-import type { HasManyThrough } from '../../src/types/relations.js'
+import type { ExtractModelRelations, HasManyThrough } from '../../src/types/relations.js'
 
 import { scope } from '../../src/orm/base_model/index.js'
 import { hasManyThrough, column } from '../../src/orm/decorators/index.js'
@@ -329,6 +329,34 @@ test.group('Model | Has Many Through | Options', (group) => {
 
     assert.equal(relation['throughForeignKey'], 'userUid')
     assert.equal(relation['throughForeignKeyColumnName'], 'user_uid')
+  })
+
+  test('allow optional relation', async ({ fs, expectTypeOf }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare countryId: number
+    }
+
+    class Post extends BaseModel {}
+
+    class Country extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @hasManyThrough([() => Post, () => User])
+      declare posts?: HasManyThrough<typeof Post>
+    }
+
+    expectTypeOf<ExtractModelRelations<Country>>().toEqualTypeOf<'posts' | undefined>()
   })
 })
 

--- a/test/orm/model_has_one.spec.ts
+++ b/test/orm/model_has_one.spec.ts
@@ -8,7 +8,7 @@
  */
 
 import { test } from '@japa/runner'
-import type { HasOne, BelongsTo } from '../../src/types/relations.js'
+import type { HasOne, BelongsTo, ExtractModelRelations } from '../../src/types/relations.js'
 
 import { scope } from '../../src/orm/base_model/index.js'
 import { column, hasOne, belongsTo } from '../../src/orm/decorators/index.js'
@@ -230,6 +230,29 @@ test.group('Model | HasOne | Options', (group) => {
 
     assert.equal(User.$getRelation('profile')!['foreignKey'], 'userUid')
     assert.deepEqual(User.$getRelation('profile')!.model, User)
+  })
+
+  test('allow nullable or optional relation', async ({ fs, expectTypeOf }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    class Profile extends BaseModel {
+      @column()
+      declare userId: number
+    }
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @hasOne(() => Profile)
+      declare profile?: HasOne<typeof Profile> | null
+    }
+
+    expectTypeOf<ExtractModelRelations<User>>().toEqualTypeOf<'profile' | undefined>()
   })
 })
 

--- a/test/orm/model_many_to_many.spec.ts
+++ b/test/orm/model_many_to_many.spec.ts
@@ -8,7 +8,7 @@
  */
 
 import { test } from '@japa/runner'
-import type { ManyToMany } from '../../src/types/relations.js'
+import type { ExtractModelRelations, ManyToMany } from '../../src/types/relations.js'
 
 import { scope } from '../../src/orm/base_model/index.js'
 import { column, manyToMany } from '../../src/orm/decorators/index.js'
@@ -337,6 +337,29 @@ test.group('Model | ManyToMany | Options', (group) => {
 
     assert.deepEqual(User.$getRelation('skills')!.model, User)
     assert.equal(User.$getRelation('skills')!['pivotRelatedForeignKey'], 'skill_uid')
+  })
+
+  test('allow optional relation', async ({ fs, expectTypeOf }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    class Skill extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+    }
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @manyToMany(() => Skill)
+      declare skills?: ManyToMany<typeof Skill>
+    }
+
+    expectTypeOf<ExtractModelRelations<User>>().toEqualTypeOf<'skills' | undefined>()
   })
 })
 


### PR DESCRIPTION
### 🔗 Linked issue

#1098 

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

- Resolves #1098 .
- This PR fixes the relation extraction when it's nullable or optional.
- It also adds support to define all relations as optional, so you have better type safety if you want to when checking whether the relation is preloaded.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
