### PR TITLE
Improve logging for failed migrations with --compact-output flag set

### DIFF
--- a/commands/migration/_base.ts
+++ b/commands/migration/_base.ts
@@ -138,16 +138,8 @@ export default abstract class MigrationsBase extends BaseCommand {
         this.logger.log(this.colors.red(message))
 
         const failedFile = files.find(({ status }) => status === 'error')
+        if (failedFile) this.logger.fatal(failedFile.file.name)
 
-        if (failedFile) {
-          this.logger.log(this.colors.red('❯ The following file failed: '))
-          this.logger.log(this.colors.cyan(failedFile.file.name))
-        }
-
-        this.logger.log('\n' + this.colors.red(migrator.error!.message))
-
-        const errorStack = new Error().stack
-        if (errorStack) this.logger.log('\n' + this.colors.red(errorStack))
         this.exitCode = 1
         break
     }

--- a/commands/migration/_base.ts
+++ b/commands/migration/_base.ts
@@ -130,13 +130,24 @@ export default abstract class MigrationsBase extends BaseCommand {
         break
 
       case 'error':
-        const skippedMigrations = Object.values(migrator.migratedFiles).filter(
-          (file) => file.status === 'pending'
-        ).length
+        const files = Object.values(migrator.migratedFiles)
+
+        const skippedMigrations = files?.filter(({ status }) => status === 'pending').length
 
         message = `❯ Executed ${processedFiles.size} migrations, 1 error, ${skippedMigrations} skipped`
         this.logger.log(this.colors.red(message))
+
+        const failedFile = files.find(({ status }) => status === 'error')
+
+        if (failedFile) {
+          this.logger.log(this.colors.red('❯ The following file failed: '))
+          this.logger.log(this.colors.cyan(failedFile.file.name))
+        }
+
         this.logger.log('\n' + this.colors.red(migrator.error!.message))
+
+        const errorStack = new Error().stack
+        if (errorStack) this.logger.log('\n' + this.colors.red(errorStack))
         this.exitCode = 1
         break
     }

--- a/commands/migration/_base.ts
+++ b/commands/migration/_base.ts
@@ -138,7 +138,9 @@ export default abstract class MigrationsBase extends BaseCommand {
         this.logger.log(this.colors.red(message))
 
         const failedFile = files.find(({ status }) => status === 'error')
-        if (failedFile) this.logger.fatal(failedFile.file.name)
+        if (failedFile) {
+          this.logger.fatal(failedFile.file.name)
+        }
 
         this.exitCode = 1
         break


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

#1047 

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [X] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When the `--compat-output` option is set to true, the logger will display the failed migration file as per the request in this [issue](https://github.com/adonisjs/lucid/issues/1047). The other wanted changes suggested in the issue I did not add since running the migrations with `--compact-output` will display the failed sql query and the stacktrace as well.

This is what the new compact message will look like: 

![ss_compact_output](https://github.com/user-attachments/assets/c3af2efb-d351-440e-8df0-52fa2f6d767d)

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
