### PR TITLE
chore: update package.json to allow commands extend.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     ".": "./build/index.js",
     "./schema": "./build/src/schema/main.js",
     "./commands": "./build/commands/main.js",
+    "./commands/*": "./build/commands/*.js",
     "./factories": "./build/src/factories/main.js",
     "./database": "./build/src/database/main.js",
     "./orm": "./build/src/orm/main.js",


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Lucid's ace commands weren't exported for third party libraries to extend. We are currently in the process of creating a package for AdonisJS that allow for consistent module scaffolding, and we wanted to extend lucid's `MakeFactory` and `MakeModel` commands to add a flag "module".

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
