### PR TITLE
fix: natural order on seeder

### DIFF
--- a/src/seeders/source.ts
+++ b/src/seeders/source.ts
@@ -29,7 +29,7 @@ export class SeedersSource {
     const { files } = await sourceFiles(
       this.app.appRoot,
       directoryPath,
-      this.config.seeders?.naturalSort || false
+      this.config.seeders?.naturalSort || true
     )
     return files
   }

--- a/src/seeders/source.ts
+++ b/src/seeders/source.ts
@@ -29,7 +29,7 @@ export class SeedersSource {
     const { files } = await sourceFiles(
       this.app.appRoot,
       directoryPath,
-      this.config.seeders?.naturalSort || true
+      this.config.seeders?.naturalSort || false
     )
     return files
   }

--- a/src/seeders/source.ts
+++ b/src/seeders/source.ts
@@ -26,7 +26,11 @@ export class SeedersSource {
    * paths are resolved from the project root
    */
   private async getDirectoryFiles(directoryPath: string): Promise<FileNode<unknown>[]> {
-    const { files } = await sourceFiles(this.app.appRoot, directoryPath, false)
+    const { files } = await sourceFiles(
+      this.app.appRoot,
+      directoryPath,
+      this.config.seeders?.naturalSort || false
+    )
     return files
   }
 

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -326,6 +326,7 @@ export type MigratorConfig = {
  */
 export type SeedersConfig = {
   paths: string[]
+  naturalSort?: boolean
 }
 
 /**

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -325,7 +325,7 @@ export type MigratorConfig = {
  * Seeders config
  */
 export type SeedersConfig = {
-  paths: string[]
+  paths?: string[]
   naturalSort?: boolean
 }
 

--- a/test/seeders/seeders_source.spec.ts
+++ b/test/seeders/seeders_source.spec.ts
@@ -181,6 +181,14 @@ test.group('Seeds Source', (group) => {
           name: 'database/seeders/2',
         },
         {
+          absPath: join(fs.basePath, 'database/seeders/3.ts'),
+          name: 'database/seeders/3',
+        },
+        {
+          absPath: join(fs.basePath, 'database/seeders/4.ts'),
+          name: 'database/seeders/4',
+        },
+        {
           absPath: join(fs.basePath, 'database/seeders/10.ts'),
           name: 'database/seeders/10',
         },

--- a/test/seeders/seeders_source.spec.ts
+++ b/test/seeders/seeders_source.spec.ts
@@ -144,4 +144,51 @@ test.group('Seeds Source', (group) => {
       ]
     )
   })
+
+  test('use a natural sort to order files when configured', async ({ fs, assert }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+
+    const config = Object.assign({}, db.getRawConnection('primary')!.config, {
+      seeders: {
+        naturalSort: true,
+        paths: ['database/seeders'],
+      },
+    })
+
+    const seedersSource = new SeedersSource(config, app)
+    await fs.create('database/seeders/1.ts', '')
+    await fs.create('database/seeders/2.ts', '')
+    await fs.create('database/seeders/10.ts', '')
+    await fs.create('database/seeders/3.ts', '')
+    await fs.create('database/seeders/100.ts', '')
+    await fs.create('database/seeders/4.ts', '')
+    await db.manager.closeAll()
+
+    const files = await seedersSource.getSeeders()
+    assert.deepEqual(
+      files.map((file) => {
+        return { absPath: file.absPath, name: file.name }
+      }),
+      [
+        {
+          absPath: join(fs.basePath, 'database/seeders/1.ts'),
+          name: 'database/seeders/1',
+        },
+        {
+          absPath: join(fs.basePath, 'database/seeders/2.ts'),
+          name: 'database/seeders/2',
+        },
+        {
+          absPath: join(fs.basePath, 'database/seeders/10.ts'),
+          name: 'database/seeders/10',
+        },
+        {
+          absPath: join(fs.basePath, 'database/seeders/100.ts'),
+          name: 'database/seeders/100',
+        },
+      ]
+    )
+  })
 })


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Seeders with a number above 9 start over when you launch the seeders, so I added the same functionality as migrations. I added an optional naturalSort.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly. (https://github.com/adonisjs/lucid.adonisjs.com/pull/55)
