### PR TITLE
feat: extend sideload

### DIFF
--- a/src/orm/query_builder/index.ts
+++ b/src/orm/query_builder/index.ts
@@ -74,11 +74,6 @@ export class ModelQueryBuilder
   implements ModelQueryBuilderContract<LucidModel, LucidRow>
 {
   /**
-   * Side-loaded attributes that will be passed to the model instances
-   */
-  protected sideloaded: ModelObject = {}
-
-  /**
    * A copy of defined preloads on the model instance
    */
   protected preloader: PreloaderContract<LucidRow>
@@ -133,6 +128,11 @@ export class ModelQueryBuilder
    * Whether query is a sub-query for `.where` callback
    */
   isChildQuery = false
+
+  /**
+   * Side-loaded attributes that will be passed to the model instances
+   */
+  sideloaded: ModelObject = {}
 
   constructor(
     builder: Knex.QueryBuilder,
@@ -448,8 +448,13 @@ export class ModelQueryBuilder
   /**
    * Set side-loaded properties to be passed to the model instance
    */
-  sideload(value: ModelObject) {
-    this.sideloaded = value
+  sideload(value: ModelObject, merge = false) {
+    if (merge) {
+      Object.assign(this.sideloaded, value)
+    } else {
+      this.sideloaded = value
+    }
+
     return this
   }
 

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -402,12 +402,17 @@ export interface ModelQueryBuilderContract<Model extends LucidModel, Result = In
    */
   clone<ClonedResult = Result>(): ModelQueryBuilderContract<Model, ClonedResult>
 
+  sideloaded: InstanceType<Model>['$sideloaded']
+
   /**
    * A custom set of sideloaded properties defined on the query
    * builder, this will be passed to the model instance created
    * by the query builder
    */
-  sideload(value: ModelObject): this
+  sideload<Sideloaded extends InstanceType<Model>['$sideloaded'], Merge extends boolean = false>(
+    value: Merge extends true ? Partial<Sideloaded> : Sideloaded,
+    merge?: Merge
+  ): this
 
   /**
    * Execute and get first result

--- a/test/orm/model_query_builder.spec.ts
+++ b/test/orm/model_query_builder.spec.ts
@@ -22,6 +22,7 @@ import {
   getBaseModel,
 } from '../../test-helpers/index.js'
 import type { HasMany } from '../../src/types/relations.js'
+import { ModelQueryBuilderContract } from '../../src/types/model.js'
 
 test.group('Model query builder', (group) => {
   group.setup(async () => {
@@ -577,5 +578,29 @@ test.group('Model query builder', (group) => {
     const posts = await Post.query().whereIn('id', users[0].related('posts').query().select('id'))
 
     assert.lengthOf(posts, 1)
+  })
+
+  test('define custom type for sideloaded', async ({ fs, expectTypeOf }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    type Sideload = { test: boolean }
+
+    class User extends BaseModel {
+      declare $sideloaded: Sideload
+
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare username: string
+    }
+
+    type Query = ModelQueryBuilderContract<typeof User>
+
+    expectTypeOf<Query['sideloaded']>().toEqualTypeOf<Sideload>()
   })
 })


### PR DESCRIPTION
### ❓ Type of change

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR extends sideload functionality:
- Changes `sideloaded` on query builder to `public` so it can be retrieved when querying.
- Infers custom sideloaded type in query builder.
- Adds option to only merge sideloaded data, not replace it completely.

On some projects we use `sideload` for getting translation data for localized content. When we filter the content by search phrase we need to check what locale (set in `sideloaded`) is used for the query to run the condition for correct locale. In order for this to work we need to be able to retrieve `sideloaded` in query builder. It's also very helpful to be able to add extra data to already `sideloaded` data, when there is other chained functionality, so it won't get replaced.
This PR enhances the `sideload` functionality to support it.

PS: This PR also uses `@japa/expect-type`, so I based it off  #1097 and it should be merged first.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
