### PR TITLE
Allow a arbitrary equality comparison function to be passed in the column options

### DIFF
--- a/src/orm/base_model/index.ts
+++ b/src/orm/base_model/index.ts
@@ -1348,9 +1348,15 @@ class BaseModelImpl implements LucidRow {
     const dirty = Object.keys(this.$attributes).reduce((result: any, key) => {
       const value = this.$attributes[key]
       const originalValue = this.$original[key]
+
+      const Model = this.constructor as LucidModel
+      const column = Model.$getColumn(key)
+
       let isEqual = true
 
-      if (isObject(value) && 'isDirty' in value) {
+      if (column?.equals) {
+        isEqual = column.equals(originalValue, value)
+      } else if (isObject(value) && 'isDirty' in value) {
         isEqual = !value.isDirty
       } else {
         isEqual = compareValues(originalValue, value)

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -216,6 +216,11 @@ export type ColumnOptions = {
    * Invoked when row is fetched from the database
    */
   consume?: (value: any, attribute: string, model: LucidRow) => any
+
+  /**
+   * Invoked to compare to values for equality when tracking dirty attributes
+   */
+  equals?: (a: any, b: any) => boolean
 }
 
 /**

--- a/test/orm/base_model.spec.ts
+++ b/test/orm/base_model.spec.ts
@@ -813,6 +813,36 @@ test.group('Base Model | dirty', (group) => {
     user.location.isDirty = true
     assert.deepEqual(user.$dirty, { location: { state: 'goa', country: 'India', isDirty: true } })
   })
+
+  test('compute diff for properties using equals column option', async ({ fs, assert }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const adapter = new FakeAdapter()
+
+    const BaseModel = getBaseModel(adapter)
+
+    class User extends BaseModel {
+      @column()
+      declare username: string
+
+      @column()
+      declare age: number
+
+      @column({
+        equals: (a: Set<string>, b: Set<string>) =>
+          a.size === b.size && Array.from(a).every((item) => b.has(item)),
+      })
+      colors: Set<string> = new Set()
+    }
+    User.$adapter = adapter
+
+    const user = new User()
+    user.username = 'virk'
+    user.colors = new Set(['red', 'green', 'blue'])
+
+    assert.isTrue(user.$isDirty)
+    assert.isTrue(!!user.$dirty.colors)
+  })
 })
 
 test.group('Base Model | persist', (group) => {


### PR DESCRIPTION

<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

#1131 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Lucid uses 'fast-deep-equal' for [comparing](https://github.com/adonisjs/lucid/blob/a4e44c9dfad601ebec2cb9959e8f36b1e91ccb4b/src/utils/index.ts#L77
) values to track changes 


As per the package documentation: https://github.com/epoberezkin/fast-deep-equal

> To support ES6 Maps, Sets and Typed arrays equality use:
> `var equal = require('fast-deep-equal/es6');`

Lucid does not use the es6 version, so comparing Sets always considers them equal, and as such will not save the changes.

We could use the es6 version with a minimal impact on performance, but I think this approach of allow custom equality comparators to be passed in is more flexible.

```
fast-deep-equal x 261,950 ops/sec ±0.52% (89 runs sampled)
fast-deep-equal/es6 x 212,991 ops/sec ±0.34% (92 runs sampled)
```

With my implementation it would allow custom equality comparison between currency objects, sets, or other custom data structures.

I will update the docs soon as I've gotten some feedback on this PR.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly. 
