### PR TITLE
fix: prevent redundant loadOnce on null 1:1 preloads

### DIFF
--- a/src/orm/base_model/index.ts
+++ b/src/orm/base_model/index.ts
@@ -2004,7 +2004,7 @@ class BaseModelImpl implements LucidRow {
    * already preloaded
    */
   async loadOnce(relationName: any) {
-    if (!this.$preloaded[relationName]) {
+    if (!(relationName in this.$preloaded)) {
       return this.load(relationName)
     }
   }

--- a/src/orm/relations/belongs_to/index.ts
+++ b/src/orm/relations/belongs_to/index.ts
@@ -156,11 +156,7 @@ export class BelongsTo implements BelongsToRelationContract<LucidModel, LucidMod
    */
   setRelated(parent: LucidRow, related: LucidRow | null): void {
     ensureRelationIsBooted(this)
-    if (related === undefined) {
-      return
-    }
-
-    parent.$setRelated(this.relationName, related)
+    parent.$setRelated(this.relationName, related ?? null)
   }
 
   /**
@@ -168,11 +164,7 @@ export class BelongsTo implements BelongsToRelationContract<LucidModel, LucidMod
    */
   pushRelated(parent: LucidRow, related: LucidRow | null): void {
     ensureRelationIsBooted(this)
-    if (related === undefined) {
-      return
-    }
-
-    parent.$setRelated(this.relationName, related)
+    parent.$setRelated(this.relationName, related ?? null)
   }
 
   /**

--- a/src/orm/relations/has_one/index.ts
+++ b/src/orm/relations/has_one/index.ts
@@ -134,11 +134,7 @@ export class HasOne implements HasOneRelationContract<LucidModel, LucidModel> {
    */
   setRelated(parent: LucidRow, related: LucidRow | null): void {
     ensureRelationIsBooted(this)
-    if (related === undefined) {
-      return
-    }
-
-    parent.$setRelated(this.relationName as any, related)
+    parent.$setRelated(this.relationName as any, related ?? null)
   }
 
   /**
@@ -146,12 +142,7 @@ export class HasOne implements HasOneRelationContract<LucidModel, LucidModel> {
    */
   pushRelated(parent: LucidRow, related: LucidRow | null): void {
     ensureRelationIsBooted(this)
-
-    if (related === undefined) {
-      return
-    }
-
-    parent.$pushRelated(this.relationName as any, related)
+    parent.$pushRelated(this.relationName as any, related ?? null)
   }
 
   /**

--- a/test/orm/model_belongs_to.spec.ts
+++ b/test/orm/model_belongs_to.spec.ts
@@ -1322,6 +1322,73 @@ test.group('Model | BelongsTo | preload', (group) => {
     assert.equal(queryCount, 1)
   })
 
+  test('loadOnce should not re-query a preloaded belongsTo with no match', async ({
+    assert,
+    fs,
+  }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    let queryCount = 0
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+    }
+
+    class Profile extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare userId: number
+
+      @column()
+      declare displayName: string
+
+      @belongsTo(() => User, {
+        onQuery() {
+          queryCount++
+        },
+      })
+      declare user: BelongsTo<typeof User>
+    }
+
+    /**
+     * Profile 1 has a matching user, profile 2 has a userId pointing
+     * to a non-existent user. After preloading, profile 2 should have
+     * `$preloaded.user = null`. Calling `loadOnce('user')` should NOT
+     * fire an extra query.
+     */
+    await db
+      .insertQuery()
+      .table('users')
+      .insert([{ username: 'jul' }])
+    await db
+      .insertQuery()
+      .table('profiles')
+      .insert([
+        { user_id: 1, display_name: 'jul' },
+        { user_id: 999, display_name: 'orphan' },
+      ])
+
+    const profiles = await Profile.query().preload('user')
+    assert.lengthOf(profiles, 2)
+
+    assert.equal(queryCount, 1)
+
+    assert.instanceOf(profiles[0].user, User)
+    assert.isNull(profiles[1].user)
+
+    await profiles[0].loadOnce('user')
+    await profiles[1].loadOnce('user')
+
+    assert.equal(queryCount, 1)
+  })
+
   test('preload nested relations', async ({ assert, fs }) => {
     const app = new AppFactory().create(fs.baseUrl, () => {})
     await app.init()

--- a/test/orm/model_has_one.spec.ts
+++ b/test/orm/model_has_one.spec.ts
@@ -1380,6 +1380,72 @@ test.group('Model | HasOne | preload', (group) => {
     assert.equal(users[1].profile.userId, users[1].id)
   })
 
+  test('loadOnce should not re-query a preloaded hasOne with no match', async ({ fs, assert }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    let queryCount = 0
+
+    class Profile extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare userId: number
+
+      @column()
+      declare displayName: string
+    }
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @hasOne(() => Profile, {
+        onQuery() {
+          queryCount++
+        },
+      })
+      declare profile: HasOne<typeof Profile>
+    }
+
+    /**
+     * User 1 has a profile, user 2 does not.
+     * When we preload profiles for both users, user 2 should get
+     * `$preloaded.profile = null`. Calling `loadOnce('profile')`
+     * afterwards should NOT fire an extra query because the relation
+     * was already resolved (to null) by the preloader.
+     */
+    await db
+      .insertQuery()
+      .table('users')
+      .insert([{ username: 'julr' }, { username: 'juliano' }])
+    await db.insertQuery().table('profiles').insert({ user_id: 1, display_name: 'julr' })
+
+    const users = await User.query().preload('profile')
+    assert.lengthOf(users, 2)
+
+    /**
+     * One query was fired by the preloader
+     */
+    assert.equal(queryCount, 1)
+
+    assert.instanceOf(users[0].profile, Profile)
+    assert.isNull(users[1].profile)
+
+    /**
+     * loadOnce should be a no-op for both users: the relation is
+     * already in `$preloaded`, regardless of the value being null.
+     */
+    await users[0].loadOnce('profile')
+    await users[1].loadOnce('profile')
+
+    assert.equal(queryCount, 1)
+  })
+
   test('raise exception when local key is not selected', async ({ fs, assert }) => {
     const app = new AppFactory().create(fs.baseUrl, () => {})
     await app.init()


### PR DESCRIPTION
PR fixes extra-query edge case when `loadOnce` is called after a 1:1 preload that resolved to null

instead now persist the null preload and loadOnce checks key existence, so it becomes a true no‑op

(seems like we have some failing test related to schema generation that are not related to this pr )