### PR TITLE
Pass adapterResult to column consume function

### DIFF
--- a/src/orm/base_model/index.ts
+++ b/src/orm/base_model/index.ts
@@ -1707,7 +1707,7 @@ class BaseModelImpl implements LucidRow {
            */
           const value =
             typeof attribute.consume === 'function'
-              ? attribute.consume(adapterResult[key], attributeName, this)
+              ? attribute.consume(adapterResult[key], attributeName, this, adapterResult)
               : adapterResult[key]
 
           /**

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -222,7 +222,7 @@ export type ColumnOptions = {
   /**
    * Invoked when row is fetched from the database
    */
-  consume?: (value: any, attribute: string, model: LucidRow) => any
+  consume?: (value: any, attribute: string, model: LucidRow, adapterResult: ModelObject) => any
 }
 
 /**

--- a/test/orm/base_model.spec.ts
+++ b/test/orm/base_model.spec.ts
@@ -1817,18 +1817,18 @@ test.group('Base Model | create from adapter results', (group) => {
       declare username: string
 
       @column({
-        consume: (value) => value.toUpperCase(),
+        consume: (value, attribute, instance, adapterResult) => `${value.toUpperCase()} ${attribute} ${instance.constructor.name.toString()} ${adapterResult.username}`,
       })
       declare fullName: string
     }
 
-    const user = User.$createFromAdapterResult({ full_name: 'virk' })
+    const user = User.$createFromAdapterResult({ full_name: 'Harminder Virk', username: 'virk' })
 
     assert.isTrue(user!.$isPersisted)
     assert.isFalse(user!.$isDirty)
     assert.isFalse(user!.$isLocal)
-    assert.deepEqual(user!.$attributes, { fullName: 'VIRK' })
-    assert.deepEqual(user!.$original, { fullName: 'VIRK' })
+    assert.deepEqual(user!.$attributes, { fullName: "HARMINDER VIRK fullName User virk", username: 'virk' })
+    assert.deepEqual(user!.$original, { fullName: "HARMINDER VIRK fullName User virk", username: 'virk' })
   })
 
   test('original and attributes should not be shared', async ({ fs, assert }) => {

--- a/test/orm/base_model.spec.ts
+++ b/test/orm/base_model.spec.ts
@@ -1817,7 +1817,8 @@ test.group('Base Model | create from adapter results', (group) => {
       declare username: string
 
       @column({
-        consume: (value, attribute, instance, adapterResult) => `${value.toUpperCase()} ${attribute} ${instance.constructor.name.toString()} ${adapterResult.username}`,
+        consume: (value, attribute, instance, adapterResult) =>
+          `${value.toUpperCase()} ${attribute} ${instance.constructor.name.toString()} ${adapterResult.username}`,
       })
       declare fullName: string
     }
@@ -1827,8 +1828,14 @@ test.group('Base Model | create from adapter results', (group) => {
     assert.isTrue(user!.$isPersisted)
     assert.isFalse(user!.$isDirty)
     assert.isFalse(user!.$isLocal)
-    assert.deepEqual(user!.$attributes, { fullName: "HARMINDER VIRK fullName User virk", username: 'virk' })
-    assert.deepEqual(user!.$original, { fullName: "HARMINDER VIRK fullName User virk", username: 'virk' })
+    assert.deepEqual(user!.$attributes, {
+      fullName: 'HARMINDER VIRK fullName User virk',
+      username: 'virk',
+    })
+    assert.deepEqual(user!.$original, {
+      fullName: 'HARMINDER VIRK fullName User virk',
+      username: 'virk',
+    })
   })
 
   test('original and attributes should not be shared', async ({ fs, assert }) => {


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

https://discord.com/channels/423256550564691970/1395127978777772052

Docs update: https://github.com/adonisjs/lucid.adonisjs.com/pull/58

### ❓ Type of change

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Impossible to use other model attributes in consume function.

The consume function signature is `(value, attribute ,model) => `

The problem is that since the attributes are parsed and assigned to the model in a random order you can't assume that a certain other attribute has already been assigned to the model, so you *can't use other model attributes when consuming an attribute*.

I read the lucid source code and there doesn't seem to be any way to access the `adapterResult` from the consume hook, since it's not a property of the model and only exists in the scope.

This seems to be the cleanest way to implement this functionality, since it's backwards compatible

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests
- [x] I have updated the documentation accordingly.
