### PR TITLE
feat(orm): add encrypted column decorator with deterministic and blind indexes

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -59,7 +59,7 @@ export const E_INVALID_ENCRYPTED_COLUMN_CONFIGURATION = createError<[string, str
 )
 
 export const E_UNSUPPORTED_ENCRYPTED_COLUMN_QUERY = createError<[string, string]>(
-  'Cannot use "%s" on encrypted column "%s". Only equality-based queries are supported',
+  'Cannot use "%s" on encrypted column "%s". Encrypted columns can only be used with equality-based WHERE clauses',
   'E_UNSUPPORTED_ENCRYPTED_COLUMN_QUERY',
   500
 )

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -46,6 +46,24 @@ export const E_MODEL_DELETED = createError(
   500
 )
 
+export const E_MISSING_MODEL_ENCRYPTION = createError<[string]>(
+  'Cannot use encrypted column "%s" without a configured encryption provider. Call "BaseModel.useEncryption()" before querying or persisting encrypted columns',
+  'E_MISSING_MODEL_ENCRYPTION',
+  500
+)
+
+export const E_INVALID_ENCRYPTED_COLUMN_CONFIGURATION = createError<[string, string]>(
+  'Invalid encrypted column configuration for "%s". %s',
+  'E_INVALID_ENCRYPTED_COLUMN_CONFIGURATION',
+  500
+)
+
+export const E_UNSUPPORTED_ENCRYPTED_COLUMN_QUERY = createError<[string, string]>(
+  'Cannot use "%s" on encrypted column "%s". Only equality-based queries are supported',
+  'E_UNSUPPORTED_ENCRYPTED_COLUMN_QUERY',
+  500
+)
+
 /**
  * The "E_ROW_NOT_FOUND" exception is raised when
  * no row is found in a database single query

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -64,6 +64,12 @@ export const E_UNSUPPORTED_ENCRYPTED_COLUMN_QUERY = createError<[string, string]
   500
 )
 
+export const E_UNSUPPORTED_STANDARD_ENCRYPTED_COLUMN_QUERY = createError<[string, string]>(
+  'Cannot use "%s" on standard encrypted column "%s". Equality queries require deterministic or blind encryption',
+  'E_UNSUPPORTED_STANDARD_ENCRYPTED_COLUMN_QUERY',
+  500
+)
+
 /**
  * The "E_ROW_NOT_FOUND" exception is raised when
  * no row is found in a database single query

--- a/src/orm/base_model/index.ts
+++ b/src/orm/base_model/index.ts
@@ -675,11 +675,6 @@ class BaseModelImpl implements LucidRow {
     this.$defineProperty('selfAssignPrimaryKey', false, 'inherit')
 
     /**
-     * Inherit encryption provider.
-     */
-    this.$defineProperty('$encryption', undefined, 'inherit')
-
-    /**
      * Define the keys' property. This allows looking up variations
      * for model keys
      */

--- a/src/orm/base_model/index.ts
+++ b/src/orm/base_model/index.ts
@@ -1408,8 +1408,23 @@ class BaseModelImpl implements LucidRow {
         return
       }
 
-      const blindColumnName = encryption.blindColumnName as string
-      const purpose = encryption.purpose as string
+      const dottedAttribute = `${Model.name}.${key}`
+      const blindColumnName = encryption.blindColumnName?.trim()
+      if (!blindColumnName) {
+        throw new errors.E_INVALID_ENCRYPTED_COLUMN_CONFIGURATION([
+          dottedAttribute,
+          'Missing "blind.columnName"',
+        ])
+      }
+
+      const purpose = encryption.purpose?.trim()
+      if (!purpose) {
+        throw new errors.E_INVALID_ENCRYPTED_COLUMN_CONFIGURATION([
+          dottedAttribute,
+          'Missing "blind.purpose"',
+        ])
+      }
+
       const encryptionProvider = Model.$getEncryption(key)
 
       result[blindColumnName] =

--- a/src/orm/base_model/index.ts
+++ b/src/orm/base_model/index.ts
@@ -1406,7 +1406,10 @@ class BaseModelImpl implements LucidRow {
         result[blindColumnName] =
           attributes[key] === null || attributes[key] === undefined
             ? attributes[key]
-            : encryptionProvider.blindIndex(attributes[key], { purpose })
+            : encryptionProvider.blindIndex(attributes[key], {
+                purpose,
+                driver: encryption.driver,
+              })
       }
 
       return result

--- a/src/orm/base_model/index.ts
+++ b/src/orm/base_model/index.ts
@@ -35,6 +35,8 @@ import {
   type ModelKeysContract,
   type ModelAssignOptions,
   type ModelAdapterOptions,
+  type EncryptedColumnMode,
+  type ModelEncryptionConfig,
   type ModelEncryptionContract,
   type ModelRelationOptions,
   type ModelQueryBuilderContract,
@@ -116,7 +118,7 @@ class BaseModelImpl implements LucidRow {
   /**
    * Encryption provider used by encrypted columns.
    */
-  static $encryption?: ModelEncryptionContract
+  static $encryption?: ModelEncryptionConfig
 
   /**
    * Define an adapter to use for interacting with
@@ -129,8 +131,8 @@ class BaseModelImpl implements LucidRow {
   /**
    * Define encryption provider to use for encrypted columns.
    */
-  static useEncryption(encryption: ModelEncryptionContract) {
-    this.$encryption = encryption
+  static useEncryption(config: ModelEncryptionConfig) {
+    this.$encryption = config
   }
 
   /**
@@ -139,12 +141,38 @@ class BaseModelImpl implements LucidRow {
   static $getEncryption(attributeName?: string): ModelEncryptionContract {
     this.boot()
 
-    if (this.$encryption) {
-      return this.$encryption
+    if (this.$encryption?.provider) {
+      return this.$encryption.provider
     }
 
     const dottedAttribute = attributeName ? `${this.name}.${attributeName}` : this.name
     throw new errors.E_MISSING_MODEL_ENCRYPTION([dottedAttribute])
+  }
+
+  /**
+   * Returns encryption provider and driver for a given encrypted column mode.
+   */
+  static $resolveEncryption(
+    attributeName: string | undefined,
+    mode: EncryptedColumnMode,
+    columnDriver?: string
+  ): {
+    provider: ModelEncryptionContract
+    driver?: string
+  } {
+    const provider = this.$getEncryption(attributeName)
+    const defaults = this.$encryption?.defaults
+    const defaultDriver =
+      mode === 'deterministic'
+        ? defaults?.deterministicDriver
+        : mode === 'blind'
+          ? defaults?.blindDriver
+          : defaults?.standardDriver
+
+    return {
+      provider,
+      driver: columnDriver ?? defaultDriver,
+    }
   }
 
   /**
@@ -1435,14 +1463,14 @@ class BaseModelImpl implements LucidRow {
      * always win over any manually assigned blind column value.
      */
     blindWrites.forEach(({ key, value, purpose, blindColumnName, driver }) => {
-      const encryptionProvider = Model.$getEncryption(key)
+      const encryption = Model.$resolveEncryption(key, 'blind', driver)
 
       result[blindColumnName] =
         value === null || value === undefined
           ? value
-          : encryptionProvider.blindIndex(value, {
+          : encryption.provider.blindIndex(value, {
               purpose,
-              driver,
+              driver: encryption.driver,
             })
     })
 

--- a/src/orm/base_model/index.ts
+++ b/src/orm/base_model/index.ts
@@ -35,6 +35,7 @@ import {
   type ModelKeysContract,
   type ModelAssignOptions,
   type ModelAdapterOptions,
+  type ModelEncryptionContract,
   type ModelRelationOptions,
   type ModelQueryBuilderContract,
   type ModelPaginatorContract,
@@ -113,11 +114,37 @@ class BaseModelImpl implements LucidRow {
   static $adapter: AdapterContract
 
   /**
+   * Encryption provider used by encrypted columns.
+   */
+  static $encryption?: ModelEncryptionContract
+
+  /**
    * Define an adapter to use for interacting with
    * the database
    */
   static useAdapter(adapter: AdapterContract) {
     this.$adapter = adapter
+  }
+
+  /**
+   * Define encryption provider to use for encrypted columns.
+   */
+  static useEncryption(encryption: ModelEncryptionContract) {
+    this.$encryption = encryption
+  }
+
+  /**
+   * Returns encryption provider and raises when missing.
+   */
+  static $getEncryption(attributeName?: string): ModelEncryptionContract {
+    this.boot()
+
+    if (this.$encryption) {
+      return this.$encryption
+    }
+
+    const dottedAttribute = attributeName ? `${this.name}.${attributeName}` : this.name
+    throw new errors.E_MISSING_MODEL_ENCRYPTION([dottedAttribute])
   }
 
   /**
@@ -646,6 +673,11 @@ class BaseModelImpl implements LucidRow {
      * Inherit selfAssignPrimaryKey or default to "false"
      */
     this.$defineProperty('selfAssignPrimaryKey', false, 'inherit')
+
+    /**
+     * Inherit encryption provider.
+     */
+    this.$defineProperty('$encryption', undefined, 'inherit')
 
     /**
      * Define the keys' property. This allows looking up variations
@@ -1357,6 +1389,7 @@ class BaseModelImpl implements LucidRow {
 
     return Object.keys(attributes).reduce((result: any, key) => {
       const column = Model.$getColumn(key)!
+      const encryption = column.meta?.encryption
 
       const value =
         typeof column.prepare === 'function'
@@ -1364,6 +1397,18 @@ class BaseModelImpl implements LucidRow {
           : attributes[key]
 
       result[column.columnName] = value
+
+      if (encryption?.mode === 'blind') {
+        const blindColumnName = encryption.blindColumnName as string
+        const purpose = encryption.purpose as string
+        const encryptionProvider = Model.$getEncryption(key)
+
+        result[blindColumnName] =
+          attributes[key] === null || attributes[key] === undefined
+            ? attributes[key]
+            : encryptionProvider.blindIndex(attributes[key], { purpose })
+      }
+
       return result
     }, {})
   }

--- a/src/orm/base_model/index.ts
+++ b/src/orm/base_model/index.ts
@@ -1387,33 +1387,41 @@ class BaseModelImpl implements LucidRow {
   protected prepareForAdapter(attributes: ModelObject) {
     const Model = this.constructor as typeof BaseModel
 
-    return Object.keys(attributes).reduce((result: any, key) => {
+    const result = Object.keys(attributes).reduce((acc: any, key) => {
       const column = Model.$getColumn(key)!
-      const encryption = column.meta?.encryption
 
       const value =
         typeof column.prepare === 'function'
           ? column.prepare(attributes[key], key, this)
           : attributes[key]
 
-      result[column.columnName] = value
+      acc[column.columnName] = value
 
-      if (encryption?.mode === 'blind') {
-        const blindColumnName = encryption.blindColumnName as string
-        const purpose = encryption.purpose as string
-        const encryptionProvider = Model.$getEncryption(key)
+      return acc
+    }, {})
 
-        result[blindColumnName] =
-          attributes[key] === null || attributes[key] === undefined
-            ? attributes[key]
-            : encryptionProvider.blindIndex(attributes[key], {
-                purpose,
-                driver: encryption.driver,
-              })
+    Object.keys(attributes).forEach((key) => {
+      const column = Model.$getColumn(key)!
+      const encryption = column.meta?.encryption
+
+      if (encryption?.mode !== 'blind') {
+        return
       }
 
-      return result
-    }, {})
+      const blindColumnName = encryption.blindColumnName as string
+      const purpose = encryption.purpose as string
+      const encryptionProvider = Model.$getEncryption(key)
+
+      result[blindColumnName] =
+        attributes[key] === null || attributes[key] === undefined
+          ? attributes[key]
+          : encryptionProvider.blindIndex(attributes[key], {
+              purpose,
+              driver: encryption.driver,
+            })
+    })
+
+    return result
   }
 
   /**

--- a/src/orm/base_model/index.ts
+++ b/src/orm/base_model/index.ts
@@ -1386,26 +1386,25 @@ class BaseModelImpl implements LucidRow {
    */
   protected prepareForAdapter(attributes: ModelObject) {
     const Model = this.constructor as typeof BaseModel
-
+    const blindWrites: Array<{
+      key: string
+      value: any
+      purpose: string
+      blindColumnName: string
+      driver?: string
+    }> = []
     const result = Object.keys(attributes).reduce((acc: any, key) => {
       const column = Model.$getColumn(key)!
+      const attributeValue = attributes[key]
 
-      const value =
+      acc[column.columnName] =
         typeof column.prepare === 'function'
-          ? column.prepare(attributes[key], key, this)
-          : attributes[key]
+          ? column.prepare(attributeValue, key, this)
+          : attributeValue
 
-      acc[column.columnName] = value
-
-      return acc
-    }, {})
-
-    Object.keys(attributes).forEach((key) => {
-      const column = Model.$getColumn(key)!
       const encryption = column.meta?.encryption
-
       if (encryption?.mode !== 'blind') {
-        return
+        return acc
       }
 
       const dottedAttribute = `${Model.name}.${key}`
@@ -1425,14 +1424,30 @@ class BaseModelImpl implements LucidRow {
         ])
       }
 
+      blindWrites.push({
+        key,
+        value: attributeValue,
+        purpose,
+        blindColumnName,
+        driver: encryption.driver,
+      })
+
+      return acc
+    }, {})
+
+    /**
+     * Apply blind writes after preparing base columns so computed blind indexes
+     * always win over any manually assigned blind column value.
+     */
+    blindWrites.forEach(({ key, value, purpose, blindColumnName, driver }) => {
       const encryptionProvider = Model.$getEncryption(key)
 
       result[blindColumnName] =
-        attributes[key] === null || attributes[key] === undefined
-          ? attributes[key]
-          : encryptionProvider.blindIndex(attributes[key], {
+        value === null || value === undefined
+          ? value
+          : encryptionProvider.blindIndex(value, {
               purpose,
-              driver: encryption.driver,
+              driver,
             })
     })
 

--- a/src/orm/decorators/encrypted.ts
+++ b/src/orm/decorators/encrypted.ts
@@ -1,0 +1,109 @@
+/*
+ * @adonisjs/lucid
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import * as errors from '../../errors.js'
+import {
+  type LucidRow,
+  type LucidModel,
+  type EncryptedColumnMeta,
+  type EncryptedColumnOptions,
+  type EncryptedColumnDecorator,
+} from '../../types/model.js'
+
+function defineEncryptedMeta(
+  model: LucidModel,
+  property: string,
+  options?: EncryptedColumnOptions
+): EncryptedColumnMeta {
+  const dottedAttribute = `${model.name}.${property}`
+
+  if (options?.deterministic && options?.blind) {
+    throw new errors.E_INVALID_ENCRYPTED_COLUMN_CONFIGURATION([
+      dottedAttribute,
+      'The "deterministic" and "blind" options cannot be used together',
+    ])
+  }
+
+  if (options?.blind) {
+    if (!options.blind.columnName?.trim()) {
+      throw new errors.E_INVALID_ENCRYPTED_COLUMN_CONFIGURATION([
+        dottedAttribute,
+        'Missing "blind.columnName"',
+      ])
+    }
+
+    if (!options.blind.purpose?.trim()) {
+      throw new errors.E_INVALID_ENCRYPTED_COLUMN_CONFIGURATION([
+        dottedAttribute,
+        'Missing "blind.purpose"',
+      ])
+    }
+
+    return {
+      mode: 'blind',
+      blindColumnName: options.blind.columnName,
+      purpose: options.blind.purpose,
+    }
+  }
+
+  if (options?.deterministic) {
+    return {
+      mode: 'deterministic',
+    }
+  }
+
+  return {
+    mode: 'standard',
+  }
+}
+
+/**
+ * Decorator to define an encrypted column
+ */
+export const encryptedColumn: EncryptedColumnDecorator = (options?) => {
+  return function decorateAsEncryptedColumn(target, property) {
+    const Model = target.constructor as LucidModel
+    Model.boot()
+
+    const {
+      deterministic: droppedDeterministic,
+      blind: droppedBlind,
+      ...columnOptions
+    } = options || {}
+    void droppedDeterministic
+    void droppedBlind
+    const encryptionMeta = defineEncryptedMeta(Model, property, options)
+    const meta = Object.assign({}, columnOptions.meta, { encryption: encryptionMeta })
+
+    Model.$addColumn(property, {
+      ...columnOptions,
+      meta,
+      prepare(value: any, attributeName: string, modelInstance: LucidRow) {
+        if (value === null || value === undefined) {
+          return value
+        }
+
+        const encryption = (modelInstance.constructor as LucidModel).$getEncryption(attributeName)
+        if (encryptionMeta.mode === 'deterministic') {
+          return encryption.encrypt(value, { deterministic: true })
+        }
+
+        return encryption.encrypt(value)
+      },
+      consume(value: any, attributeName: string, modelInstance: LucidRow) {
+        if (value === null || value === undefined) {
+          return value
+        }
+
+        const encryption = (modelInstance.constructor as LucidModel).$getEncryption(attributeName)
+        return encryption.decrypt(value)
+      },
+    })
+  }
+}

--- a/src/orm/decorators/encrypted.ts
+++ b/src/orm/decorators/encrypted.ts
@@ -74,14 +74,13 @@ export const encryptedColumn: EncryptedColumnDecorator = (options?) => {
     const Model = target.constructor as LucidModel
     Model.boot()
 
-    const {
-      deterministic: droppedDeterministic,
-      blind: droppedBlind,
-      ...columnOptions
-    } = options || {}
-    void droppedDeterministic
-    void droppedBlind
-    const encryptionMeta = defineEncryptedMeta(Model, property, options)
+    const { deterministic, blind, driver, ...columnOptions } = options || {}
+
+    const encryptionMeta = defineEncryptedMeta(Model, property, {
+      deterministic,
+      blind,
+      driver,
+    })
     const meta = Object.assign({}, columnOptions.meta, { encryption: encryptionMeta })
 
     Model.$addColumn(property, {

--- a/src/orm/decorators/encrypted.ts
+++ b/src/orm/decorators/encrypted.ts
@@ -111,6 +111,11 @@ export const encryptedColumn: EncryptedColumnDecorator = (options?) => {
         }
 
         const encryption = (modelInstance.constructor as LucidModel).$getEncryption(attributeName)
+
+        if (encryptionMeta.driver) {
+          return encryption.decrypt(value, { driver: encryptionMeta.driver })
+        }
+
         return encryption.decrypt(value)
       },
     })

--- a/src/orm/decorators/encrypted.ts
+++ b/src/orm/decorators/encrypted.ts
@@ -95,32 +95,48 @@ export const encryptedColumn: EncryptedColumnDecorator = (options?) => {
           return value
         }
 
-        const encryption = (modelInstance.constructor as LucidModel).$getEncryption(attributeName)
+        const model = modelInstance.constructor as LucidModel
         if (encryptionMeta.mode === 'deterministic') {
-          return encryption.encrypt(value, {
-            deterministic: true,
-            driver: encryptionMeta.driver,
-          })
+          const encryption = model.$resolveEncryption(
+            attributeName,
+            'deterministic',
+            encryptionMeta.driver
+          )
+
+          return encryption.driver
+            ? encryption.provider.encrypt(value, {
+                deterministic: true,
+                driver: encryption.driver,
+              })
+            : encryption.provider.encrypt(value, {
+                deterministic: true,
+              })
         }
 
-        if (encryptionMeta.driver) {
-          return encryption.encrypt(value, { driver: encryptionMeta.driver })
-        }
+        const encryption = model.$resolveEncryption(
+          attributeName,
+          encryptionMeta.mode,
+          encryptionMeta.driver
+        )
 
-        return encryption.encrypt(value)
+        return encryption.driver
+          ? encryption.provider.encrypt(value, { driver: encryption.driver })
+          : encryption.provider.encrypt(value)
       },
       consume(value: any, attributeName: string, modelInstance: LucidRow) {
         if (value === null || value === undefined) {
           return value
         }
 
-        const encryption = (modelInstance.constructor as LucidModel).$getEncryption(attributeName)
+        const encryption = (modelInstance.constructor as LucidModel).$resolveEncryption(
+          attributeName,
+          encryptionMeta.mode,
+          encryptionMeta.driver
+        )
 
-        if (encryptionMeta.driver) {
-          return encryption.decrypt(value, { driver: encryptionMeta.driver })
-        }
-
-        return encryption.decrypt(value)
+        return encryption.driver
+          ? encryption.provider.decrypt(value, { driver: encryption.driver })
+          : encryption.provider.decrypt(value)
       },
     })
   }

--- a/src/orm/decorators/encrypted.ts
+++ b/src/orm/decorators/encrypted.ts
@@ -22,6 +22,7 @@ function defineEncryptedMeta(
   options?: EncryptedColumnOptions
 ): EncryptedColumnMeta {
   const dottedAttribute = `${model.name}.${property}`
+  const driver = options?.driver
 
   if (options?.deterministic && options?.blind) {
     throw new errors.E_INVALID_ENCRYPTED_COLUMN_CONFIGURATION([
@@ -31,14 +32,17 @@ function defineEncryptedMeta(
   }
 
   if (options?.blind) {
-    if (!options.blind.columnName?.trim()) {
+    const blindColumnName = options.blind.columnName?.trim()
+    const purpose = options.blind.purpose?.trim()
+
+    if (!blindColumnName) {
       throw new errors.E_INVALID_ENCRYPTED_COLUMN_CONFIGURATION([
         dottedAttribute,
         'Missing "blind.columnName"',
       ])
     }
 
-    if (!options.blind.purpose?.trim()) {
+    if (!purpose) {
       throw new errors.E_INVALID_ENCRYPTED_COLUMN_CONFIGURATION([
         dottedAttribute,
         'Missing "blind.purpose"',
@@ -47,22 +51,22 @@ function defineEncryptedMeta(
 
     return {
       mode: 'blind',
-      driver: options.driver,
-      blindColumnName: options.blind.columnName,
-      purpose: options.blind.purpose,
+      driver,
+      blindColumnName,
+      purpose,
     }
   }
 
   if (options?.deterministic) {
     return {
       mode: 'deterministic',
-      driver: options.driver,
+      driver,
     }
   }
 
   return {
     mode: 'standard',
-    driver: options?.driver,
+    driver,
   }
 }
 

--- a/src/orm/decorators/encrypted.ts
+++ b/src/orm/decorators/encrypted.ts
@@ -47,6 +47,7 @@ function defineEncryptedMeta(
 
     return {
       mode: 'blind',
+      driver: options.driver,
       blindColumnName: options.blind.columnName,
       purpose: options.blind.purpose,
     }
@@ -55,11 +56,13 @@ function defineEncryptedMeta(
   if (options?.deterministic) {
     return {
       mode: 'deterministic',
+      driver: options.driver,
     }
   }
 
   return {
     mode: 'standard',
+    driver: options?.driver,
   }
 }
 
@@ -91,7 +94,14 @@ export const encryptedColumn: EncryptedColumnDecorator = (options?) => {
 
         const encryption = (modelInstance.constructor as LucidModel).$getEncryption(attributeName)
         if (encryptionMeta.mode === 'deterministic') {
-          return encryption.encrypt(value, { deterministic: true })
+          return encryption.encrypt(value, {
+            deterministic: true,
+            driver: encryptionMeta.driver,
+          })
+        }
+
+        if (encryptionMeta.driver) {
+          return encryption.encrypt(value, { driver: encryptionMeta.driver })
         }
 
         return encryption.encrypt(value)

--- a/src/orm/decorators/index.ts
+++ b/src/orm/decorators/index.ts
@@ -11,6 +11,7 @@ import {
   type LucidModel,
   type HooksDecorator,
   type ColumnDecorator,
+  type EncryptedColumnDecorator,
   type ComputedDecorator,
   type DateColumnDecorator,
   type DateTimeColumnDecorator,
@@ -26,6 +27,7 @@ import {
 
 import { dateColumn } from './date.js'
 import { dateTimeColumn } from './date_time.js'
+import { encryptedColumn } from './encrypted.js'
 
 /**
  * Define property on a model as a column. The decorator needs a
@@ -34,6 +36,7 @@ import { dateTimeColumn } from './date_time.js'
 export const column: ColumnDecorator & {
   date: DateColumnDecorator
   dateTime: DateTimeColumnDecorator
+  encrypted: EncryptedColumnDecorator
 } = (options?) => {
   return function decorateAsColumn(target, property) {
     const Model = target.constructor as LucidModel
@@ -44,6 +47,7 @@ export const column: ColumnDecorator & {
 
 column.date = dateColumn
 column.dateTime = dateTimeColumn
+column.encrypted = encryptedColumn
 
 /**
  * Define computed property on a model. The decorator needs a

--- a/src/orm/main.ts
+++ b/src/orm/main.ts
@@ -10,6 +10,7 @@
 export * from './decorators/index.js'
 export * from './decorators/date.js'
 export * from './decorators/date_time.js'
+export * from './decorators/encrypted.js'
 export { BaseModel, scope } from './base_model/index.js'
 export { ModelQueryBuilder } from './query_builder/index.js'
 export { ModelPaginator } from './paginator/index.js'

--- a/src/orm/query_builder/encrypted_query_support.ts
+++ b/src/orm/query_builder/encrypted_query_support.ts
@@ -1,0 +1,567 @@
+/*
+ * @adonisjs/lucid
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import {
+  type LucidModel,
+  type EncryptedColumnMeta,
+  type ModelColumnOptions,
+} from '../../types/model.js'
+import { type Dictionary } from '../../types/querybuilder.js'
+import { isObject } from '../../utils/index.js'
+import { Chainable } from '../../database/query_builder/chainable.js'
+import * as errors from '../../errors.js'
+
+type EncryptedQueryColumn = {
+  key: string
+  attributeName: string
+  columnName: string
+  encryption: EncryptedColumnMeta
+}
+
+type EncryptedWhereArgs = [any] | [any, any] | [any, any, any]
+
+export type EncryptedWhereMethod = 'where' | 'orWhere' | 'whereNot' | 'orWhereNot'
+export type EncryptedWhereInMethod = 'whereIn' | 'orWhereIn' | 'whereNotIn' | 'orWhereNotIn'
+
+export type EncryptedWhereRewrite =
+  | {
+      target: 'where'
+      method: EncryptedWhereMethod
+      args: EncryptedWhereArgs
+    }
+  | {
+      target: 'whereIn'
+      method: EncryptedWhereInMethod
+      columns: any
+      value: any
+    }
+
+export type EncryptedWhereInRewrite = {
+  method: EncryptedWhereInMethod
+  columns: any
+  value: any
+}
+
+/**
+ * Encapsulates encrypted-column query rewriting and write payload preparation.
+ */
+export class EncryptedQuerySupport {
+  readonly #model: LucidModel
+  readonly #getTableAlias: () => string | undefined
+
+  constructor(model: LucidModel, getTableAlias: () => string | undefined = () => undefined) {
+    this.#model = model
+    this.#getTableAlias = getTableAlias
+  }
+
+  rewriteWhereTernary(
+    method: EncryptedWhereMethod,
+    key: string,
+    operator: any,
+    value: any
+  ): EncryptedWhereRewrite {
+    const column = this.#getEncryptedQueryColumn(key, true)
+    this.#ensureStandardEncryptedQuerySupport(column, method)
+
+    const inOperatorRewrite = this.#rewriteInOperator(method, key, operator, value)
+    if (inOperatorRewrite) {
+      return {
+        target: 'whereIn',
+        ...inOperatorRewrite,
+      }
+    }
+
+    this.#ensureEncryptedEqualityOperator(column, operator, method)
+
+    if (column?.encryption.mode === 'blind') {
+      const encryptedValues = this.#getEncryptedQueryValues(column, value)
+      const encryptedKey = this.#getEncryptedQueryKey(column)
+      const whereInMethod = this.#getEncryptedWhereInMethod(method)
+
+      if (encryptedValues.length > 1) {
+        return {
+          target: 'whereIn',
+          method: whereInMethod,
+          columns: encryptedKey,
+          value: encryptedValues,
+        }
+      }
+
+      return this.#toWhereCall(method, encryptedKey, operator, encryptedValues[0])
+    }
+
+    return this.#toWhereCall(
+      method,
+      column ? this.#getEncryptedQueryKey(column) : key,
+      operator,
+      column ? this.#getEncryptedQueryValue(column, value) : value
+    )
+  }
+
+  rewriteWhereBinary(method: EncryptedWhereMethod, key: string, value: any): EncryptedWhereRewrite {
+    const column = this.#getEncryptedQueryColumn(key, true)
+    this.#ensureStandardEncryptedQuerySupport(column, method)
+
+    if (column?.encryption.mode === 'blind') {
+      const encryptedValues = this.#getEncryptedQueryValues(column, value)
+      const encryptedKey = this.#getEncryptedQueryKey(column)
+      const whereInMethod = this.#getEncryptedWhereInMethod(method)
+
+      if (encryptedValues.length > 1) {
+        return {
+          target: 'whereIn',
+          method: whereInMethod,
+          columns: encryptedKey,
+          value: encryptedValues,
+        }
+      }
+
+      return this.#toWhereCall(method, encryptedKey, encryptedValues[0])
+    }
+
+    return this.#toWhereCall(
+      method,
+      column ? this.#getEncryptedQueryKey(column) : key,
+      column ? this.#getEncryptedQueryValue(column, value) : value
+    )
+  }
+
+  rewriteWhereIn(
+    method: EncryptedWhereInMethod,
+    columns: any,
+    value: any
+  ): EncryptedWhereInRewrite {
+    if (typeof columns !== 'string') {
+      return {
+        method,
+        columns,
+        value,
+      }
+    }
+
+    const column = this.#getEncryptedQueryColumn(columns, true)
+    this.#ensureStandardEncryptedQuerySupport(column, method)
+
+    if (!column) {
+      return {
+        method,
+        columns,
+        value,
+      }
+    }
+
+    const transformedValue = Array.isArray(value)
+      ? value.flatMap((item) => this.#getEncryptedQueryValues(column, item))
+      : this.#isQueryBuilderValue(value)
+        ? value
+        : this.#getEncryptedQueryValues(column, value)
+
+    return {
+      method,
+      columns: this.#getEncryptedQueryKey(column),
+      value: transformedValue,
+    }
+  }
+
+  ensureMethodSupport(key: any, method: string) {
+    const column = this.#getEncryptedQueryColumn(key, true)
+    if (column) {
+      this.#raiseUnsupportedEncryptedColumn(method, column)
+    }
+  }
+
+  ensureColumnComparisonSupport(method: string, column: any, comparisonColumn: any) {
+    this.ensureMethodSupport(column, method)
+    this.ensureMethodSupport(comparisonColumn, method)
+  }
+
+  ensureArithmeticSupport(key: any, method: string) {
+    const keys = typeof key === 'string' ? [key] : isObject(key) ? Object.keys(key) : []
+
+    for (const columnKey of keys) {
+      this.ensureMethodSupport(columnKey, method)
+    }
+  }
+
+  prepareUpdateValues(
+    values: Dictionary<any, string>,
+    resolveKey: (key: string) => string,
+    transformRaw: (value: any) => any
+  ): Dictionary<any, string> {
+    const result: Dictionary<any, string> = {}
+    const blindWrites: Array<{ value: any; column: EncryptedQueryColumn }> = []
+
+    for (const [key, value] of Object.entries(values)) {
+      const column = this.#getEncryptedQueryColumn(key, true)
+      if (!column) {
+        result[resolveKey(key)] = transformRaw(value)
+        continue
+      }
+
+      result[resolveKey(key)] = transformRaw(this.#getEncryptedWriteValue(column, value))
+
+      if (column.encryption.mode === 'blind') {
+        blindWrites.push({ value, column })
+      }
+    }
+
+    /**
+     * Apply blind writes after processing the original payload so computed indexes
+     * always win over any manually provided blind column value, regardless of key order.
+     */
+    for (const { value, column } of blindWrites) {
+      const blindResult = this.#getBlindWriteValue(column, value)
+      if (blindResult.shouldWrite) {
+        result[resolveKey(this.#getEncryptedQueryKey(column))] = transformRaw(blindResult.value)
+      }
+    }
+
+    return result
+  }
+
+  #toWhereCall(
+    method: EncryptedWhereMethod,
+    key: any,
+    operator?: any,
+    value?: any
+  ): EncryptedWhereRewrite {
+    if (value !== undefined) {
+      return {
+        target: 'where',
+        method,
+        args: [key, operator, value],
+      }
+    }
+
+    if (operator !== undefined) {
+      return {
+        target: 'where',
+        method,
+        args: [key, operator],
+      }
+    }
+
+    return {
+      target: 'where',
+      method,
+      args: [key],
+    }
+  }
+
+  #rewriteInOperator(
+    method: EncryptedWhereMethod,
+    key: string,
+    operator: any,
+    value: any
+  ): EncryptedWhereInRewrite | null {
+    const column = this.#getEncryptedQueryColumn(key)
+    if (!column) {
+      return null
+    }
+
+    const normalizedOperator = this.#normalizeOperator(operator)
+    if (!this.#isInOperator(normalizedOperator) && !this.#isNotInOperator(normalizedOperator)) {
+      return null
+    }
+
+    const whereInMethod = this.#getEncryptedWhereInMethod(method)
+    const targetMethod = this.#isInOperator(normalizedOperator)
+      ? whereInMethod
+      : this.#getOppositeEncryptedWhereInMethod(whereInMethod)
+
+    return this.rewriteWhereIn(targetMethod, key, value)
+  }
+
+  #getEncryptedWhereInMethod(method: EncryptedWhereMethod): EncryptedWhereInMethod {
+    switch (method) {
+      case 'where':
+        return 'whereIn'
+      case 'orWhere':
+        return 'orWhereIn'
+      case 'whereNot':
+        return 'whereNotIn'
+      case 'orWhereNot':
+        return 'orWhereNotIn'
+    }
+  }
+
+  #getOppositeEncryptedWhereInMethod(method: EncryptedWhereInMethod): EncryptedWhereInMethod {
+    switch (method) {
+      case 'whereIn':
+        return 'whereNotIn'
+      case 'orWhereIn':
+        return 'orWhereNotIn'
+      case 'whereNotIn':
+        return 'whereIn'
+      case 'orWhereNotIn':
+        return 'orWhereIn'
+    }
+  }
+
+  #getEncryptedQueryColumn(
+    key: any,
+    includeStandard: boolean = false
+  ): EncryptedQueryColumn | null {
+    if (typeof key !== 'string') {
+      return null
+    }
+
+    const lastDot = key.lastIndexOf('.')
+    const normalizedKey = lastDot >= 0 ? key.slice(lastDot + 1) : key
+
+    if (lastDot >= 0) {
+      const source = key.slice(0, lastDot)
+      if (!this.#isModelColumnSource(source)) {
+        return null
+      }
+    }
+
+    const attributeName =
+      this.#model.$keys.columnsToAttributes.get(normalizedKey) ??
+      this.#model.$keys.columnsToAttributes.get(key) ??
+      normalizedKey
+
+    if (!this.#model.$hasColumn(attributeName)) {
+      return null
+    }
+
+    const column = this.#model.$getColumn(attributeName) as ModelColumnOptions
+    if (!this.#isModelColumnReference(normalizedKey, attributeName, column.columnName)) {
+      return null
+    }
+
+    const encryption = column.meta?.encryption as EncryptedColumnMeta | undefined
+    if (!encryption || (!includeStandard && encryption.mode === 'standard')) {
+      return null
+    }
+
+    return {
+      key,
+      attributeName,
+      columnName: column.columnName,
+      encryption,
+    }
+  }
+
+  #isModelColumnSource(source: string): boolean {
+    if (source === this.#model.table || source.endsWith(`.${this.#model.table}`)) {
+      return true
+    }
+
+    const tableAlias = this.#getTableAlias()
+    if (tableAlias && (source === tableAlias || source.endsWith(`.${tableAlias}`))) {
+      return true
+    }
+
+    return false
+  }
+
+  #isModelColumnReference(column: string, attributeName: string, columnName: string): boolean {
+    return column === attributeName || column === columnName
+  }
+
+  #isQueryBuilderValue(value: any): boolean {
+    if (value instanceof Chainable || typeof value === 'function') {
+      return true
+    }
+
+    return !!value && typeof value === 'object' && ('knexQuery' in value || 'toKnex' in value)
+  }
+
+  #getEncryptedQueryKey(column: EncryptedQueryColumn): string {
+    if (column.encryption.mode !== 'blind') {
+      return column.key
+    }
+
+    const blindColumnName = column.encryption.blindColumnName
+    if (!blindColumnName) {
+      throw new errors.E_INVALID_ENCRYPTED_COLUMN_CONFIGURATION([
+        `${this.#model.name}.${column.attributeName}`,
+        'Missing "blind.columnName"',
+      ])
+    }
+
+    if (column.key === column.attributeName || column.key === column.columnName) {
+      return blindColumnName
+    }
+
+    if (
+      column.key.endsWith(`.${column.attributeName}`) ||
+      column.key.endsWith(`.${column.columnName}`)
+    ) {
+      const lastDot = column.key.lastIndexOf('.')
+      return `${column.key.slice(0, lastDot + 1)}${blindColumnName}`
+    }
+
+    return blindColumnName
+  }
+
+  #normalizeBlindIndexValues(indexes: any): any[] {
+    if (!indexes) {
+      return []
+    }
+
+    if (Array.isArray(indexes)) {
+      return indexes.filter((item) => item !== null && item !== undefined)
+    }
+
+    if (isObject(indexes)) {
+      return Object.values(indexes).filter((item) => item !== null && item !== undefined)
+    }
+
+    return [indexes]
+  }
+
+  #getEncryptedQueryValues(column: EncryptedQueryColumn, value: any): any[] {
+    if (value === null || value === undefined || this.#isQueryBuilderValue(value)) {
+      return [value]
+    }
+
+    const encryption = this.#model.$getEncryption(column.attributeName)
+    if (column.encryption.mode === 'deterministic') {
+      return [
+        encryption.encrypt(value, {
+          deterministic: true,
+          driver: column.encryption.driver,
+        }),
+      ]
+    }
+
+    if (!column.encryption.purpose) {
+      throw new errors.E_INVALID_ENCRYPTED_COLUMN_CONFIGURATION([
+        `${this.#model.name}.${column.attributeName}`,
+        'Missing "blind.purpose"',
+      ])
+    }
+
+    const blindIndexes = this.#normalizeBlindIndexValues(
+      encryption.blindIndexes(value, {
+        purpose: column.encryption.purpose,
+        driver: column.encryption.driver,
+      })
+    )
+
+    if (blindIndexes.length) {
+      return blindIndexes
+    }
+
+    return [
+      encryption.blindIndex(value, {
+        purpose: column.encryption.purpose,
+        driver: column.encryption.driver,
+      }),
+    ]
+  }
+
+  #getEncryptedQueryValue(column: EncryptedQueryColumn, value: any): any {
+    return this.#getEncryptedQueryValues(column, value)[0]
+  }
+
+  #normalizeOperator(operator: any): string {
+    return typeof operator === 'string' ? operator.trim().replace(/\s+/g, ' ').toLowerCase() : ''
+  }
+
+  #isInOperator(operator: string): boolean {
+    return operator === 'in'
+  }
+
+  #isNotInOperator(operator: string): boolean {
+    return operator === 'not in'
+  }
+
+  #ensureEncryptedEqualityOperator(
+    column: EncryptedQueryColumn | null,
+    operator: any,
+    method: string
+  ) {
+    if (!column) {
+      return
+    }
+
+    const normalizedOperator = this.#normalizeOperator(operator)
+    if (
+      normalizedOperator !== '=' &&
+      !this.#isInOperator(normalizedOperator) &&
+      !this.#isNotInOperator(normalizedOperator)
+    ) {
+      this.#raiseUnsupportedEncryptedColumn(method, column)
+    }
+  }
+
+  #ensureStandardEncryptedQuerySupport(column: EncryptedQueryColumn | null, method: string) {
+    if (column?.encryption.mode === 'standard') {
+      throw new errors.E_UNSUPPORTED_STANDARD_ENCRYPTED_COLUMN_QUERY([
+        method,
+        `${this.#model.name}.${column.attributeName}`,
+      ])
+    }
+  }
+
+  #raiseUnsupportedEncryptedColumn(method: string, column: EncryptedQueryColumn) {
+    throw new errors.E_UNSUPPORTED_ENCRYPTED_COLUMN_QUERY([
+      method,
+      `${this.#model.name}.${column.attributeName}`,
+    ])
+  }
+
+  #getEncryptedWriteValue(column: EncryptedQueryColumn, value: any): any {
+    if (value === null || value === undefined || this.#isQueryBuilderValue(value)) {
+      return value
+    }
+
+    const encryption = this.#model.$getEncryption(column.attributeName)
+    if (column.encryption.mode === 'deterministic') {
+      return encryption.encrypt(value, {
+        deterministic: true,
+        driver: column.encryption.driver,
+      })
+    }
+
+    if (column.encryption.driver) {
+      return encryption.encrypt(value, {
+        driver: column.encryption.driver,
+      })
+    }
+
+    return encryption.encrypt(value)
+  }
+
+  #getBlindWriteValue(
+    column: EncryptedQueryColumn,
+    value: any
+  ): {
+    shouldWrite: boolean
+    value: any
+  } {
+    if (value === null || value === undefined) {
+      return { shouldWrite: true, value }
+    }
+
+    if (this.#isQueryBuilderValue(value)) {
+      return { shouldWrite: false, value: null }
+    }
+
+    const purpose = column.encryption.purpose
+    if (!purpose) {
+      throw new errors.E_INVALID_ENCRYPTED_COLUMN_CONFIGURATION([
+        `${this.#model.name}.${column.attributeName}`,
+        'Missing "blind.purpose"',
+      ])
+    }
+
+    const encryption = this.#model.$getEncryption(column.attributeName)
+    return {
+      shouldWrite: true,
+      value: encryption.blindIndex(value, {
+        purpose,
+        driver: column.encryption.driver,
+      }),
+    }
+  }
+}

--- a/src/orm/query_builder/encrypted_query_support.ts
+++ b/src/orm/query_builder/encrypted_query_support.ts
@@ -423,13 +423,22 @@ export class EncryptedQuerySupport {
       return [value]
     }
 
-    const encryption = this.#model.$getEncryption(column.attributeName)
     if (column.encryption.mode === 'deterministic') {
+      const encryption = this.#model.$resolveEncryption(
+        column.attributeName,
+        'deterministic',
+        column.encryption.driver
+      )
+
       return [
-        encryption.encrypt(value, {
-          deterministic: true,
-          driver: column.encryption.driver,
-        }),
+        encryption.driver
+          ? encryption.provider.encrypt(value, {
+              deterministic: true,
+              driver: encryption.driver,
+            })
+          : encryption.provider.encrypt(value, {
+              deterministic: true,
+            }),
       ]
     }
 
@@ -440,10 +449,16 @@ export class EncryptedQuerySupport {
       ])
     }
 
+    const encryption = this.#model.$resolveEncryption(
+      column.attributeName,
+      'blind',
+      column.encryption.driver
+    )
+
     const blindIndexes = this.#normalizeBlindIndexValues(
-      encryption.blindIndexes(value, {
+      encryption.provider.blindIndexes(value, {
         purpose: column.encryption.purpose,
-        driver: column.encryption.driver,
+        driver: encryption.driver,
       })
     )
 
@@ -452,9 +467,9 @@ export class EncryptedQuerySupport {
     }
 
     return [
-      encryption.blindIndex(value, {
+      encryption.provider.blindIndex(value, {
         purpose: column.encryption.purpose,
-        driver: column.encryption.driver,
+        driver: encryption.driver,
       }),
     ]
   }
@@ -515,21 +530,34 @@ export class EncryptedQuerySupport {
       return value
     }
 
-    const encryption = this.#model.$getEncryption(column.attributeName)
     if (column.encryption.mode === 'deterministic') {
-      return encryption.encrypt(value, {
-        deterministic: true,
-        driver: column.encryption.driver,
-      })
+      const encryption = this.#model.$resolveEncryption(
+        column.attributeName,
+        'deterministic',
+        column.encryption.driver
+      )
+
+      return encryption.driver
+        ? encryption.provider.encrypt(value, {
+            deterministic: true,
+            driver: encryption.driver,
+          })
+        : encryption.provider.encrypt(value, {
+            deterministic: true,
+          })
     }
 
-    if (column.encryption.driver) {
-      return encryption.encrypt(value, {
-        driver: column.encryption.driver,
-      })
-    }
+    const encryption = this.#model.$resolveEncryption(
+      column.attributeName,
+      column.encryption.mode,
+      column.encryption.driver
+    )
 
-    return encryption.encrypt(value)
+    return encryption.driver
+      ? encryption.provider.encrypt(value, {
+          driver: encryption.driver,
+        })
+      : encryption.provider.encrypt(value)
   }
 
   #getBlindWriteValue(
@@ -555,12 +583,17 @@ export class EncryptedQuerySupport {
       ])
     }
 
-    const encryption = this.#model.$getEncryption(column.attributeName)
+    const encryption = this.#model.$resolveEncryption(
+      column.attributeName,
+      'blind',
+      column.encryption.driver
+    )
+
     return {
       shouldWrite: true,
-      value: encryption.blindIndex(value, {
+      value: encryption.provider.blindIndex(value, {
         purpose,
-        driver: column.encryption.driver,
+        driver: encryption.driver,
       }),
     }
   }

--- a/src/orm/query_builder/index.ts
+++ b/src/orm/query_builder/index.ts
@@ -48,6 +48,9 @@ type EncryptedQueryColumn = {
   encryption: EncryptedColumnMeta
 }
 
+type EncryptedWhereMethod = 'where' | 'orWhere' | 'whereNot' | 'orWhereNot'
+type EncryptedWhereInMethod = 'whereIn' | 'orWhereIn' | 'whereNotIn' | 'orWhereNotIn'
+
 /**
  * A wrapper to invoke scope methods on the query builder
  * underlying model
@@ -404,7 +407,7 @@ export class ModelQueryBuilder
    * Routes operator forms using IN/NOT IN through the dedicated methods.
    */
   private handleEncryptedInOperator(
-    method: 'where' | 'orWhere' | 'whereNot' | 'orWhereNot',
+    method: EncryptedWhereMethod,
     key: string,
     operator: any,
     value: any
@@ -419,22 +422,231 @@ export class ModelQueryBuilder
       return null
     }
 
-    const usePositiveIn =
-      this.isInOperator(normalizedOperator) === (method === 'where' || method === 'orWhere')
+    const whereInMethod = this.getEncryptedWhereInMethod(method)
+    const targetMethod = this.isInOperator(normalizedOperator)
+      ? whereInMethod
+      : this.getOppositeEncryptedWhereInMethod(whereInMethod)
 
+    return this.encryptedWhereIn(targetMethod, key, value)
+  }
+
+  /**
+   * Returns the IN method associated with a WHERE variant.
+   */
+  private getEncryptedWhereInMethod(method: EncryptedWhereMethod): EncryptedWhereInMethod {
     if (method === 'where') {
-      return usePositiveIn ? this.whereIn(key, value) : this.whereNotIn(key, value)
+      return 'whereIn'
     }
 
     if (method === 'orWhere') {
-      return usePositiveIn ? this.orWhereIn(key, value) : this.orWhereNotIn(key, value)
+      return 'orWhereIn'
     }
 
     if (method === 'whereNot') {
-      return usePositiveIn ? this.whereIn(key, value) : this.whereNotIn(key, value)
+      return 'whereNotIn'
     }
 
-    return usePositiveIn ? this.orWhereIn(key, value) : this.orWhereNotIn(key, value)
+    return 'orWhereNotIn'
+  }
+
+  /**
+   * Returns the opposite IN method (IN <-> NOT IN) preserving the boolean variant.
+   */
+  private getOppositeEncryptedWhereInMethod(
+    method: EncryptedWhereInMethod
+  ): EncryptedWhereInMethod {
+    if (method === 'whereIn') {
+      return 'whereNotIn'
+    }
+
+    if (method === 'orWhereIn') {
+      return 'orWhereNotIn'
+    }
+
+    if (method === 'whereNotIn') {
+      return 'whereIn'
+    }
+
+    return 'orWhereIn'
+  }
+
+  /**
+   * Calls the matching super where* method with a single argument.
+   */
+  private callSuperWhereUnary(method: EncryptedWhereMethod, key: any): this {
+    if (method === 'where') {
+      return super.where(key)
+    }
+
+    if (method === 'orWhere') {
+      return super.orWhere(key)
+    }
+
+    if (method === 'whereNot') {
+      return super.whereNot(key)
+    }
+
+    return super.orWhereNot(key)
+  }
+
+  /**
+   * Calls the matching super where* method with 2 arguments.
+   */
+  private callSuperWhereBinary(method: EncryptedWhereMethod, key: any, value: any): this {
+    if (method === 'where') {
+      return super.where(key, value)
+    }
+
+    if (method === 'orWhere') {
+      return super.orWhere(key, value)
+    }
+
+    if (method === 'whereNot') {
+      return super.whereNot(key, value)
+    }
+
+    return super.orWhereNot(key, value)
+  }
+
+  /**
+   * Calls the matching super where* method with 3 arguments.
+   */
+  private callSuperWhereTernary(
+    method: EncryptedWhereMethod,
+    key: any,
+    operator: any,
+    value: any
+  ): this {
+    if (method === 'where') {
+      return super.where(key, operator, value)
+    }
+
+    if (method === 'orWhere') {
+      return super.orWhere(key, operator, value)
+    }
+
+    if (method === 'whereNot') {
+      return super.whereNot(key, operator, value)
+    }
+
+    return super.orWhereNot(key, operator, value)
+  }
+
+  /**
+   * Calls the matching super where*In method.
+   */
+  private callSuperWhereIn(method: EncryptedWhereInMethod, columns: any, value: any): this {
+    if (method === 'whereIn') {
+      return super.whereIn(columns, value)
+    }
+
+    if (method === 'orWhereIn') {
+      return super.orWhereIn(columns, value)
+    }
+
+    if (method === 'whereNotIn') {
+      return super.whereNotIn(columns, value)
+    }
+
+    return super.orWhereNotIn(columns, value)
+  }
+
+  /**
+   * Shared implementation for where/orWhere/whereNot/orWhereNot.
+   */
+  private encryptedWhere(
+    method: EncryptedWhereMethod,
+    key: any,
+    operator?: any,
+    value?: any
+  ): this {
+    if (value !== undefined && typeof key === 'string') {
+      const column = this.getEncryptedQueryColumn(key)
+      const inOperatorResult = this.handleEncryptedInOperator(method, key, operator, value)
+      if (inOperatorResult) {
+        return inOperatorResult
+      }
+      this.ensureEncryptedEqualityOperator(column, operator, method)
+
+      if (column?.encryption.mode === 'blind') {
+        const encryptedValues = this.getEncryptedQueryValues(column, value)
+        const encryptedKey = this.getEncryptedQueryKey(column)
+        const whereInMethod = this.getEncryptedWhereInMethod(method)
+
+        return encryptedValues.length > 1
+          ? this.callSuperWhereIn(whereInMethod, encryptedKey, encryptedValues)
+          : this.callSuperWhereTernary(method, encryptedKey, operator, encryptedValues[0])
+      }
+
+      return this.callSuperWhereTernary(
+        method,
+        column ? this.getEncryptedQueryKey(column) : key,
+        operator,
+        column ? this.getEncryptedQueryValue(column, value) : value
+      )
+    }
+
+    if (operator !== undefined && typeof key === 'string') {
+      const column = this.getEncryptedQueryColumn(key)
+
+      if (column?.encryption.mode === 'blind') {
+        const encryptedValues = this.getEncryptedQueryValues(column, operator)
+        const encryptedKey = this.getEncryptedQueryKey(column)
+        const whereInMethod = this.getEncryptedWhereInMethod(method)
+
+        return encryptedValues.length > 1
+          ? this.callSuperWhereIn(whereInMethod, encryptedKey, encryptedValues)
+          : this.callSuperWhereBinary(method, encryptedKey, encryptedValues[0])
+      }
+
+      return this.callSuperWhereBinary(
+        method,
+        column ? this.getEncryptedQueryKey(column) : key,
+        column ? this.getEncryptedQueryValue(column, operator) : operator
+      )
+    }
+
+    if (isObject(key)) {
+      if (method === 'where') {
+        const clauses = Object.entries(key)
+
+        if (!clauses.length) {
+          return this.callSuperWhereUnary(method, key)
+        }
+
+        clauses.forEach(([clauseKey, clauseValue]) => {
+          this.where(clauseKey, clauseValue)
+        })
+
+        return this
+      }
+
+      return this.callSuperWhereUnary(method, this.transformWhereObjectClause(key))
+    }
+
+    return this.callSuperWhereTernary(method, key, operator, value)
+  }
+
+  /**
+   * Shared implementation for whereIn/orWhereIn/whereNotIn/orWhereNotIn.
+   */
+  private encryptedWhereIn(method: EncryptedWhereInMethod, columns: any, value: any): this {
+    if (typeof columns !== 'string') {
+      return this.callSuperWhereIn(method, columns, value)
+    }
+
+    const column = this.getEncryptedQueryColumn(columns)
+    if (!column) {
+      return this.callSuperWhereIn(method, columns, value)
+    }
+
+    const transformedValue = Array.isArray(value)
+      ? value.flatMap((item) => this.getEncryptedQueryValues(column, item))
+      : this.isQueryBuilderValue(value)
+        ? value
+        : this.getEncryptedQueryValues(column, value)
+
+    return this.callSuperWhereIn(method, this.getEncryptedQueryKey(column), transformedValue)
   }
 
   /**
@@ -568,281 +780,35 @@ export class ModelQueryBuilder
   }
 
   where(key: any, operator?: any, value?: any): this {
-    if (value !== undefined && typeof key === 'string') {
-      const column = this.getEncryptedQueryColumn(key)
-      const inOperatorResult = this.handleEncryptedInOperator('where', key, operator, value)
-      if (inOperatorResult) {
-        return inOperatorResult
-      }
-      this.ensureEncryptedEqualityOperator(column, operator, 'where')
-
-      if (column?.encryption.mode === 'blind') {
-        const encryptedValues = this.getEncryptedQueryValues(column, value)
-        const encryptedKey = this.getEncryptedQueryKey(column)
-        return encryptedValues.length > 1
-          ? super.whereIn(encryptedKey, encryptedValues)
-          : super.where(encryptedKey, operator, encryptedValues[0])
-      }
-
-      return super.where(
-        column ? this.getEncryptedQueryKey(column) : key,
-        operator,
-        column ? this.getEncryptedQueryValue(column, value) : value
-      )
-    }
-
-    if (operator !== undefined && typeof key === 'string') {
-      const column = this.getEncryptedQueryColumn(key)
-
-      if (column?.encryption.mode === 'blind') {
-        const encryptedValues = this.getEncryptedQueryValues(column, operator)
-        const encryptedKey = this.getEncryptedQueryKey(column)
-        return encryptedValues.length > 1
-          ? super.whereIn(encryptedKey, encryptedValues)
-          : super.where(encryptedKey, encryptedValues[0])
-      }
-
-      return super.where(
-        column ? this.getEncryptedQueryKey(column) : key,
-        column ? this.getEncryptedQueryValue(column, operator) : operator
-      )
-    }
-
-    if (isObject(key)) {
-      const clauses = Object.entries(key)
-
-      if (!clauses.length) {
-        return super.where(key)
-      }
-
-      clauses.forEach(([clauseKey, clauseValue]) => {
-        this.where(clauseKey, clauseValue)
-      })
-
-      return this
-    }
-
-    return super.where(key, operator, value)
+    return this.encryptedWhere('where', key, operator, value)
   }
 
   orWhere(key: any, operator?: any, value?: any): this {
-    if (value !== undefined && typeof key === 'string') {
-      const column = this.getEncryptedQueryColumn(key)
-      const inOperatorResult = this.handleEncryptedInOperator('orWhere', key, operator, value)
-      if (inOperatorResult) {
-        return inOperatorResult
-      }
-      this.ensureEncryptedEqualityOperator(column, operator, 'orWhere')
-
-      if (column?.encryption.mode === 'blind') {
-        const encryptedValues = this.getEncryptedQueryValues(column, value)
-        const encryptedKey = this.getEncryptedQueryKey(column)
-        return encryptedValues.length > 1
-          ? super.orWhereIn(encryptedKey, encryptedValues)
-          : super.orWhere(encryptedKey, operator, encryptedValues[0])
-      }
-
-      return super.orWhere(
-        column ? this.getEncryptedQueryKey(column) : key,
-        operator,
-        column ? this.getEncryptedQueryValue(column, value) : value
-      )
-    }
-
-    if (operator !== undefined && typeof key === 'string') {
-      const column = this.getEncryptedQueryColumn(key)
-
-      if (column?.encryption.mode === 'blind') {
-        const encryptedValues = this.getEncryptedQueryValues(column, operator)
-        const encryptedKey = this.getEncryptedQueryKey(column)
-        return encryptedValues.length > 1
-          ? super.orWhereIn(encryptedKey, encryptedValues)
-          : super.orWhere(encryptedKey, encryptedValues[0])
-      }
-
-      return super.orWhere(
-        column ? this.getEncryptedQueryKey(column) : key,
-        column ? this.getEncryptedQueryValue(column, operator) : operator
-      )
-    }
-
-    if (isObject(key)) {
-      return super.orWhere(this.transformWhereObjectClause(key))
-    }
-
-    return super.orWhere(key, operator, value)
+    return this.encryptedWhere('orWhere', key, operator, value)
   }
 
   whereNot(key: any, operator?: any, value?: any): this {
-    if (value !== undefined && typeof key === 'string') {
-      const column = this.getEncryptedQueryColumn(key)
-      const inOperatorResult = this.handleEncryptedInOperator('whereNot', key, operator, value)
-      if (inOperatorResult) {
-        return inOperatorResult
-      }
-      this.ensureEncryptedEqualityOperator(column, operator, 'whereNot')
-
-      if (column?.encryption.mode === 'blind') {
-        const encryptedValues = this.getEncryptedQueryValues(column, value)
-        const encryptedKey = this.getEncryptedQueryKey(column)
-        return encryptedValues.length > 1
-          ? super.whereNotIn(encryptedKey, encryptedValues)
-          : super.whereNot(encryptedKey, operator, encryptedValues[0])
-      }
-
-      return super.whereNot(
-        column ? this.getEncryptedQueryKey(column) : key,
-        operator,
-        column ? this.getEncryptedQueryValue(column, value) : value
-      )
-    }
-
-    if (operator !== undefined && typeof key === 'string') {
-      const column = this.getEncryptedQueryColumn(key)
-
-      if (column?.encryption.mode === 'blind') {
-        const encryptedValues = this.getEncryptedQueryValues(column, operator)
-        const encryptedKey = this.getEncryptedQueryKey(column)
-        return encryptedValues.length > 1
-          ? super.whereNotIn(encryptedKey, encryptedValues)
-          : super.whereNot(encryptedKey, encryptedValues[0])
-      }
-
-      return super.whereNot(
-        column ? this.getEncryptedQueryKey(column) : key,
-        column ? this.getEncryptedQueryValue(column, operator) : operator
-      )
-    }
-
-    if (isObject(key)) {
-      return super.whereNot(this.transformWhereObjectClause(key))
-    }
-
-    return super.whereNot(key, operator, value)
+    return this.encryptedWhere('whereNot', key, operator, value)
   }
 
   orWhereNot(key: any, operator?: any, value?: any): this {
-    if (value !== undefined && typeof key === 'string') {
-      const column = this.getEncryptedQueryColumn(key)
-      const inOperatorResult = this.handleEncryptedInOperator('orWhereNot', key, operator, value)
-      if (inOperatorResult) {
-        return inOperatorResult
-      }
-      this.ensureEncryptedEqualityOperator(column, operator, 'orWhereNot')
-
-      if (column?.encryption.mode === 'blind') {
-        const encryptedValues = this.getEncryptedQueryValues(column, value)
-        const encryptedKey = this.getEncryptedQueryKey(column)
-        return encryptedValues.length > 1
-          ? super.orWhereNotIn(encryptedKey, encryptedValues)
-          : super.orWhereNot(encryptedKey, operator, encryptedValues[0])
-      }
-
-      return super.orWhereNot(
-        column ? this.getEncryptedQueryKey(column) : key,
-        operator,
-        column ? this.getEncryptedQueryValue(column, value) : value
-      )
-    }
-
-    if (operator !== undefined && typeof key === 'string') {
-      const column = this.getEncryptedQueryColumn(key)
-
-      if (column?.encryption.mode === 'blind') {
-        const encryptedValues = this.getEncryptedQueryValues(column, operator)
-        const encryptedKey = this.getEncryptedQueryKey(column)
-        return encryptedValues.length > 1
-          ? super.orWhereNotIn(encryptedKey, encryptedValues)
-          : super.orWhereNot(encryptedKey, encryptedValues[0])
-      }
-
-      return super.orWhereNot(
-        column ? this.getEncryptedQueryKey(column) : key,
-        column ? this.getEncryptedQueryValue(column, operator) : operator
-      )
-    }
-
-    if (isObject(key)) {
-      return super.orWhereNot(this.transformWhereObjectClause(key))
-    }
-
-    return super.orWhereNot(key, operator, value)
+    return this.encryptedWhere('orWhereNot', key, operator, value)
   }
 
   whereIn(columns: any, value: any): this {
-    if (typeof columns !== 'string') {
-      return super.whereIn(columns, value)
-    }
-
-    const column = this.getEncryptedQueryColumn(columns)
-    if (!column) {
-      return super.whereIn(columns, value)
-    }
-
-    const transformedValue = Array.isArray(value)
-      ? value.flatMap((item) => this.getEncryptedQueryValues(column, item))
-      : this.isQueryBuilderValue(value)
-        ? value
-        : this.getEncryptedQueryValues(column, value)
-
-    return super.whereIn(this.getEncryptedQueryKey(column), transformedValue)
+    return this.encryptedWhereIn('whereIn', columns, value)
   }
 
   orWhereIn(columns: any, value: any): this {
-    if (typeof columns !== 'string') {
-      return super.orWhereIn(columns, value)
-    }
-
-    const column = this.getEncryptedQueryColumn(columns)
-    if (!column) {
-      return super.orWhereIn(columns, value)
-    }
-
-    const transformedValue = Array.isArray(value)
-      ? value.flatMap((item) => this.getEncryptedQueryValues(column, item))
-      : this.isQueryBuilderValue(value)
-        ? value
-        : this.getEncryptedQueryValues(column, value)
-
-    return super.orWhereIn(this.getEncryptedQueryKey(column), transformedValue)
+    return this.encryptedWhereIn('orWhereIn', columns, value)
   }
 
   whereNotIn(columns: any, value: any): this {
-    if (typeof columns !== 'string') {
-      return super.whereNotIn(columns, value)
-    }
-
-    const column = this.getEncryptedQueryColumn(columns)
-    if (!column) {
-      return super.whereNotIn(columns, value)
-    }
-
-    const transformedValue = Array.isArray(value)
-      ? value.flatMap((item) => this.getEncryptedQueryValues(column, item))
-      : this.isQueryBuilderValue(value)
-        ? value
-        : this.getEncryptedQueryValues(column, value)
-
-    return super.whereNotIn(this.getEncryptedQueryKey(column), transformedValue)
+    return this.encryptedWhereIn('whereNotIn', columns, value)
   }
 
   orWhereNotIn(columns: any, value: any): this {
-    if (typeof columns !== 'string') {
-      return super.orWhereNotIn(columns, value)
-    }
-
-    const column = this.getEncryptedQueryColumn(columns)
-    if (!column) {
-      return super.orWhereNotIn(columns, value)
-    }
-
-    const transformedValue = Array.isArray(value)
-      ? value.flatMap((item) => this.getEncryptedQueryValues(column, item))
-      : this.isQueryBuilderValue(value)
-        ? value
-        : this.getEncryptedQueryValues(column, value)
-
-    return super.orWhereNotIn(this.getEncryptedQueryKey(column), transformedValue)
+    return this.encryptedWhereIn('orWhereNotIn', columns, value)
   }
 
   whereLike(key: any, value: any): this {

--- a/src/orm/query_builder/index.ts
+++ b/src/orm/query_builder/index.ts
@@ -666,14 +666,68 @@ export class ModelQueryBuilder
   /**
    * Raises for unsupported encrypted column operators.
    */
-  private ensureEncryptedMethodSupport(key: any, method: string) {
-    const column = this.getEncryptedQueryColumn(key)
+  private ensureEncryptedMethodSupport({
+    key,
+    method,
+    includeStandard = false,
+  }: {
+    key: any
+    method: string
+    includeStandard?: boolean
+  }) {
+    const column = this.getEncryptedQueryColumn(key, includeStandard)
     if (column) {
       throw new errors.E_UNSUPPORTED_ENCRYPTED_COLUMN_QUERY([
         method,
         `${this.model.name}.${column.attributeName}`,
       ])
     }
+  }
+
+  /**
+   * Extract string columns from orderBy inputs.
+   */
+  private getOrderByColumns(column: any): string[] {
+    if (typeof column === 'string') {
+      return [column]
+    }
+
+    if (!Array.isArray(column)) {
+      if (column && typeof column === 'object' && typeof column.column === 'string') {
+        return [column.column]
+      }
+
+      return []
+    }
+
+    return column.flatMap((item) => {
+      if (typeof item === 'string') {
+        return [item]
+      }
+
+      if (item && typeof item === 'object' && typeof item.column === 'string') {
+        return [item.column]
+      }
+
+      return []
+    })
+  }
+
+  /**
+   * Extract string columns from groupBy inputs.
+   */
+  private getGroupByColumns(columns: any[]): string[] {
+    return columns.flatMap((item) => {
+      if (typeof item === 'string') {
+        return [item]
+      }
+
+      if (Array.isArray(item)) {
+        return item.filter((entry) => typeof entry === 'string')
+      }
+
+      return []
+    })
   }
 
   /**
@@ -697,8 +751,8 @@ export class ModelQueryBuilder
     column: any,
     comparisonColumn: any
   ) {
-    this.ensureEncryptedMethodSupport(column, method)
-    this.ensureEncryptedMethodSupport(comparisonColumn, method)
+    this.ensureEncryptedMethodSupport({ key: column, method })
+    this.ensureEncryptedMethodSupport({ key: comparisonColumn, method })
   }
 
   /**
@@ -834,8 +888,24 @@ export class ModelQueryBuilder
   }
 
   whereLike(key: any, value: any): this {
-    this.ensureEncryptedMethodSupport(key, 'whereLike')
+    this.ensureEncryptedMethodSupport({ key, method: 'whereLike' })
     return super.whereLike(key, value)
+  }
+
+  groupBy(...columns: any[]): this {
+    this.getGroupByColumns(columns).forEach((column) => {
+      this.ensureEncryptedMethodSupport({ key: column, method: 'groupBy', includeStandard: true })
+    })
+
+    return super.groupBy(...columns)
+  }
+
+  orderBy(column: any, direction?: any): this {
+    this.getOrderByColumns(column).forEach((item) => {
+      this.ensureEncryptedMethodSupport({ key: item, method: 'orderBy', includeStandard: true })
+    })
+
+    return super.orderBy(column, direction)
   }
 
   whereColumn(column: any, operator: any, comparisonColumn?: any): this {
@@ -879,107 +949,107 @@ export class ModelQueryBuilder
   }
 
   orWhereLike(key: any, value: any): this {
-    this.ensureEncryptedMethodSupport(key, 'orWhereLike')
+    this.ensureEncryptedMethodSupport({ key, method: 'orWhereLike' })
     return super.orWhereLike(key, value)
   }
 
   whereILike(key: any, value: any): this {
-    this.ensureEncryptedMethodSupport(key, 'whereILike')
+    this.ensureEncryptedMethodSupport({ key, method: 'whereILike' })
     return super.whereILike(key, value)
   }
 
   orWhereILike(key: any, value: any): this {
-    this.ensureEncryptedMethodSupport(key, 'orWhereILike')
+    this.ensureEncryptedMethodSupport({ key, method: 'orWhereILike' })
     return super.orWhereILike(key, value)
   }
 
   whereBetween(key: any, value: [any, any]): this {
-    this.ensureEncryptedMethodSupport(key, 'whereBetween')
+    this.ensureEncryptedMethodSupport({ key, method: 'whereBetween' })
     return super.whereBetween(key, value)
   }
 
   orWhereBetween(key: any, value: [any, any]): this {
-    this.ensureEncryptedMethodSupport(key, 'orWhereBetween')
+    this.ensureEncryptedMethodSupport({ key, method: 'orWhereBetween' })
     return super.orWhereBetween(key, value)
   }
 
   whereNotBetween(key: any, value: [any, any]): this {
-    this.ensureEncryptedMethodSupport(key, 'whereNotBetween')
+    this.ensureEncryptedMethodSupport({ key, method: 'whereNotBetween' })
     return super.whereNotBetween(key, value)
   }
 
   orWhereNotBetween(key: any, value: [any, any]): this {
-    this.ensureEncryptedMethodSupport(key, 'orWhereNotBetween')
+    this.ensureEncryptedMethodSupport({ key, method: 'orWhereNotBetween' })
     return super.orWhereNotBetween(key, value)
   }
 
   whereJson(column: string, value: any) {
-    this.ensureEncryptedMethodSupport(column, 'whereJson')
+    this.ensureEncryptedMethodSupport({ key: column, method: 'whereJson' })
     return super.whereJson(column, value)
   }
 
   orWhereJson(column: string, value: any) {
-    this.ensureEncryptedMethodSupport(column, 'orWhereJson')
+    this.ensureEncryptedMethodSupport({ key: column, method: 'orWhereJson' })
     return super.orWhereJson(column, value)
   }
 
   whereNotJson(column: string, value: any) {
-    this.ensureEncryptedMethodSupport(column, 'whereNotJson')
+    this.ensureEncryptedMethodSupport({ key: column, method: 'whereNotJson' })
     return super.whereNotJson(column, value)
   }
 
   orWhereNotJson(column: string, value: any) {
-    this.ensureEncryptedMethodSupport(column, 'orWhereNotJson')
+    this.ensureEncryptedMethodSupport({ key: column, method: 'orWhereNotJson' })
     return super.orWhereNotJson(column, value)
   }
 
   whereJsonSuperset(column: string, value: any) {
-    this.ensureEncryptedMethodSupport(column, 'whereJsonSuperset')
+    this.ensureEncryptedMethodSupport({ key: column, method: 'whereJsonSuperset' })
     return super.whereJsonSuperset(column, value)
   }
 
   orWhereJsonSuperset(column: string, value: any) {
-    this.ensureEncryptedMethodSupport(column, 'orWhereJsonSuperset')
+    this.ensureEncryptedMethodSupport({ key: column, method: 'orWhereJsonSuperset' })
     return super.orWhereJsonSuperset(column, value)
   }
 
   whereNotJsonSuperset(column: string, value: any) {
-    this.ensureEncryptedMethodSupport(column, 'whereNotJsonSuperset')
+    this.ensureEncryptedMethodSupport({ key: column, method: 'whereNotJsonSuperset' })
     return super.whereNotJsonSuperset(column, value)
   }
 
   orWhereNotJsonSuperset(column: string, value: any) {
-    this.ensureEncryptedMethodSupport(column, 'orWhereNotJsonSuperset')
+    this.ensureEncryptedMethodSupport({ key: column, method: 'orWhereNotJsonSuperset' })
     return super.orWhereNotJsonSuperset(column, value)
   }
 
   whereJsonSubset(column: string, value: any) {
-    this.ensureEncryptedMethodSupport(column, 'whereJsonSubset')
+    this.ensureEncryptedMethodSupport({ key: column, method: 'whereJsonSubset' })
     return super.whereJsonSubset(column, value)
   }
 
   orWhereJsonSubset(column: string, value: any) {
-    this.ensureEncryptedMethodSupport(column, 'orWhereJsonSubset')
+    this.ensureEncryptedMethodSupport({ key: column, method: 'orWhereJsonSubset' })
     return super.orWhereJsonSubset(column, value)
   }
 
   whereNotJsonSubset(column: string, value: any) {
-    this.ensureEncryptedMethodSupport(column, 'whereNotJsonSubset')
+    this.ensureEncryptedMethodSupport({ key: column, method: 'whereNotJsonSubset' })
     return super.whereNotJsonSubset(column, value)
   }
 
   orWhereNotJsonSubset(column: string, value: any) {
-    this.ensureEncryptedMethodSupport(column, 'orWhereNotJsonSubset')
+    this.ensureEncryptedMethodSupport({ key: column, method: 'orWhereNotJsonSubset' })
     return super.orWhereNotJsonSubset(column, value)
   }
 
   whereJsonPath(column: string, jsonPath: string, operator: any, value?: any): this {
-    this.ensureEncryptedMethodSupport(column, 'whereJsonPath')
+    this.ensureEncryptedMethodSupport({ key: column, method: 'whereJsonPath' })
     return super.whereJsonPath(column, jsonPath, operator, value)
   }
 
   orWhereJsonPath(column: string, jsonPath: string, operator: any, value?: any): this {
-    this.ensureEncryptedMethodSupport(column, 'orWhereJsonPath')
+    this.ensureEncryptedMethodSupport({ key: column, method: 'orWhereJsonPath' })
     return super.orWhereJsonPath(column, jsonPath, operator, value)
   }
 

--- a/src/orm/query_builder/index.ts
+++ b/src/orm/query_builder/index.ts
@@ -252,18 +252,40 @@ export class ModelQueryBuilder
     return blindColumnName
   }
 
+  private normalizeBlindIndexValues(indexes: any): any[] {
+    if (!indexes) {
+      return []
+    }
+
+    if (Array.isArray(indexes)) {
+      return indexes.filter((item) => item !== null && item !== undefined)
+    }
+
+    if (isObject(indexes)) {
+      return Object.values(indexes).filter((item) => item !== null && item !== undefined)
+    }
+
+    return [indexes]
+  }
+
   /**
-   * Transforms a query value for deterministic/blind encrypted columns.
+   * Transforms a query value for deterministic/blind encrypted columns and
+   * returns one or many candidate values.
    */
-  private getEncryptedQueryValue(column: EncryptedQueryColumn, value: any): any {
+  private getEncryptedQueryValues(column: EncryptedQueryColumn, value: any): any[] {
     if (value === null || value === undefined || this.isQueryBuilderValue(value)) {
-      return value
+      return [value]
     }
 
     const encryption = this.model.$getEncryption(column.attributeName)
 
     if (column.encryption.mode === 'deterministic') {
-      return encryption.encrypt(value, { deterministic: true })
+      return [
+        encryption.encrypt(value, {
+          deterministic: true,
+          driver: column.encryption.driver,
+        }),
+      ]
     }
 
     if (!column.encryption.purpose) {
@@ -273,7 +295,30 @@ export class ModelQueryBuilder
       ])
     }
 
-    return encryption.blindIndex(value, { purpose: column.encryption.purpose })
+    const blindIndexes = this.normalizeBlindIndexValues(
+      encryption.blindIndexes(value, {
+        purpose: column.encryption.purpose,
+        driver: column.encryption.driver,
+      })
+    )
+
+    if (blindIndexes.length) {
+      return blindIndexes
+    }
+
+    return [
+      encryption.blindIndex(value, {
+        purpose: column.encryption.purpose,
+        driver: column.encryption.driver,
+      }),
+    ]
+  }
+
+  /**
+   * Returns the first transformed query value.
+   */
+  private getEncryptedQueryValue(column: EncryptedQueryColumn, value: any): any {
+    return this.getEncryptedQueryValues(column, value)[0]
   }
 
   /**
@@ -326,6 +371,15 @@ export class ModelQueryBuilder
     if (value !== undefined && typeof key === 'string') {
       const column = this.getEncryptedQueryColumn(key)
       this.ensureEncryptedEqualityOperator(column, operator, 'where')
+
+      if (column?.encryption.mode === 'blind') {
+        const encryptedValues = this.getEncryptedQueryValues(column, value)
+        const encryptedKey = this.getEncryptedQueryKey(column)
+        return encryptedValues.length > 1
+          ? super.whereIn(encryptedKey, encryptedValues)
+          : super.where(encryptedKey, operator, encryptedValues[0])
+      }
+
       return super.where(
         column ? this.getEncryptedQueryKey(column) : key,
         operator,
@@ -335,6 +389,15 @@ export class ModelQueryBuilder
 
     if (operator !== undefined && typeof key === 'string') {
       const column = this.getEncryptedQueryColumn(key)
+
+      if (column?.encryption.mode === 'blind') {
+        const encryptedValues = this.getEncryptedQueryValues(column, operator)
+        const encryptedKey = this.getEncryptedQueryKey(column)
+        return encryptedValues.length > 1
+          ? super.whereIn(encryptedKey, encryptedValues)
+          : super.where(encryptedKey, encryptedValues[0])
+      }
+
       return super.where(
         column ? this.getEncryptedQueryKey(column) : key,
         column ? this.getEncryptedQueryValue(column, operator) : operator
@@ -342,7 +405,21 @@ export class ModelQueryBuilder
     }
 
     if (isObject(key)) {
-      return super.where(this.transformWhereObjectClause(key))
+      const clauses = Object.entries(key)
+
+      if (!clauses.length) {
+        return super.where(key)
+      }
+
+      clauses.forEach(([clauseKey, clauseValue], index) => {
+        if (index === 0) {
+          this.where(clauseKey, clauseValue)
+        } else {
+          this.andWhere(clauseKey, clauseValue)
+        }
+      })
+
+      return this
     }
 
     return super.where(key, operator, value)
@@ -352,6 +429,15 @@ export class ModelQueryBuilder
     if (value !== undefined && typeof key === 'string') {
       const column = this.getEncryptedQueryColumn(key)
       this.ensureEncryptedEqualityOperator(column, operator, 'orWhere')
+
+      if (column?.encryption.mode === 'blind') {
+        const encryptedValues = this.getEncryptedQueryValues(column, value)
+        const encryptedKey = this.getEncryptedQueryKey(column)
+        return encryptedValues.length > 1
+          ? super.orWhereIn(encryptedKey, encryptedValues)
+          : super.orWhere(encryptedKey, operator, encryptedValues[0])
+      }
+
       return super.orWhere(
         column ? this.getEncryptedQueryKey(column) : key,
         operator,
@@ -361,6 +447,15 @@ export class ModelQueryBuilder
 
     if (operator !== undefined && typeof key === 'string') {
       const column = this.getEncryptedQueryColumn(key)
+
+      if (column?.encryption.mode === 'blind') {
+        const encryptedValues = this.getEncryptedQueryValues(column, operator)
+        const encryptedKey = this.getEncryptedQueryKey(column)
+        return encryptedValues.length > 1
+          ? super.orWhereIn(encryptedKey, encryptedValues)
+          : super.orWhere(encryptedKey, encryptedValues[0])
+      }
+
       return super.orWhere(
         column ? this.getEncryptedQueryKey(column) : key,
         column ? this.getEncryptedQueryValue(column, operator) : operator
@@ -378,6 +473,15 @@ export class ModelQueryBuilder
     if (value !== undefined && typeof key === 'string') {
       const column = this.getEncryptedQueryColumn(key)
       this.ensureEncryptedEqualityOperator(column, operator, 'whereNot')
+
+      if (column?.encryption.mode === 'blind') {
+        const encryptedValues = this.getEncryptedQueryValues(column, value)
+        const encryptedKey = this.getEncryptedQueryKey(column)
+        return encryptedValues.length > 1
+          ? super.whereNotIn(encryptedKey, encryptedValues)
+          : super.whereNot(encryptedKey, operator, encryptedValues[0])
+      }
+
       return super.whereNot(
         column ? this.getEncryptedQueryKey(column) : key,
         operator,
@@ -387,6 +491,15 @@ export class ModelQueryBuilder
 
     if (operator !== undefined && typeof key === 'string') {
       const column = this.getEncryptedQueryColumn(key)
+
+      if (column?.encryption.mode === 'blind') {
+        const encryptedValues = this.getEncryptedQueryValues(column, operator)
+        const encryptedKey = this.getEncryptedQueryKey(column)
+        return encryptedValues.length > 1
+          ? super.whereNotIn(encryptedKey, encryptedValues)
+          : super.whereNot(encryptedKey, encryptedValues[0])
+      }
+
       return super.whereNot(
         column ? this.getEncryptedQueryKey(column) : key,
         column ? this.getEncryptedQueryValue(column, operator) : operator
@@ -404,6 +517,15 @@ export class ModelQueryBuilder
     if (value !== undefined && typeof key === 'string') {
       const column = this.getEncryptedQueryColumn(key)
       this.ensureEncryptedEqualityOperator(column, operator, 'orWhereNot')
+
+      if (column?.encryption.mode === 'blind') {
+        const encryptedValues = this.getEncryptedQueryValues(column, value)
+        const encryptedKey = this.getEncryptedQueryKey(column)
+        return encryptedValues.length > 1
+          ? super.orWhereNotIn(encryptedKey, encryptedValues)
+          : super.orWhereNot(encryptedKey, operator, encryptedValues[0])
+      }
+
       return super.orWhereNot(
         column ? this.getEncryptedQueryKey(column) : key,
         operator,
@@ -413,6 +535,15 @@ export class ModelQueryBuilder
 
     if (operator !== undefined && typeof key === 'string') {
       const column = this.getEncryptedQueryColumn(key)
+
+      if (column?.encryption.mode === 'blind') {
+        const encryptedValues = this.getEncryptedQueryValues(column, operator)
+        const encryptedKey = this.getEncryptedQueryKey(column)
+        return encryptedValues.length > 1
+          ? super.orWhereNotIn(encryptedKey, encryptedValues)
+          : super.orWhereNot(encryptedKey, encryptedValues[0])
+      }
+
       return super.orWhereNot(
         column ? this.getEncryptedQueryKey(column) : key,
         column ? this.getEncryptedQueryValue(column, operator) : operator
@@ -437,8 +568,10 @@ export class ModelQueryBuilder
     }
 
     const transformedValue = Array.isArray(value)
-      ? value.map((item) => this.getEncryptedQueryValue(column, item))
-      : value
+      ? value.flatMap((item) => this.getEncryptedQueryValues(column, item))
+      : this.isQueryBuilderValue(value)
+        ? value
+        : this.getEncryptedQueryValues(column, value)
 
     return super.whereIn(this.getEncryptedQueryKey(column), transformedValue)
   }
@@ -454,8 +587,10 @@ export class ModelQueryBuilder
     }
 
     const transformedValue = Array.isArray(value)
-      ? value.map((item) => this.getEncryptedQueryValue(column, item))
-      : value
+      ? value.flatMap((item) => this.getEncryptedQueryValues(column, item))
+      : this.isQueryBuilderValue(value)
+        ? value
+        : this.getEncryptedQueryValues(column, value)
 
     return super.orWhereIn(this.getEncryptedQueryKey(column), transformedValue)
   }
@@ -471,8 +606,10 @@ export class ModelQueryBuilder
     }
 
     const transformedValue = Array.isArray(value)
-      ? value.map((item) => this.getEncryptedQueryValue(column, item))
-      : value
+      ? value.flatMap((item) => this.getEncryptedQueryValues(column, item))
+      : this.isQueryBuilderValue(value)
+        ? value
+        : this.getEncryptedQueryValues(column, value)
 
     return super.whereNotIn(this.getEncryptedQueryKey(column), transformedValue)
   }
@@ -488,8 +625,10 @@ export class ModelQueryBuilder
     }
 
     const transformedValue = Array.isArray(value)
-      ? value.map((item) => this.getEncryptedQueryValue(column, item))
-      : value
+      ? value.flatMap((item) => this.getEncryptedQueryValues(column, item))
+      : this.isQueryBuilderValue(value)
+        ? value
+        : this.getEncryptedQueryValues(column, value)
 
     return super.orWhereNotIn(this.getEncryptedQueryKey(column), transformedValue)
   }

--- a/src/orm/query_builder/index.ts
+++ b/src/orm/query_builder/index.ts
@@ -607,21 +607,25 @@ export class ModelQueryBuilder
     }
 
     if (isObject(key)) {
-      if (method === 'where') {
-        const clauses = Object.entries(key)
+      const clauses = Object.entries(key)
 
-        if (!clauses.length) {
-          return this.callSuperWhereUnary(method, key)
-        }
-
-        clauses.forEach(([clauseKey, clauseValue]) => {
-          this.where(clauseKey, clauseValue)
-        })
-
-        return this
+      if (!clauses.length) {
+        return method === 'where' ? this.callSuperWhereUnary(method, key) : this
       }
 
-      return this.callSuperWhereUnary(method, this.transformWhereObjectClause(key))
+      if (method === 'orWhere') {
+        return this.callSuperWhereUnary(method, (query: ModelQueryBuilder) => {
+          clauses.forEach(([clauseKey, clauseValue]) => {
+            query.where(clauseKey, clauseValue)
+          })
+        })
+      }
+
+      clauses.forEach(([clauseKey, clauseValue]) => {
+        this.encryptedWhere(method, clauseKey, clauseValue)
+      })
+
+      return this
     }
 
     return this.callSuperWhereTernary(method, key, operator, value)
@@ -660,23 +664,6 @@ export class ModelQueryBuilder
         `${this.model.name}.${column.attributeName}`,
       ])
     }
-  }
-
-  /**
-   * Transforms an object where clause for deterministic/blind encrypted columns.
-   */
-  private transformWhereObjectClause(clause: Dictionary<any, string>) {
-    return Object.keys(clause).reduce((result: Dictionary<any, string>, key) => {
-      const column = this.getEncryptedQueryColumn(key)
-
-      if (!column) {
-        result[key] = clause[key]
-        return result
-      }
-
-      result[this.getEncryptedQueryKey(column)] = this.getEncryptedQueryValue(column, clause[key])
-      return result
-    }, {})
   }
 
   /**

--- a/src/orm/query_builder/index.ts
+++ b/src/orm/query_builder/index.ts
@@ -177,10 +177,12 @@ export class ModelQueryBuilder
   }
 
   /**
-   * Returns encrypted metadata for a query key when it references a
-   * deterministic or blind encrypted column.
+   * Returns encrypted metadata for a query key.
    */
-  private getEncryptedQueryColumn(key: any): EncryptedQueryColumn | null {
+  private getEncryptedQueryColumn(
+    key: any,
+    includeStandard: boolean = false
+  ): EncryptedQueryColumn | null {
     if (typeof key !== 'string') {
       return null
     }
@@ -198,7 +200,7 @@ export class ModelQueryBuilder
     const column = this.model.$getColumn(attributeName)!
     const encryption = column.meta?.encryption as EncryptedColumnMeta | undefined
 
-    if (!encryption || encryption.mode === 'standard') {
+    if (!encryption || (!includeStandard && encryption.mode === 'standard')) {
       return null
     }
 
@@ -363,6 +365,95 @@ export class ModelQueryBuilder
       }
 
       result[this.getEncryptedQueryKey(column)] = this.getEncryptedQueryValue(column, clause[key])
+      return result
+    }, {})
+  }
+
+  /**
+   * Encrypt value before writing it to an encrypted model column.
+   */
+  private getEncryptedWriteValue(column: EncryptedQueryColumn, value: any): any {
+    if (value === null || value === undefined || this.isQueryBuilderValue(value)) {
+      return value
+    }
+
+    const encryption = this.model.$getEncryption(column.attributeName)
+    if (column.encryption.mode === 'deterministic') {
+      return encryption.encrypt(value, {
+        deterministic: true,
+        driver: column.encryption.driver,
+      })
+    }
+
+    if (column.encryption.driver) {
+      return encryption.encrypt(value, {
+        driver: column.encryption.driver,
+      })
+    }
+
+    return encryption.encrypt(value)
+  }
+
+  /**
+   * Compute blind index value for writes.
+   */
+  private getBlindWriteValue(
+    column: EncryptedQueryColumn,
+    value: any
+  ): {
+    shouldWrite: boolean
+    value: any
+  } {
+    if (value === null || value === undefined) {
+      return { shouldWrite: true, value }
+    }
+
+    if (this.isQueryBuilderValue(value)) {
+      return { shouldWrite: false, value: null }
+    }
+
+    const purpose = column.encryption.purpose
+    if (!purpose) {
+      throw new errors.E_INVALID_ENCRYPTED_COLUMN_CONFIGURATION([
+        `${this.model.name}.${column.attributeName}`,
+        'Missing "blind.purpose"',
+      ])
+    }
+
+    const encryption = this.model.$getEncryption(column.attributeName)
+    return {
+      shouldWrite: true,
+      value: encryption.blindIndex(value, {
+        purpose,
+        driver: column.encryption.driver,
+      }),
+    }
+  }
+
+  /**
+   * Prepares update payload by applying encrypted column transforms.
+   */
+  private prepareUpdateValues(values: Dictionary<any, string>): Dictionary<any, string> {
+    return Object.keys(values).reduce((result: Dictionary<any, string>, key) => {
+      const column = this.getEncryptedQueryColumn(key, true)
+      if (!column) {
+        result[this.resolveKey(key)] = this.transformRaw(values[key])
+        return result
+      }
+
+      result[this.resolveKey(key)] = this.transformRaw(
+        this.getEncryptedWriteValue(column, values[key])
+      )
+
+      if (column.encryption.mode === 'blind') {
+        const blindResult = this.getBlindWriteValue(column, values[key])
+        if (blindResult.shouldWrite) {
+          result[this.resolveKey(this.getEncryptedQueryKey(column))] = this.transformRaw(
+            blindResult.value
+          )
+        }
+      }
+
       return result
     }, {})
   }
@@ -1280,21 +1371,30 @@ export class ModelQueryBuilder
   ): ModelQueryBuilderContract<LucidModel> {
     this.ensureCanPerformWrites()
 
-    if (value === undefined && returning === undefined) {
-      // Transform values in the object before passing to knex
-      if (column && typeof column === 'object') {
-        const columns = Object.keys(column).reduce((result: any, key) => {
-          result[this.resolveKey(key)] = this.transformRaw(column[key])
-          return result
-        }, {})
+    if (column && typeof column === 'object') {
+      const columns = this.prepareUpdateValues(column)
+      if (value === undefined) {
         this.knexQuery.update(columns)
       } else {
-        this.knexQuery.update(column)
+        this.knexQuery.update(columns, value)
       }
-    } else if (returning === undefined) {
-      this.knexQuery.update(this.resolveKey(column), this.transformRaw(value))
+
+      return this
+    }
+
+    if (value === undefined) {
+      this.knexQuery.update(column)
+      return this
+    }
+
+    const columns = this.prepareUpdateValues({
+      [column]: value,
+    })
+
+    if (returning === undefined) {
+      this.knexQuery.update(columns)
     } else {
-      this.knexQuery.update(this.resolveKey(column), this.transformRaw(value), returning)
+      this.knexQuery.update(columns, returning)
     }
 
     return this

--- a/src/orm/query_builder/index.ts
+++ b/src/orm/query_builder/index.ts
@@ -734,12 +734,16 @@ export class ModelQueryBuilder
    * Raises for unsupported arithmetic operations on encrypted columns.
    */
   private ensureEncryptedArithmeticSupport(key: any, method: string) {
-    const column = this.getEncryptedQueryColumn(key, true)
-    if (column) {
-      throw new errors.E_UNSUPPORTED_ENCRYPTED_COLUMN_QUERY([
-        method,
-        `${this.model.name}.${column.attributeName}`,
-      ])
+    const keys = typeof key === 'string' ? [key] : isObject(key) ? Object.keys(key) : []
+
+    for (const columnKey of keys) {
+      const column = this.getEncryptedQueryColumn(columnKey, true)
+      if (column) {
+        throw new errors.E_UNSUPPORTED_ENCRYPTED_COLUMN_QUERY([
+          method,
+          `${this.model.name}.${column.attributeName}`,
+        ])
+      }
     }
   }
 

--- a/src/orm/query_builder/index.ts
+++ b/src/orm/query_builder/index.ts
@@ -465,28 +465,35 @@ export class ModelQueryBuilder
    * Prepares update payload by applying encrypted column transforms.
    */
   private prepareUpdateValues(values: Dictionary<any, string>): Dictionary<any, string> {
-    return Object.keys(values).reduce((result: Dictionary<any, string>, key) => {
+    const result = Object.keys(values).reduce((acc: Dictionary<any, string>, key) => {
       const column = this.getEncryptedQueryColumn(key, true)
       if (!column) {
-        result[this.resolveKey(key)] = this.transformRaw(values[key])
-        return result
+        acc[this.resolveKey(key)] = this.transformRaw(values[key])
+        return acc
       }
 
-      result[this.resolveKey(key)] = this.transformRaw(
+      acc[this.resolveKey(key)] = this.transformRaw(
         this.getEncryptedWriteValue(column, values[key])
       )
 
-      if (column.encryption.mode === 'blind') {
-        const blindResult = this.getBlindWriteValue(column, values[key])
-        if (blindResult.shouldWrite) {
-          result[this.resolveKey(this.getEncryptedQueryKey(column))] = this.transformRaw(
-            blindResult.value
-          )
-        }
+      return acc
+    }, {})
+
+    Object.keys(values).forEach((key) => {
+      const column = this.getEncryptedQueryColumn(key, true)
+      if (column?.encryption.mode !== 'blind') {
+        return
       }
 
-      return result
-    }, {})
+      const blindResult = this.getBlindWriteValue(column, values[key])
+      if (blindResult.shouldWrite) {
+        result[this.resolveKey(this.getEncryptedQueryKey(column))] = this.transformRaw(
+          blindResult.value
+        )
+      }
+    })
+
+    return result
   }
 
   where(key: any, operator?: any, value?: any): this {

--- a/src/orm/query_builder/index.ts
+++ b/src/orm/query_builder/index.ts
@@ -355,19 +355,86 @@ export class ModelQueryBuilder
   }
 
   /**
+   * Normalize operators used by where/orWhere methods.
+   */
+  private normalizeOperator(operator: any): string {
+    return typeof operator === 'string' ? operator.trim().replace(/\s+/g, ' ').toLowerCase() : ''
+  }
+
+  /**
+   * Check if operator maps to an IN clause.
+   */
+  private isInOperator(operator: string): boolean {
+    return operator === 'in'
+  }
+
+  /**
+   * Check if operator maps to a NOT IN clause.
+   */
+  private isNotInOperator(operator: string): boolean {
+    return operator === 'not in'
+  }
+
+  /**
    * Raises when using a non equality operator for deterministic/blind columns.
    */
   private ensureEncryptedEqualityOperator(
     column: EncryptedQueryColumn | null,
-    operator: string,
+    operator: any,
     method: string
   ) {
-    if (column && operator !== '=') {
+    if (!column) {
+      return
+    }
+
+    const normalizedOperator = this.normalizeOperator(operator)
+    if (
+      normalizedOperator !== '=' &&
+      !this.isInOperator(normalizedOperator) &&
+      !this.isNotInOperator(normalizedOperator)
+    ) {
       throw new errors.E_UNSUPPORTED_ENCRYPTED_COLUMN_QUERY([
         method,
         `${this.model.name}.${column.attributeName}`,
       ])
     }
+  }
+
+  /**
+   * Routes operator forms using IN/NOT IN through the dedicated methods.
+   */
+  private handleEncryptedInOperator(
+    method: 'where' | 'orWhere' | 'whereNot' | 'orWhereNot',
+    key: string,
+    operator: any,
+    value: any
+  ): this | null {
+    const column = this.getEncryptedQueryColumn(key)
+    if (!column) {
+      return null
+    }
+
+    const normalizedOperator = this.normalizeOperator(operator)
+    if (!this.isInOperator(normalizedOperator) && !this.isNotInOperator(normalizedOperator)) {
+      return null
+    }
+
+    const usePositiveIn =
+      this.isInOperator(normalizedOperator) === (method === 'where' || method === 'orWhere')
+
+    if (method === 'where') {
+      return usePositiveIn ? this.whereIn(key, value) : this.whereNotIn(key, value)
+    }
+
+    if (method === 'orWhere') {
+      return usePositiveIn ? this.orWhereIn(key, value) : this.orWhereNotIn(key, value)
+    }
+
+    if (method === 'whereNot') {
+      return usePositiveIn ? this.whereIn(key, value) : this.whereNotIn(key, value)
+    }
+
+    return usePositiveIn ? this.orWhereIn(key, value) : this.orWhereNotIn(key, value)
   }
 
   /**
@@ -499,6 +566,10 @@ export class ModelQueryBuilder
   where(key: any, operator?: any, value?: any): this {
     if (value !== undefined && typeof key === 'string') {
       const column = this.getEncryptedQueryColumn(key)
+      const inOperatorResult = this.handleEncryptedInOperator('where', key, operator, value)
+      if (inOperatorResult) {
+        return inOperatorResult
+      }
       this.ensureEncryptedEqualityOperator(column, operator, 'where')
 
       if (column?.encryption.mode === 'blind') {
@@ -557,6 +628,10 @@ export class ModelQueryBuilder
   orWhere(key: any, operator?: any, value?: any): this {
     if (value !== undefined && typeof key === 'string') {
       const column = this.getEncryptedQueryColumn(key)
+      const inOperatorResult = this.handleEncryptedInOperator('orWhere', key, operator, value)
+      if (inOperatorResult) {
+        return inOperatorResult
+      }
       this.ensureEncryptedEqualityOperator(column, operator, 'orWhere')
 
       if (column?.encryption.mode === 'blind') {
@@ -601,6 +676,10 @@ export class ModelQueryBuilder
   whereNot(key: any, operator?: any, value?: any): this {
     if (value !== undefined && typeof key === 'string') {
       const column = this.getEncryptedQueryColumn(key)
+      const inOperatorResult = this.handleEncryptedInOperator('whereNot', key, operator, value)
+      if (inOperatorResult) {
+        return inOperatorResult
+      }
       this.ensureEncryptedEqualityOperator(column, operator, 'whereNot')
 
       if (column?.encryption.mode === 'blind') {
@@ -645,6 +724,10 @@ export class ModelQueryBuilder
   orWhereNot(key: any, operator?: any, value?: any): this {
     if (value !== undefined && typeof key === 'string') {
       const column = this.getEncryptedQueryColumn(key)
+      const inOperatorResult = this.handleEncryptedInOperator('orWhereNot', key, operator, value)
+      if (inOperatorResult) {
+        return inOperatorResult
+      }
       this.ensureEncryptedEqualityOperator(column, operator, 'orWhereNot')
 
       if (column?.encryption.mode === 'blind') {

--- a/src/orm/query_builder/index.ts
+++ b/src/orm/query_builder/index.ts
@@ -414,6 +414,18 @@ export class ModelQueryBuilder
   }
 
   /**
+   * Raises when querying a standard encrypted column.
+   */
+  private ensureStandardEncryptedQuerySupport(column: EncryptedQueryColumn | null, method: string) {
+    if (column?.encryption.mode === 'standard') {
+      throw new errors.E_UNSUPPORTED_STANDARD_ENCRYPTED_COLUMN_QUERY([
+        method,
+        `${this.model.name}.${column.attributeName}`,
+      ])
+    }
+  }
+
+  /**
    * Routes operator forms using IN/NOT IN through the dedicated methods.
    */
   private handleEncryptedInOperator(
@@ -571,7 +583,8 @@ export class ModelQueryBuilder
     value?: any
   ): this {
     if (value !== undefined && typeof key === 'string') {
-      const column = this.getEncryptedQueryColumn(key)
+      const column = this.getEncryptedQueryColumn(key, true)
+      this.ensureStandardEncryptedQuerySupport(column, method)
       const inOperatorResult = this.handleEncryptedInOperator(method, key, operator, value)
       if (inOperatorResult) {
         return inOperatorResult
@@ -597,7 +610,8 @@ export class ModelQueryBuilder
     }
 
     if (operator !== undefined && typeof key === 'string') {
-      const column = this.getEncryptedQueryColumn(key)
+      const column = this.getEncryptedQueryColumn(key, true)
+      this.ensureStandardEncryptedQuerySupport(column, method)
 
       if (column?.encryption.mode === 'blind') {
         const encryptedValues = this.getEncryptedQueryValues(column, operator)
@@ -649,7 +663,8 @@ export class ModelQueryBuilder
       return this.callSuperWhereIn(method, columns, value)
     }
 
-    const column = this.getEncryptedQueryColumn(columns)
+    const column = this.getEncryptedQueryColumn(columns, true)
+    this.ensureStandardEncryptedQuerySupport(column, method)
     if (!column) {
       return this.callSuperWhereIn(method, columns, value)
     }

--- a/src/orm/query_builder/index.ts
+++ b/src/orm/query_builder/index.ts
@@ -681,16 +681,8 @@ export class ModelQueryBuilder
   /**
    * Raises for unsupported encrypted column operators.
    */
-  private ensureEncryptedMethodSupport({
-    key,
-    method,
-    includeStandard = false,
-  }: {
-    key: any
-    method: string
-    includeStandard?: boolean
-  }) {
-    const column = this.getEncryptedQueryColumn(key, includeStandard)
+  private ensureEncryptedMethodSupport(key: any, method: string) {
+    const column = this.getEncryptedQueryColumn(key, true)
     if (column) {
       throw new errors.E_UNSUPPORTED_ENCRYPTED_COLUMN_QUERY([
         method,
@@ -770,8 +762,8 @@ export class ModelQueryBuilder
     column: any,
     comparisonColumn: any
   ) {
-    this.ensureEncryptedMethodSupport({ key: column, method })
-    this.ensureEncryptedMethodSupport({ key: comparisonColumn, method })
+    this.ensureEncryptedMethodSupport(column, method)
+    this.ensureEncryptedMethodSupport(comparisonColumn, method)
   }
 
   /**
@@ -907,13 +899,13 @@ export class ModelQueryBuilder
   }
 
   whereLike(key: any, value: any): this {
-    this.ensureEncryptedMethodSupport({ key, method: 'whereLike' })
+    this.ensureEncryptedMethodSupport(key, 'whereLike')
     return super.whereLike(key, value)
   }
 
   groupBy(...columns: any[]): this {
     this.getGroupByColumns(columns).forEach((column) => {
-      this.ensureEncryptedMethodSupport({ key: column, method: 'groupBy', includeStandard: true })
+      this.ensureEncryptedMethodSupport(column, 'groupBy')
     })
 
     return super.groupBy(...columns)
@@ -921,7 +913,7 @@ export class ModelQueryBuilder
 
   orderBy(column: any, direction?: any): this {
     this.getOrderByColumns(column).forEach((item) => {
-      this.ensureEncryptedMethodSupport({ key: item, method: 'orderBy', includeStandard: true })
+      this.ensureEncryptedMethodSupport(item, 'orderBy')
     })
 
     return super.orderBy(column, direction)
@@ -968,107 +960,107 @@ export class ModelQueryBuilder
   }
 
   orWhereLike(key: any, value: any): this {
-    this.ensureEncryptedMethodSupport({ key, method: 'orWhereLike' })
+    this.ensureEncryptedMethodSupport(key, 'orWhereLike')
     return super.orWhereLike(key, value)
   }
 
   whereILike(key: any, value: any): this {
-    this.ensureEncryptedMethodSupport({ key, method: 'whereILike' })
+    this.ensureEncryptedMethodSupport(key, 'whereILike')
     return super.whereILike(key, value)
   }
 
   orWhereILike(key: any, value: any): this {
-    this.ensureEncryptedMethodSupport({ key, method: 'orWhereILike' })
+    this.ensureEncryptedMethodSupport(key, 'orWhereILike')
     return super.orWhereILike(key, value)
   }
 
   whereBetween(key: any, value: [any, any]): this {
-    this.ensureEncryptedMethodSupport({ key, method: 'whereBetween' })
+    this.ensureEncryptedMethodSupport(key, 'whereBetween')
     return super.whereBetween(key, value)
   }
 
   orWhereBetween(key: any, value: [any, any]): this {
-    this.ensureEncryptedMethodSupport({ key, method: 'orWhereBetween' })
+    this.ensureEncryptedMethodSupport(key, 'orWhereBetween')
     return super.orWhereBetween(key, value)
   }
 
   whereNotBetween(key: any, value: [any, any]): this {
-    this.ensureEncryptedMethodSupport({ key, method: 'whereNotBetween' })
+    this.ensureEncryptedMethodSupport(key, 'whereNotBetween')
     return super.whereNotBetween(key, value)
   }
 
   orWhereNotBetween(key: any, value: [any, any]): this {
-    this.ensureEncryptedMethodSupport({ key, method: 'orWhereNotBetween' })
+    this.ensureEncryptedMethodSupport(key, 'orWhereNotBetween')
     return super.orWhereNotBetween(key, value)
   }
 
   whereJson(column: string, value: any) {
-    this.ensureEncryptedMethodSupport({ key: column, method: 'whereJson' })
+    this.ensureEncryptedMethodSupport(column, 'whereJson')
     return super.whereJson(column, value)
   }
 
   orWhereJson(column: string, value: any) {
-    this.ensureEncryptedMethodSupport({ key: column, method: 'orWhereJson' })
+    this.ensureEncryptedMethodSupport(column, 'orWhereJson')
     return super.orWhereJson(column, value)
   }
 
   whereNotJson(column: string, value: any) {
-    this.ensureEncryptedMethodSupport({ key: column, method: 'whereNotJson' })
+    this.ensureEncryptedMethodSupport(column, 'whereNotJson')
     return super.whereNotJson(column, value)
   }
 
   orWhereNotJson(column: string, value: any) {
-    this.ensureEncryptedMethodSupport({ key: column, method: 'orWhereNotJson' })
+    this.ensureEncryptedMethodSupport(column, 'orWhereNotJson')
     return super.orWhereNotJson(column, value)
   }
 
   whereJsonSuperset(column: string, value: any) {
-    this.ensureEncryptedMethodSupport({ key: column, method: 'whereJsonSuperset' })
+    this.ensureEncryptedMethodSupport(column, 'whereJsonSuperset')
     return super.whereJsonSuperset(column, value)
   }
 
   orWhereJsonSuperset(column: string, value: any) {
-    this.ensureEncryptedMethodSupport({ key: column, method: 'orWhereJsonSuperset' })
+    this.ensureEncryptedMethodSupport(column, 'orWhereJsonSuperset')
     return super.orWhereJsonSuperset(column, value)
   }
 
   whereNotJsonSuperset(column: string, value: any) {
-    this.ensureEncryptedMethodSupport({ key: column, method: 'whereNotJsonSuperset' })
+    this.ensureEncryptedMethodSupport(column, 'whereNotJsonSuperset')
     return super.whereNotJsonSuperset(column, value)
   }
 
   orWhereNotJsonSuperset(column: string, value: any) {
-    this.ensureEncryptedMethodSupport({ key: column, method: 'orWhereNotJsonSuperset' })
+    this.ensureEncryptedMethodSupport(column, 'orWhereNotJsonSuperset')
     return super.orWhereNotJsonSuperset(column, value)
   }
 
   whereJsonSubset(column: string, value: any) {
-    this.ensureEncryptedMethodSupport({ key: column, method: 'whereJsonSubset' })
+    this.ensureEncryptedMethodSupport(column, 'whereJsonSubset')
     return super.whereJsonSubset(column, value)
   }
 
   orWhereJsonSubset(column: string, value: any) {
-    this.ensureEncryptedMethodSupport({ key: column, method: 'orWhereJsonSubset' })
+    this.ensureEncryptedMethodSupport(column, 'orWhereJsonSubset')
     return super.orWhereJsonSubset(column, value)
   }
 
   whereNotJsonSubset(column: string, value: any) {
-    this.ensureEncryptedMethodSupport({ key: column, method: 'whereNotJsonSubset' })
+    this.ensureEncryptedMethodSupport(column, 'whereNotJsonSubset')
     return super.whereNotJsonSubset(column, value)
   }
 
   orWhereNotJsonSubset(column: string, value: any) {
-    this.ensureEncryptedMethodSupport({ key: column, method: 'orWhereNotJsonSubset' })
+    this.ensureEncryptedMethodSupport(column, 'orWhereNotJsonSubset')
     return super.orWhereNotJsonSubset(column, value)
   }
 
   whereJsonPath(column: string, jsonPath: string, operator: any, value?: any): this {
-    this.ensureEncryptedMethodSupport({ key: column, method: 'whereJsonPath' })
+    this.ensureEncryptedMethodSupport(column, 'whereJsonPath')
     return super.whereJsonPath(column, jsonPath, operator, value)
   }
 
   orWhereJsonPath(column: string, jsonPath: string, operator: any, value?: any): this {
-    this.ensureEncryptedMethodSupport({ key: column, method: 'orWhereJsonPath' })
+    this.ensureEncryptedMethodSupport(column, 'orWhereJsonPath')
     return super.orWhereJsonPath(column, jsonPath, operator, value)
   }
 

--- a/src/orm/query_builder/index.ts
+++ b/src/orm/query_builder/index.ts
@@ -190,7 +190,17 @@ export class ModelQueryBuilder
       return null
     }
 
-    const normalizedKey = key.includes('.') ? key.split('.').pop()! : key
+    const lastDot = key.lastIndexOf('.')
+    const normalizedKey = lastDot >= 0 ? key.slice(lastDot + 1) : key
+
+    if (lastDot >= 0) {
+      const source = key.slice(0, lastDot)
+
+      if (!this.isModelColumnSource(source)) {
+        return null
+      }
+    }
+
     const attributeName =
       this.model.$keys.columnsToAttributes.get(normalizedKey) ??
       this.model.$keys.columnsToAttributes.get(key) ??
@@ -201,7 +211,7 @@ export class ModelQueryBuilder
     }
 
     const column = this.model.$getColumn(attributeName)!
-    if (!this.isModelColumnReference(key, attributeName, column.columnName)) {
+    if (!this.isModelColumnReference(normalizedKey, attributeName, column.columnName)) {
       return null
     }
 
@@ -220,21 +230,9 @@ export class ModelQueryBuilder
   }
 
   /**
-   * Returns true when the key references the current model table.
+   * Returns true when a dotted key source points to the current model table.
    */
-  private isModelColumnReference(key: string, attributeName: string, columnName: string): boolean {
-    if (!key.includes('.')) {
-      return true
-    }
-
-    const lastDot = key.lastIndexOf('.')
-    const source = key.slice(0, lastDot)
-    const column = key.slice(lastDot + 1)
-
-    if (column !== attributeName && column !== columnName) {
-      return false
-    }
-
+  private isModelColumnSource(source: string): boolean {
     if (source === this.model.table || source.endsWith(`.${this.model.table}`)) {
       return true
     }
@@ -244,6 +242,18 @@ export class ModelQueryBuilder
     }
 
     return false
+  }
+
+  /**
+   * Returns true when a key segment matches either the model attribute name
+   * or the underlying database column name.
+   */
+  private isModelColumnReference(
+    column: string,
+    attributeName: string,
+    columnName: string
+  ): boolean {
+    return column === attributeName || column === columnName
   }
 
   /**

--- a/src/orm/query_builder/index.ts
+++ b/src/orm/query_builder/index.ts
@@ -532,27 +532,31 @@ export class ModelQueryBuilder
    * Prepares update payload by applying encrypted column transforms.
    */
   private prepareUpdateValues(values: Dictionary<any, string>): Dictionary<any, string> {
-    const result = Object.keys(values).reduce((acc: Dictionary<any, string>, key) => {
-      const column = this.getEncryptedQueryColumn(key, true)
-      if (!column) {
-        acc[this.resolveKey(key)] = this.transformRaw(values[key])
-        return acc
-      }
-
-      acc[this.resolveKey(key)] = this.transformRaw(
-        this.getEncryptedWriteValue(column, values[key])
-      )
-
-      return acc
-    }, {})
+    const result: Dictionary<any, string> = {}
+    const blindWrites: Array<{ value: any; column: EncryptedQueryColumn }> = []
 
     Object.keys(values).forEach((key) => {
+      const value = values[key]
       const column = this.getEncryptedQueryColumn(key, true)
-      if (column?.encryption.mode !== 'blind') {
+
+      if (!column) {
+        result[this.resolveKey(key)] = this.transformRaw(value)
         return
       }
 
-      const blindResult = this.getBlindWriteValue(column, values[key])
+      result[this.resolveKey(key)] = this.transformRaw(this.getEncryptedWriteValue(column, value))
+
+      if (column.encryption.mode === 'blind') {
+        blindWrites.push({ value, column })
+      }
+    })
+
+    /**
+     * Apply blind writes after processing the original payload so computed indexes
+     * always win over any manually provided blind column value, regardless of key order.
+     */
+    blindWrites.forEach(({ value, column }) => {
+      const blindResult = this.getBlindWriteValue(column, value)
       if (blindResult.shouldWrite) {
         result[this.resolveKey(this.getEncryptedQueryKey(column))] = this.transformRaw(
           blindResult.value

--- a/src/orm/query_builder/index.ts
+++ b/src/orm/query_builder/index.ts
@@ -667,6 +667,18 @@ export class ModelQueryBuilder
   }
 
   /**
+   * Raises for unsupported column-vs-column comparisons on encrypted columns.
+   */
+  private ensureEncryptedColumnComparisonSupport(
+    method: string,
+    column: any,
+    comparisonColumn: any
+  ) {
+    this.ensureEncryptedMethodSupport(column, method)
+    this.ensureEncryptedMethodSupport(comparisonColumn, method)
+  }
+
+  /**
    * Encrypt value before writing it to an encrypted model column.
    */
   private getEncryptedWriteValue(column: EncryptedQueryColumn, value: any): any {
@@ -801,6 +813,46 @@ export class ModelQueryBuilder
   whereLike(key: any, value: any): this {
     this.ensureEncryptedMethodSupport(key, 'whereLike')
     return super.whereLike(key, value)
+  }
+
+  whereColumn(column: any, operator: any, comparisonColumn?: any): this {
+    if (comparisonColumn !== undefined) {
+      this.ensureEncryptedColumnComparisonSupport('whereColumn', column, comparisonColumn)
+      return super.whereColumn(column, operator, comparisonColumn)
+    }
+
+    this.ensureEncryptedColumnComparisonSupport('whereColumn', column, operator)
+    return super.whereColumn(column, operator)
+  }
+
+  orWhereColumn(column: any, operator: any, comparisonColumn?: any): this {
+    if (comparisonColumn !== undefined) {
+      this.ensureEncryptedColumnComparisonSupport('orWhereColumn', column, comparisonColumn)
+      return super.orWhereColumn(column, operator, comparisonColumn)
+    }
+
+    this.ensureEncryptedColumnComparisonSupport('orWhereColumn', column, operator)
+    return super.orWhereColumn(column, operator)
+  }
+
+  whereNotColumn(column: any, operator: any, comparisonColumn?: any): this {
+    if (comparisonColumn !== undefined) {
+      this.ensureEncryptedColumnComparisonSupport('whereNotColumn', column, comparisonColumn)
+      return super.whereNotColumn(column, operator, comparisonColumn)
+    }
+
+    this.ensureEncryptedColumnComparisonSupport('whereNotColumn', column, operator)
+    return super.whereNotColumn(column, operator)
+  }
+
+  orWhereNotColumn(column: any, operator: any, comparisonColumn?: any): this {
+    if (comparisonColumn !== undefined) {
+      this.ensureEncryptedColumnComparisonSupport('orWhereNotColumn', column, comparisonColumn)
+      return super.orWhereNotColumn(column, operator, comparisonColumn)
+    }
+
+    this.ensureEncryptedColumnComparisonSupport('orWhereNotColumn', column, operator)
+    return super.orWhereNotColumn(column, operator)
   }
 
   orWhereLike(key: any, value: any): this {

--- a/src/orm/query_builder/index.ts
+++ b/src/orm/query_builder/index.ts
@@ -14,7 +14,6 @@ import {
   type LucidRow,
   type LucidModel,
   type ModelObject,
-  type EncryptedColumnMeta,
   type ModelAdapterOptions,
   type ModelQueryBuilderContract,
 } from '../../types/model.js'
@@ -40,16 +39,12 @@ import { QueryRunner } from '../../query_runner/index.js'
 import { Chainable } from '../../database/query_builder/chainable.js'
 import { SimplePaginator } from '../../database/paginator/simple_paginator.js'
 import * as errors from '../../errors.js'
-
-type EncryptedQueryColumn = {
-  key: string
-  attributeName: string
-  columnName: string
-  encryption: EncryptedColumnMeta
-}
-
-type EncryptedWhereMethod = 'where' | 'orWhere' | 'whereNot' | 'orWhereNot'
-type EncryptedWhereInMethod = 'whereIn' | 'orWhereIn' | 'whereNotIn' | 'orWhereNotIn'
+import {
+  EncryptedQuerySupport,
+  type EncryptedWhereMethod,
+  type EncryptedWhereInMethod,
+  type EncryptedWhereRewrite,
+} from './encrypted_query_support.js'
 
 /**
  * A wrapper to invoke scope methods on the query builder
@@ -141,6 +136,11 @@ export class ModelQueryBuilder
   isChildQuery = false
 
   /**
+   * Support class responsible for encrypted query rewrites and guards.
+   */
+  private encryptedSupport: EncryptedQuerySupport
+
+  /**
    * Side-loaded attributes that will be passed to the model instances
    */
   sideloaded: ModelObject = {}
@@ -166,6 +166,7 @@ export class ModelQueryBuilder
 
     this.preloader = new Preloader(this.model)
     this.debugQueries = this.client.debug
+    this.encryptedSupport = new EncryptedQuerySupport(this.model, () => this.tableAlias)
     this.clientOptions = {
       client: this.client,
       connection: this.client.connectionName,
@@ -180,397 +181,85 @@ export class ModelQueryBuilder
   }
 
   /**
-   * Returns encrypted metadata for a query key.
+   * Calls the matching super where* method.
    */
-  private getEncryptedQueryColumn(
+  private callSuperWhere(
+    method: EncryptedWhereMethod,
     key: any,
-    includeStandard: boolean = false
-  ): EncryptedQueryColumn | null {
-    if (typeof key !== 'string') {
-      return null
-    }
-
-    const lastDot = key.lastIndexOf('.')
-    const normalizedKey = lastDot >= 0 ? key.slice(lastDot + 1) : key
-
-    if (lastDot >= 0) {
-      const source = key.slice(0, lastDot)
-
-      if (!this.isModelColumnSource(source)) {
-        return null
+    operator?: any,
+    value?: any
+  ): this {
+    if (value !== undefined) {
+      switch (method) {
+        case 'where':
+          return super.where(key, operator, value)
+        case 'orWhere':
+          return super.orWhere(key, operator, value)
+        case 'whereNot':
+          return super.whereNot(key, operator, value)
+        case 'orWhereNot':
+          return super.orWhereNot(key, operator, value)
       }
     }
 
-    const attributeName =
-      this.model.$keys.columnsToAttributes.get(normalizedKey) ??
-      this.model.$keys.columnsToAttributes.get(key) ??
-      normalizedKey
-
-    if (!this.model.$hasColumn(attributeName)) {
-      return null
+    if (operator !== undefined) {
+      switch (method) {
+        case 'where':
+          return super.where(key, operator)
+        case 'orWhere':
+          return super.orWhere(key, operator)
+        case 'whereNot':
+          return super.whereNot(key, operator)
+        case 'orWhereNot':
+          return super.orWhereNot(key, operator)
+      }
     }
 
-    const column = this.model.$getColumn(attributeName)!
-    if (!this.isModelColumnReference(normalizedKey, attributeName, column.columnName)) {
-      return null
+    switch (method) {
+      case 'where':
+        return super.where(key)
+      case 'orWhere':
+        return super.orWhere(key)
+      case 'whereNot':
+        return super.whereNot(key)
+      case 'orWhereNot':
+        return super.orWhereNot(key)
     }
-
-    const encryption = column.meta?.encryption as EncryptedColumnMeta | undefined
-
-    if (!encryption || (!includeStandard && encryption.mode === 'standard')) {
-      return null
-    }
-
-    return {
-      key,
-      attributeName,
-      columnName: column.columnName,
-      encryption,
-    }
-  }
-
-  /**
-   * Returns true when a dotted key source points to the current model table.
-   */
-  private isModelColumnSource(source: string): boolean {
-    if (source === this.model.table || source.endsWith(`.${this.model.table}`)) {
-      return true
-    }
-
-    if (this.tableAlias && (source === this.tableAlias || source.endsWith(`.${this.tableAlias}`))) {
-      return true
-    }
-
-    return false
-  }
-
-  /**
-   * Returns true when a key segment matches either the model attribute name
-   * or the underlying database column name.
-   */
-  private isModelColumnReference(
-    column: string,
-    attributeName: string,
-    columnName: string
-  ): boolean {
-    return column === attributeName || column === columnName
-  }
-
-  /**
-   * Returns true when the value is a query/raw/reference value and should not be transformed.
-   */
-  private isQueryBuilderValue(value: any): boolean {
-    if (value instanceof Chainable || typeof value === 'function') {
-      return true
-    }
-
-    return !!value && typeof value === 'object' && ('knexQuery' in value || 'toKnex' in value)
-  }
-
-  /**
-   * Rewrites the query key for blind-index columns.
-   */
-  private getEncryptedQueryKey(column: EncryptedQueryColumn): string {
-    if (column.encryption.mode !== 'blind') {
-      return column.key
-    }
-
-    const blindColumnName = column.encryption.blindColumnName
-    if (!blindColumnName) {
-      throw new errors.E_INVALID_ENCRYPTED_COLUMN_CONFIGURATION([
-        `${this.model.name}.${column.attributeName}`,
-        'Missing "blind.columnName"',
-      ])
-    }
-
-    if (column.key === column.attributeName || column.key === column.columnName) {
-      return blindColumnName
-    }
-
-    if (
-      column.key.endsWith(`.${column.attributeName}`) ||
-      column.key.endsWith(`.${column.columnName}`)
-    ) {
-      const lastDot = column.key.lastIndexOf('.')
-      return `${column.key.slice(0, lastDot + 1)}${blindColumnName}`
-    }
-
-    return blindColumnName
-  }
-
-  private normalizeBlindIndexValues(indexes: any): any[] {
-    if (!indexes) {
-      return []
-    }
-
-    if (Array.isArray(indexes)) {
-      return indexes.filter((item) => item !== null && item !== undefined)
-    }
-
-    if (isObject(indexes)) {
-      return Object.values(indexes).filter((item) => item !== null && item !== undefined)
-    }
-
-    return [indexes]
-  }
-
-  /**
-   * Transforms a query value for deterministic/blind encrypted columns and
-   * returns one or many candidate values.
-   */
-  private getEncryptedQueryValues(column: EncryptedQueryColumn, value: any): any[] {
-    if (value === null || value === undefined || this.isQueryBuilderValue(value)) {
-      return [value]
-    }
-
-    const encryption = this.model.$getEncryption(column.attributeName)
-
-    if (column.encryption.mode === 'deterministic') {
-      return [
-        encryption.encrypt(value, {
-          deterministic: true,
-          driver: column.encryption.driver,
-        }),
-      ]
-    }
-
-    if (!column.encryption.purpose) {
-      throw new errors.E_INVALID_ENCRYPTED_COLUMN_CONFIGURATION([
-        `${this.model.name}.${column.attributeName}`,
-        'Missing "blind.purpose"',
-      ])
-    }
-
-    const blindIndexes = this.normalizeBlindIndexValues(
-      encryption.blindIndexes(value, {
-        purpose: column.encryption.purpose,
-        driver: column.encryption.driver,
-      })
-    )
-
-    if (blindIndexes.length) {
-      return blindIndexes
-    }
-
-    return [
-      encryption.blindIndex(value, {
-        purpose: column.encryption.purpose,
-        driver: column.encryption.driver,
-      }),
-    ]
-  }
-
-  /**
-   * Returns the first transformed query value.
-   */
-  private getEncryptedQueryValue(column: EncryptedQueryColumn, value: any): any {
-    return this.getEncryptedQueryValues(column, value)[0]
-  }
-
-  /**
-   * Normalize operators used by where/orWhere methods.
-   */
-  private normalizeOperator(operator: any): string {
-    return typeof operator === 'string' ? operator.trim().replace(/\s+/g, ' ').toLowerCase() : ''
-  }
-
-  /**
-   * Check if operator maps to an IN clause.
-   */
-  private isInOperator(operator: string): boolean {
-    return operator === 'in'
-  }
-
-  /**
-   * Check if operator maps to a NOT IN clause.
-   */
-  private isNotInOperator(operator: string): boolean {
-    return operator === 'not in'
-  }
-
-  /**
-   * Raises when using a non equality operator for deterministic/blind columns.
-   */
-  private ensureEncryptedEqualityOperator(
-    column: EncryptedQueryColumn | null,
-    operator: any,
-    method: string
-  ) {
-    if (!column) {
-      return
-    }
-
-    const normalizedOperator = this.normalizeOperator(operator)
-    if (
-      normalizedOperator !== '=' &&
-      !this.isInOperator(normalizedOperator) &&
-      !this.isNotInOperator(normalizedOperator)
-    ) {
-      throw new errors.E_UNSUPPORTED_ENCRYPTED_COLUMN_QUERY([
-        method,
-        `${this.model.name}.${column.attributeName}`,
-      ])
-    }
-  }
-
-  /**
-   * Raises when querying a standard encrypted column.
-   */
-  private ensureStandardEncryptedQuerySupport(column: EncryptedQueryColumn | null, method: string) {
-    if (column?.encryption.mode === 'standard') {
-      throw new errors.E_UNSUPPORTED_STANDARD_ENCRYPTED_COLUMN_QUERY([
-        method,
-        `${this.model.name}.${column.attributeName}`,
-      ])
-    }
-  }
-
-  /**
-   * Routes operator forms using IN/NOT IN through the dedicated methods.
-   */
-  private handleEncryptedInOperator(
-    method: EncryptedWhereMethod,
-    key: string,
-    operator: any,
-    value: any
-  ): this | null {
-    const column = this.getEncryptedQueryColumn(key)
-    if (!column) {
-      return null
-    }
-
-    const normalizedOperator = this.normalizeOperator(operator)
-    if (!this.isInOperator(normalizedOperator) && !this.isNotInOperator(normalizedOperator)) {
-      return null
-    }
-
-    const whereInMethod = this.getEncryptedWhereInMethod(method)
-    const targetMethod = this.isInOperator(normalizedOperator)
-      ? whereInMethod
-      : this.getOppositeEncryptedWhereInMethod(whereInMethod)
-
-    return this.encryptedWhereIn(targetMethod, key, value)
-  }
-
-  /**
-   * Returns the IN method associated with a WHERE variant.
-   */
-  private getEncryptedWhereInMethod(method: EncryptedWhereMethod): EncryptedWhereInMethod {
-    if (method === 'where') {
-      return 'whereIn'
-    }
-
-    if (method === 'orWhere') {
-      return 'orWhereIn'
-    }
-
-    if (method === 'whereNot') {
-      return 'whereNotIn'
-    }
-
-    return 'orWhereNotIn'
-  }
-
-  /**
-   * Returns the opposite IN method (IN <-> NOT IN) preserving the boolean variant.
-   */
-  private getOppositeEncryptedWhereInMethod(
-    method: EncryptedWhereInMethod
-  ): EncryptedWhereInMethod {
-    if (method === 'whereIn') {
-      return 'whereNotIn'
-    }
-
-    if (method === 'orWhereIn') {
-      return 'orWhereNotIn'
-    }
-
-    if (method === 'whereNotIn') {
-      return 'whereIn'
-    }
-
-    return 'orWhereIn'
-  }
-
-  /**
-   * Calls the matching super where* method with a single argument.
-   */
-  private callSuperWhereUnary(method: EncryptedWhereMethod, key: any): this {
-    if (method === 'where') {
-      return super.where(key)
-    }
-
-    if (method === 'orWhere') {
-      return super.orWhere(key)
-    }
-
-    if (method === 'whereNot') {
-      return super.whereNot(key)
-    }
-
-    return super.orWhereNot(key)
-  }
-
-  /**
-   * Calls the matching super where* method with 2 arguments.
-   */
-  private callSuperWhereBinary(method: EncryptedWhereMethod, key: any, value: any): this {
-    if (method === 'where') {
-      return super.where(key, value)
-    }
-
-    if (method === 'orWhere') {
-      return super.orWhere(key, value)
-    }
-
-    if (method === 'whereNot') {
-      return super.whereNot(key, value)
-    }
-
-    return super.orWhereNot(key, value)
-  }
-
-  /**
-   * Calls the matching super where* method with 3 arguments.
-   */
-  private callSuperWhereTernary(
-    method: EncryptedWhereMethod,
-    key: any,
-    operator: any,
-    value: any
-  ): this {
-    if (method === 'where') {
-      return super.where(key, operator, value)
-    }
-
-    if (method === 'orWhere') {
-      return super.orWhere(key, operator, value)
-    }
-
-    if (method === 'whereNot') {
-      return super.whereNot(key, operator, value)
-    }
-
-    return super.orWhereNot(key, operator, value)
   }
 
   /**
    * Calls the matching super where*In method.
    */
   private callSuperWhereIn(method: EncryptedWhereInMethod, columns: any, value: any): this {
-    if (method === 'whereIn') {
-      return super.whereIn(columns, value)
+    switch (method) {
+      case 'whereIn':
+        return super.whereIn(columns, value)
+      case 'orWhereIn':
+        return super.orWhereIn(columns, value)
+      case 'whereNotIn':
+        return super.whereNotIn(columns, value)
+      case 'orWhereNotIn':
+        return super.orWhereNotIn(columns, value)
+    }
+  }
+
+  /**
+   * Applies encrypted where rewrite instructions to the matching super method.
+   */
+  private applyWhereRewrite(rewrite: EncryptedWhereRewrite): this {
+    if (rewrite.target === 'whereIn') {
+      return this.callSuperWhereIn(rewrite.method, rewrite.columns, rewrite.value)
     }
 
-    if (method === 'orWhereIn') {
-      return super.orWhereIn(columns, value)
+    if (rewrite.args.length === 1) {
+      return this.callSuperWhere(rewrite.method, rewrite.args[0])
     }
 
-    if (method === 'whereNotIn') {
-      return super.whereNotIn(columns, value)
+    if (rewrite.args.length === 2) {
+      return this.callSuperWhere(rewrite.method, rewrite.args[0], rewrite.args[1])
     }
 
-    return super.orWhereNotIn(columns, value)
+    return this.callSuperWhere(rewrite.method, rewrite.args[0], rewrite.args[1], rewrite.args[2])
   }
 
   /**
@@ -582,113 +271,57 @@ export class ModelQueryBuilder
     operator?: any,
     value?: any
   ): this {
-    if (value !== undefined && typeof key === 'string') {
-      const column = this.getEncryptedQueryColumn(key, true)
-      this.ensureStandardEncryptedQuerySupport(column, method)
-      const inOperatorResult = this.handleEncryptedInOperator(method, key, operator, value)
-      if (inOperatorResult) {
-        return inOperatorResult
-      }
-      this.ensureEncryptedEqualityOperator(column, operator, method)
-
-      if (column?.encryption.mode === 'blind') {
-        const encryptedValues = this.getEncryptedQueryValues(column, value)
-        const encryptedKey = this.getEncryptedQueryKey(column)
-        const whereInMethod = this.getEncryptedWhereInMethod(method)
-
-        return encryptedValues.length > 1
-          ? this.callSuperWhereIn(whereInMethod, encryptedKey, encryptedValues)
-          : this.callSuperWhereTernary(method, encryptedKey, operator, encryptedValues[0])
+    if (typeof key === 'string') {
+      if (value !== undefined) {
+        return this.applyWhereRewrite(
+          this.encryptedSupport.rewriteWhereTernary(method, key, operator, value)
+        )
       }
 
-      return this.callSuperWhereTernary(
-        method,
-        column ? this.getEncryptedQueryKey(column) : key,
-        operator,
-        column ? this.getEncryptedQueryValue(column, value) : value
-      )
+      if (operator !== undefined) {
+        return this.applyWhereRewrite(
+          this.encryptedSupport.rewriteWhereBinary(method, key, operator)
+        )
+      }
     }
 
-    if (operator !== undefined && typeof key === 'string') {
-      const column = this.getEncryptedQueryColumn(key, true)
-      this.ensureStandardEncryptedQuerySupport(column, method)
-
-      if (column?.encryption.mode === 'blind') {
-        const encryptedValues = this.getEncryptedQueryValues(column, operator)
-        const encryptedKey = this.getEncryptedQueryKey(column)
-        const whereInMethod = this.getEncryptedWhereInMethod(method)
-
-        return encryptedValues.length > 1
-          ? this.callSuperWhereIn(whereInMethod, encryptedKey, encryptedValues)
-          : this.callSuperWhereBinary(method, encryptedKey, encryptedValues[0])
-      }
-
-      return this.callSuperWhereBinary(
-        method,
-        column ? this.getEncryptedQueryKey(column) : key,
-        column ? this.getEncryptedQueryValue(column, operator) : operator
-      )
+    if (!isObject(key)) {
+      return this.callSuperWhere(method, key, operator, value)
     }
 
-    if (isObject(key)) {
-      const clauses = Object.entries(key)
+    const clauses = Object.entries(key)
+    if (!clauses.length) {
+      return method === 'where' ? this.callSuperWhere(method, key) : this
+    }
 
-      if (!clauses.length) {
-        return method === 'where' ? this.callSuperWhereUnary(method, key) : this
-      }
-
-      if (method === 'orWhere') {
-        return this.callSuperWhereUnary(method, (query: ModelQueryBuilder) => {
-          clauses.forEach(([clauseKey, clauseValue]) => {
-            query.where(clauseKey, clauseValue)
-          })
+    if (method === 'orWhere') {
+      return this.callSuperWhere(method, (query: ModelQueryBuilder) => {
+        clauses.forEach(([clauseKey, clauseValue]) => {
+          query.where(clauseKey, clauseValue)
         })
-      }
-
-      clauses.forEach(([clauseKey, clauseValue]) => {
-        this.encryptedWhere(method, clauseKey, clauseValue)
       })
-
-      return this
     }
 
-    return this.callSuperWhereTernary(method, key, operator, value)
+    clauses.forEach(([clauseKey, clauseValue]) => {
+      this.encryptedWhere(method, clauseKey, clauseValue)
+    })
+
+    return this
   }
 
   /**
    * Shared implementation for whereIn/orWhereIn/whereNotIn/orWhereNotIn.
    */
   private encryptedWhereIn(method: EncryptedWhereInMethod, columns: any, value: any): this {
-    if (typeof columns !== 'string') {
-      return this.callSuperWhereIn(method, columns, value)
-    }
-
-    const column = this.getEncryptedQueryColumn(columns, true)
-    this.ensureStandardEncryptedQuerySupport(column, method)
-    if (!column) {
-      return this.callSuperWhereIn(method, columns, value)
-    }
-
-    const transformedValue = Array.isArray(value)
-      ? value.flatMap((item) => this.getEncryptedQueryValues(column, item))
-      : this.isQueryBuilderValue(value)
-        ? value
-        : this.getEncryptedQueryValues(column, value)
-
-    return this.callSuperWhereIn(method, this.getEncryptedQueryKey(column), transformedValue)
+    const rewrite = this.encryptedSupport.rewriteWhereIn(method, columns, value)
+    return this.callSuperWhereIn(rewrite.method, rewrite.columns, rewrite.value)
   }
 
   /**
    * Raises for unsupported encrypted column operators.
    */
   private ensureEncryptedMethodSupport(key: any, method: string) {
-    const column = this.getEncryptedQueryColumn(key, true)
-    if (column) {
-      throw new errors.E_UNSUPPORTED_ENCRYPTED_COLUMN_QUERY([
-        method,
-        `${this.model.name}.${column.attributeName}`,
-      ])
-    }
+    this.encryptedSupport.ensureMethodSupport(key, method)
   }
 
   /**
@@ -741,17 +374,7 @@ export class ModelQueryBuilder
    * Raises for unsupported arithmetic operations on encrypted columns.
    */
   private ensureEncryptedArithmeticSupport(key: any, method: string) {
-    const keys = typeof key === 'string' ? [key] : isObject(key) ? Object.keys(key) : []
-
-    for (const columnKey of keys) {
-      const column = this.getEncryptedQueryColumn(columnKey, true)
-      if (column) {
-        throw new errors.E_UNSUPPORTED_ENCRYPTED_COLUMN_QUERY([
-          method,
-          `${this.model.name}.${column.attributeName}`,
-        ])
-      }
-    }
+    this.encryptedSupport.ensureArithmeticSupport(key, method)
   }
 
   /**
@@ -762,108 +385,18 @@ export class ModelQueryBuilder
     column: any,
     comparisonColumn: any
   ) {
-    this.ensureEncryptedMethodSupport(column, method)
-    this.ensureEncryptedMethodSupport(comparisonColumn, method)
-  }
-
-  /**
-   * Encrypt value before writing it to an encrypted model column.
-   */
-  private getEncryptedWriteValue(column: EncryptedQueryColumn, value: any): any {
-    if (value === null || value === undefined || this.isQueryBuilderValue(value)) {
-      return value
-    }
-
-    const encryption = this.model.$getEncryption(column.attributeName)
-    if (column.encryption.mode === 'deterministic') {
-      return encryption.encrypt(value, {
-        deterministic: true,
-        driver: column.encryption.driver,
-      })
-    }
-
-    if (column.encryption.driver) {
-      return encryption.encrypt(value, {
-        driver: column.encryption.driver,
-      })
-    }
-
-    return encryption.encrypt(value)
-  }
-
-  /**
-   * Compute blind index value for writes.
-   */
-  private getBlindWriteValue(
-    column: EncryptedQueryColumn,
-    value: any
-  ): {
-    shouldWrite: boolean
-    value: any
-  } {
-    if (value === null || value === undefined) {
-      return { shouldWrite: true, value }
-    }
-
-    if (this.isQueryBuilderValue(value)) {
-      return { shouldWrite: false, value: null }
-    }
-
-    const purpose = column.encryption.purpose
-    if (!purpose) {
-      throw new errors.E_INVALID_ENCRYPTED_COLUMN_CONFIGURATION([
-        `${this.model.name}.${column.attributeName}`,
-        'Missing "blind.purpose"',
-      ])
-    }
-
-    const encryption = this.model.$getEncryption(column.attributeName)
-    return {
-      shouldWrite: true,
-      value: encryption.blindIndex(value, {
-        purpose,
-        driver: column.encryption.driver,
-      }),
-    }
+    this.encryptedSupport.ensureColumnComparisonSupport(method, column, comparisonColumn)
   }
 
   /**
    * Prepares update payload by applying encrypted column transforms.
    */
   private prepareUpdateValues(values: Dictionary<any, string>): Dictionary<any, string> {
-    const result: Dictionary<any, string> = {}
-    const blindWrites: Array<{ value: any; column: EncryptedQueryColumn }> = []
-
-    Object.keys(values).forEach((key) => {
-      const value = values[key]
-      const column = this.getEncryptedQueryColumn(key, true)
-
-      if (!column) {
-        result[this.resolveKey(key)] = this.transformRaw(value)
-        return
-      }
-
-      result[this.resolveKey(key)] = this.transformRaw(this.getEncryptedWriteValue(column, value))
-
-      if (column.encryption.mode === 'blind') {
-        blindWrites.push({ value, column })
-      }
-    })
-
-    /**
-     * Apply blind writes after processing the original payload so computed indexes
-     * always win over any manually provided blind column value, regardless of key order.
-     */
-    blindWrites.forEach(({ value, column }) => {
-      const blindResult = this.getBlindWriteValue(column, value)
-      if (blindResult.shouldWrite) {
-        result[this.resolveKey(this.getEncryptedQueryKey(column))] = this.transformRaw(
-          blindResult.value
-        )
-      }
-    })
-
-    return result
+    return this.encryptedSupport.prepareUpdateValues(
+      values,
+      (key) => this.resolveKey(key),
+      (rawValue) => this.transformRaw(rawValue)
+    )
   }
 
   where(key: any, operator?: any, value?: any): this {

--- a/src/orm/query_builder/index.ts
+++ b/src/orm/query_builder/index.ts
@@ -198,6 +198,10 @@ export class ModelQueryBuilder
     }
 
     const column = this.model.$getColumn(attributeName)!
+    if (!this.isModelColumnReference(key, attributeName, column.columnName)) {
+      return null
+    }
+
     const encryption = column.meta?.encryption as EncryptedColumnMeta | undefined
 
     if (!encryption || (!includeStandard && encryption.mode === 'standard')) {
@@ -210,6 +214,33 @@ export class ModelQueryBuilder
       columnName: column.columnName,
       encryption,
     }
+  }
+
+  /**
+   * Returns true when the key references the current model table.
+   */
+  private isModelColumnReference(key: string, attributeName: string, columnName: string): boolean {
+    if (!key.includes('.')) {
+      return true
+    }
+
+    const lastDot = key.lastIndexOf('.')
+    const source = key.slice(0, lastDot)
+    const column = key.slice(lastDot + 1)
+
+    if (column !== attributeName && column !== columnName) {
+      return false
+    }
+
+    if (source === this.model.table || source.endsWith(`.${this.model.table}`)) {
+      return true
+    }
+
+    if (this.tableAlias && (source === this.tableAlias || source.endsWith(`.${this.tableAlias}`))) {
+      return true
+    }
+
+    return false
   }
 
   /**

--- a/src/orm/query_builder/index.ts
+++ b/src/orm/query_builder/index.ts
@@ -14,6 +14,7 @@ import {
   type LucidRow,
   type LucidModel,
   type ModelObject,
+  type EncryptedColumnMeta,
   type ModelAdapterOptions,
   type ModelQueryBuilderContract,
 } from '../../types/model.js'
@@ -39,6 +40,13 @@ import { QueryRunner } from '../../query_runner/index.js'
 import { Chainable } from '../../database/query_builder/chainable.js'
 import { SimplePaginator } from '../../database/paginator/simple_paginator.js'
 import * as errors from '../../errors.js'
+
+type EncryptedQueryColumn = {
+  key: string
+  attributeName: string
+  columnName: string
+  encryption: EncryptedColumnMeta
+}
 
 /**
  * A wrapper to invoke scope methods on the query builder
@@ -166,6 +174,434 @@ export class ModelQueryBuilder
     if (!(builder as any)['_single'] || !(builder as any)['_single'].table) {
       builder.table(model.table)
     }
+  }
+
+  /**
+   * Returns encrypted metadata for a query key when it references a
+   * deterministic or blind encrypted column.
+   */
+  private getEncryptedQueryColumn(key: any): EncryptedQueryColumn | null {
+    if (typeof key !== 'string') {
+      return null
+    }
+
+    const normalizedKey = key.includes('.') ? key.split('.').pop()! : key
+    const attributeName =
+      this.model.$keys.columnsToAttributes.get(normalizedKey) ??
+      this.model.$keys.columnsToAttributes.get(key) ??
+      normalizedKey
+
+    if (!this.model.$hasColumn(attributeName)) {
+      return null
+    }
+
+    const column = this.model.$getColumn(attributeName)!
+    const encryption = column.meta?.encryption as EncryptedColumnMeta | undefined
+
+    if (!encryption || encryption.mode === 'standard') {
+      return null
+    }
+
+    return {
+      key,
+      attributeName,
+      columnName: column.columnName,
+      encryption,
+    }
+  }
+
+  /**
+   * Returns true when the value is a query/raw/reference value and should not be transformed.
+   */
+  private isQueryBuilderValue(value: any): boolean {
+    if (value instanceof Chainable || typeof value === 'function') {
+      return true
+    }
+
+    return !!value && typeof value === 'object' && ('knexQuery' in value || 'toKnex' in value)
+  }
+
+  /**
+   * Rewrites the query key for blind-index columns.
+   */
+  private getEncryptedQueryKey(column: EncryptedQueryColumn): string {
+    if (column.encryption.mode !== 'blind') {
+      return column.key
+    }
+
+    const blindColumnName = column.encryption.blindColumnName
+    if (!blindColumnName) {
+      throw new errors.E_INVALID_ENCRYPTED_COLUMN_CONFIGURATION([
+        `${this.model.name}.${column.attributeName}`,
+        'Missing "blind.columnName"',
+      ])
+    }
+
+    if (column.key === column.attributeName || column.key === column.columnName) {
+      return blindColumnName
+    }
+
+    if (
+      column.key.endsWith(`.${column.attributeName}`) ||
+      column.key.endsWith(`.${column.columnName}`)
+    ) {
+      const lastDot = column.key.lastIndexOf('.')
+      return `${column.key.slice(0, lastDot + 1)}${blindColumnName}`
+    }
+
+    return blindColumnName
+  }
+
+  /**
+   * Transforms a query value for deterministic/blind encrypted columns.
+   */
+  private getEncryptedQueryValue(column: EncryptedQueryColumn, value: any): any {
+    if (value === null || value === undefined || this.isQueryBuilderValue(value)) {
+      return value
+    }
+
+    const encryption = this.model.$getEncryption(column.attributeName)
+
+    if (column.encryption.mode === 'deterministic') {
+      return encryption.encrypt(value, { deterministic: true })
+    }
+
+    if (!column.encryption.purpose) {
+      throw new errors.E_INVALID_ENCRYPTED_COLUMN_CONFIGURATION([
+        `${this.model.name}.${column.attributeName}`,
+        'Missing "blind.purpose"',
+      ])
+    }
+
+    return encryption.blindIndex(value, { purpose: column.encryption.purpose })
+  }
+
+  /**
+   * Raises when using a non equality operator for deterministic/blind columns.
+   */
+  private ensureEncryptedEqualityOperator(
+    column: EncryptedQueryColumn | null,
+    operator: string,
+    method: string
+  ) {
+    if (column && operator !== '=') {
+      throw new errors.E_UNSUPPORTED_ENCRYPTED_COLUMN_QUERY([
+        method,
+        `${this.model.name}.${column.attributeName}`,
+      ])
+    }
+  }
+
+  /**
+   * Raises for unsupported encrypted column operators.
+   */
+  private ensureEncryptedMethodSupport(key: any, method: string) {
+    const column = this.getEncryptedQueryColumn(key)
+    if (column) {
+      throw new errors.E_UNSUPPORTED_ENCRYPTED_COLUMN_QUERY([
+        method,
+        `${this.model.name}.${column.attributeName}`,
+      ])
+    }
+  }
+
+  /**
+   * Transforms an object where clause for deterministic/blind encrypted columns.
+   */
+  private transformWhereObjectClause(clause: Dictionary<any, string>) {
+    return Object.keys(clause).reduce((result: Dictionary<any, string>, key) => {
+      const column = this.getEncryptedQueryColumn(key)
+
+      if (!column) {
+        result[key] = clause[key]
+        return result
+      }
+
+      result[this.getEncryptedQueryKey(column)] = this.getEncryptedQueryValue(column, clause[key])
+      return result
+    }, {})
+  }
+
+  where(key: any, operator?: any, value?: any): this {
+    if (value !== undefined && typeof key === 'string') {
+      const column = this.getEncryptedQueryColumn(key)
+      this.ensureEncryptedEqualityOperator(column, operator, 'where')
+      return super.where(
+        column ? this.getEncryptedQueryKey(column) : key,
+        operator,
+        column ? this.getEncryptedQueryValue(column, value) : value
+      )
+    }
+
+    if (operator !== undefined && typeof key === 'string') {
+      const column = this.getEncryptedQueryColumn(key)
+      return super.where(
+        column ? this.getEncryptedQueryKey(column) : key,
+        column ? this.getEncryptedQueryValue(column, operator) : operator
+      )
+    }
+
+    if (isObject(key)) {
+      return super.where(this.transformWhereObjectClause(key))
+    }
+
+    return super.where(key, operator, value)
+  }
+
+  orWhere(key: any, operator?: any, value?: any): this {
+    if (value !== undefined && typeof key === 'string') {
+      const column = this.getEncryptedQueryColumn(key)
+      this.ensureEncryptedEqualityOperator(column, operator, 'orWhere')
+      return super.orWhere(
+        column ? this.getEncryptedQueryKey(column) : key,
+        operator,
+        column ? this.getEncryptedQueryValue(column, value) : value
+      )
+    }
+
+    if (operator !== undefined && typeof key === 'string') {
+      const column = this.getEncryptedQueryColumn(key)
+      return super.orWhere(
+        column ? this.getEncryptedQueryKey(column) : key,
+        column ? this.getEncryptedQueryValue(column, operator) : operator
+      )
+    }
+
+    if (isObject(key)) {
+      return super.orWhere(this.transformWhereObjectClause(key))
+    }
+
+    return super.orWhere(key, operator, value)
+  }
+
+  whereNot(key: any, operator?: any, value?: any): this {
+    if (value !== undefined && typeof key === 'string') {
+      const column = this.getEncryptedQueryColumn(key)
+      this.ensureEncryptedEqualityOperator(column, operator, 'whereNot')
+      return super.whereNot(
+        column ? this.getEncryptedQueryKey(column) : key,
+        operator,
+        column ? this.getEncryptedQueryValue(column, value) : value
+      )
+    }
+
+    if (operator !== undefined && typeof key === 'string') {
+      const column = this.getEncryptedQueryColumn(key)
+      return super.whereNot(
+        column ? this.getEncryptedQueryKey(column) : key,
+        column ? this.getEncryptedQueryValue(column, operator) : operator
+      )
+    }
+
+    if (isObject(key)) {
+      return super.whereNot(this.transformWhereObjectClause(key))
+    }
+
+    return super.whereNot(key, operator, value)
+  }
+
+  orWhereNot(key: any, operator?: any, value?: any): this {
+    if (value !== undefined && typeof key === 'string') {
+      const column = this.getEncryptedQueryColumn(key)
+      this.ensureEncryptedEqualityOperator(column, operator, 'orWhereNot')
+      return super.orWhereNot(
+        column ? this.getEncryptedQueryKey(column) : key,
+        operator,
+        column ? this.getEncryptedQueryValue(column, value) : value
+      )
+    }
+
+    if (operator !== undefined && typeof key === 'string') {
+      const column = this.getEncryptedQueryColumn(key)
+      return super.orWhereNot(
+        column ? this.getEncryptedQueryKey(column) : key,
+        column ? this.getEncryptedQueryValue(column, operator) : operator
+      )
+    }
+
+    if (isObject(key)) {
+      return super.orWhereNot(this.transformWhereObjectClause(key))
+    }
+
+    return super.orWhereNot(key, operator, value)
+  }
+
+  whereIn(columns: any, value: any): this {
+    if (typeof columns !== 'string') {
+      return super.whereIn(columns, value)
+    }
+
+    const column = this.getEncryptedQueryColumn(columns)
+    if (!column) {
+      return super.whereIn(columns, value)
+    }
+
+    const transformedValue = Array.isArray(value)
+      ? value.map((item) => this.getEncryptedQueryValue(column, item))
+      : value
+
+    return super.whereIn(this.getEncryptedQueryKey(column), transformedValue)
+  }
+
+  orWhereIn(columns: any, value: any): this {
+    if (typeof columns !== 'string') {
+      return super.orWhereIn(columns, value)
+    }
+
+    const column = this.getEncryptedQueryColumn(columns)
+    if (!column) {
+      return super.orWhereIn(columns, value)
+    }
+
+    const transformedValue = Array.isArray(value)
+      ? value.map((item) => this.getEncryptedQueryValue(column, item))
+      : value
+
+    return super.orWhereIn(this.getEncryptedQueryKey(column), transformedValue)
+  }
+
+  whereNotIn(columns: any, value: any): this {
+    if (typeof columns !== 'string') {
+      return super.whereNotIn(columns, value)
+    }
+
+    const column = this.getEncryptedQueryColumn(columns)
+    if (!column) {
+      return super.whereNotIn(columns, value)
+    }
+
+    const transformedValue = Array.isArray(value)
+      ? value.map((item) => this.getEncryptedQueryValue(column, item))
+      : value
+
+    return super.whereNotIn(this.getEncryptedQueryKey(column), transformedValue)
+  }
+
+  orWhereNotIn(columns: any, value: any): this {
+    if (typeof columns !== 'string') {
+      return super.orWhereNotIn(columns, value)
+    }
+
+    const column = this.getEncryptedQueryColumn(columns)
+    if (!column) {
+      return super.orWhereNotIn(columns, value)
+    }
+
+    const transformedValue = Array.isArray(value)
+      ? value.map((item) => this.getEncryptedQueryValue(column, item))
+      : value
+
+    return super.orWhereNotIn(this.getEncryptedQueryKey(column), transformedValue)
+  }
+
+  whereLike(key: any, value: any): this {
+    this.ensureEncryptedMethodSupport(key, 'whereLike')
+    return super.whereLike(key, value)
+  }
+
+  orWhereLike(key: any, value: any): this {
+    this.ensureEncryptedMethodSupport(key, 'orWhereLike')
+    return super.orWhereLike(key, value)
+  }
+
+  whereILike(key: any, value: any): this {
+    this.ensureEncryptedMethodSupport(key, 'whereILike')
+    return super.whereILike(key, value)
+  }
+
+  orWhereILike(key: any, value: any): this {
+    this.ensureEncryptedMethodSupport(key, 'orWhereILike')
+    return super.orWhereILike(key, value)
+  }
+
+  whereBetween(key: any, value: [any, any]): this {
+    this.ensureEncryptedMethodSupport(key, 'whereBetween')
+    return super.whereBetween(key, value)
+  }
+
+  orWhereBetween(key: any, value: [any, any]): this {
+    this.ensureEncryptedMethodSupport(key, 'orWhereBetween')
+    return super.orWhereBetween(key, value)
+  }
+
+  whereNotBetween(key: any, value: [any, any]): this {
+    this.ensureEncryptedMethodSupport(key, 'whereNotBetween')
+    return super.whereNotBetween(key, value)
+  }
+
+  orWhereNotBetween(key: any, value: [any, any]): this {
+    this.ensureEncryptedMethodSupport(key, 'orWhereNotBetween')
+    return super.orWhereNotBetween(key, value)
+  }
+
+  whereJson(column: string, value: any) {
+    this.ensureEncryptedMethodSupport(column, 'whereJson')
+    return super.whereJson(column, value)
+  }
+
+  orWhereJson(column: string, value: any) {
+    this.ensureEncryptedMethodSupport(column, 'orWhereJson')
+    return super.orWhereJson(column, value)
+  }
+
+  whereNotJson(column: string, value: any) {
+    this.ensureEncryptedMethodSupport(column, 'whereNotJson')
+    return super.whereNotJson(column, value)
+  }
+
+  orWhereNotJson(column: string, value: any) {
+    this.ensureEncryptedMethodSupport(column, 'orWhereNotJson')
+    return super.orWhereNotJson(column, value)
+  }
+
+  whereJsonSuperset(column: string, value: any) {
+    this.ensureEncryptedMethodSupport(column, 'whereJsonSuperset')
+    return super.whereJsonSuperset(column, value)
+  }
+
+  orWhereJsonSuperset(column: string, value: any) {
+    this.ensureEncryptedMethodSupport(column, 'orWhereJsonSuperset')
+    return super.orWhereJsonSuperset(column, value)
+  }
+
+  whereNotJsonSuperset(column: string, value: any) {
+    this.ensureEncryptedMethodSupport(column, 'whereNotJsonSuperset')
+    return super.whereNotJsonSuperset(column, value)
+  }
+
+  orWhereNotJsonSuperset(column: string, value: any) {
+    this.ensureEncryptedMethodSupport(column, 'orWhereNotJsonSuperset')
+    return super.orWhereNotJsonSuperset(column, value)
+  }
+
+  whereJsonSubset(column: string, value: any) {
+    this.ensureEncryptedMethodSupport(column, 'whereJsonSubset')
+    return super.whereJsonSubset(column, value)
+  }
+
+  orWhereJsonSubset(column: string, value: any) {
+    this.ensureEncryptedMethodSupport(column, 'orWhereJsonSubset')
+    return super.orWhereJsonSubset(column, value)
+  }
+
+  whereNotJsonSubset(column: string, value: any) {
+    this.ensureEncryptedMethodSupport(column, 'whereNotJsonSubset')
+    return super.whereNotJsonSubset(column, value)
+  }
+
+  orWhereNotJsonSubset(column: string, value: any) {
+    this.ensureEncryptedMethodSupport(column, 'orWhereNotJsonSubset')
+    return super.orWhereNotJsonSubset(column, value)
+  }
+
+  whereJsonPath(column: string, jsonPath: string, operator: any, value?: any): this {
+    this.ensureEncryptedMethodSupport(column, 'whereJsonPath')
+    return super.whereJsonPath(column, jsonPath, operator, value)
+  }
+
+  orWhereJsonPath(column: string, jsonPath: string, operator: any, value?: any): this {
+    this.ensureEncryptedMethodSupport(column, 'orWhereJsonPath')
+    return super.orWhereJsonPath(column, jsonPath, operator, value)
   }
 
   /**

--- a/src/orm/query_builder/index.ts
+++ b/src/orm/query_builder/index.ts
@@ -677,6 +677,19 @@ export class ModelQueryBuilder
   }
 
   /**
+   * Raises for unsupported arithmetic operations on encrypted columns.
+   */
+  private ensureEncryptedArithmeticSupport(key: any, method: string) {
+    const column = this.getEncryptedQueryColumn(key, true)
+    if (column) {
+      throw new errors.E_UNSUPPORTED_ENCRYPTED_COLUMN_QUERY([
+        method,
+        `${this.model.name}.${column.attributeName}`,
+      ])
+    }
+  }
+
+  /**
    * Raises for unsupported column-vs-column comparisons on encrypted columns.
    */
   private ensureEncryptedColumnComparisonSupport(
@@ -1474,6 +1487,7 @@ export class ModelQueryBuilder
    */
   increment(column: any, counter?: any): any {
     this.ensureCanPerformWrites()
+    this.ensureEncryptedArithmeticSupport(column, 'increment')
     this.knexQuery.increment(this.resolveKey(column, true), counter)
     return this
   }
@@ -1484,6 +1498,7 @@ export class ModelQueryBuilder
    */
   decrement(column: any, counter?: any): any {
     this.ensureCanPerformWrites()
+    this.ensureEncryptedArithmeticSupport(column, 'decrement')
     this.knexQuery.decrement(this.resolveKey(column, true), counter)
     return this
   }

--- a/src/orm/query_builder/index.ts
+++ b/src/orm/query_builder/index.ts
@@ -611,12 +611,8 @@ export class ModelQueryBuilder
         return super.where(key)
       }
 
-      clauses.forEach(([clauseKey, clauseValue], index) => {
-        if (index === 0) {
-          this.where(clauseKey, clauseValue)
-        } else {
-          this.andWhere(clauseKey, clauseValue)
-        }
+      clauses.forEach(([clauseKey, clauseValue]) => {
+        this.where(clauseKey, clauseValue)
       })
 
       return this

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -227,7 +227,7 @@ export type ColumnOptions = {
  */
 export type ModelEncryptionContract = {
   encrypt(value: any, options?: { deterministic?: boolean; [key: string]: any }): any
-  decrypt(value: any): any
+  decrypt(value: any, options?: { [key: string]: any }): any
   blindIndexes(value: any, options?: { [key: string]: any }): any
   blindIndex(value: any, options: { purpose: string; [key: string]: any }): any
 }

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -258,7 +258,10 @@ export type EncryptedColumnMeta = {
 /**
  * Options accepted by the encrypted column decorator.
  */
-export type EncryptedColumnOptions = Partial<ColumnOptions> & {
+export type EncryptedColumnOptions = Omit<
+  Partial<ColumnOptions>,
+  'isPrimary' | 'prepare' | 'consume'
+> & {
   deterministic?: boolean
   driver?: string
   blind?: BlindEncryptedColumnOptions

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -233,6 +233,23 @@ export type ModelEncryptionContract = {
 }
 
 /**
+ * Default drivers used when encrypted columns do not define one.
+ */
+export type ModelEncryptionDefaults = {
+  standardDriver?: string
+  deterministicDriver?: string
+  blindDriver?: string
+}
+
+/**
+ * Encryption configuration for Lucid models.
+ */
+export type ModelEncryptionConfig = {
+  provider?: ModelEncryptionContract
+  defaults?: ModelEncryptionDefaults
+}
+
+/**
  * Supported encryption strategies for columns.
  */
 export type EncryptedColumnMode = 'standard' | 'deterministic' | 'blind'
@@ -876,7 +893,7 @@ export interface LucidModel {
   /**
    * Encryption provider used by encrypted columns.
    */
-  $encryption?: ModelEncryptionContract
+  $encryption?: ModelEncryptionConfig
 
   /**
    * Define an adapter to use for interacting with
@@ -887,12 +904,21 @@ export interface LucidModel {
   /**
    * Define encryption provider to use for encrypted columns.
    */
-  useEncryption(encryption: ModelEncryptionContract): void
+  useEncryption(config: ModelEncryptionConfig): void
 
   /**
    * Returns the encryption provider.
    */
   $getEncryption(attributeName?: string): ModelEncryptionContract
+
+  /**
+   * Returns encryption provider along with the resolved driver for a given mode.
+   */
+  $resolveEncryption(
+    attributeName: string | undefined,
+    mode: EncryptedColumnMode,
+    columnDriver?: string
+  ): { provider: ModelEncryptionContract; driver?: string }
 
   /**
    * Reference to hooks

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -221,6 +221,48 @@ export type ColumnOptions = {
 }
 
 /**
+ * Encryption contract used by encrypted columns.
+ * The shape is intentionally aligned with the
+ * boringnode/encryption package.
+ */
+export type ModelEncryptionContract = {
+  encrypt(value: any, options?: { deterministic?: boolean; [key: string]: any }): any
+  decrypt(value: any): any
+  blindIndexes(value: any, options?: { [key: string]: any }): any
+  blindIndex(value: any, options: { purpose: string; [key: string]: any }): any
+}
+
+/**
+ * Supported encryption strategies for columns.
+ */
+export type EncryptedColumnMode = 'standard' | 'deterministic' | 'blind'
+
+/**
+ * Configuration for blind indexes.
+ */
+export type BlindEncryptedColumnOptions = {
+  columnName: string
+  purpose: string
+}
+
+/**
+ * Metadata persisted on encrypted columns.
+ */
+export type EncryptedColumnMeta = {
+  mode: EncryptedColumnMode
+  blindColumnName?: string
+  purpose?: string
+}
+
+/**
+ * Options accepted by the encrypted column decorator.
+ */
+export type EncryptedColumnOptions = Partial<ColumnOptions> & {
+  deterministic?: boolean
+  blind?: BlindEncryptedColumnOptions
+}
+
+/**
  * Shape of column options after they have set on the model
  */
 export type ModelColumnOptions = ColumnOptions & {
@@ -248,6 +290,11 @@ export type ModelRelationOptions =
  * Signature for column decorator function
  */
 export type ColumnDecorator = (options?: Partial<ColumnOptions>) => DecoratorFn
+
+/**
+ * Signature for encrypted column decorator function
+ */
+export type EncryptedColumnDecorator = (options?: EncryptedColumnOptions) => DecoratorFn
 
 /**
  * Signature for computed decorator function
@@ -822,10 +869,25 @@ export interface LucidModel {
   $adapter: AdapterContract
 
   /**
+   * Encryption provider used by encrypted columns.
+   */
+  $encryption?: ModelEncryptionContract
+
+  /**
    * Define an adapter to use for interacting with
    * the database
    */
   useAdapter(adapter: AdapterContract): void
+
+  /**
+   * Define encryption provider to use for encrypted columns.
+   */
+  useEncryption(encryption: ModelEncryptionContract): void
+
+  /**
+   * Returns the encryption provider.
+   */
+  $getEncryption(attributeName?: string): ModelEncryptionContract
 
   /**
    * Reference to hooks

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -250,6 +250,7 @@ export type BlindEncryptedColumnOptions = {
  */
 export type EncryptedColumnMeta = {
   mode: EncryptedColumnMode
+  driver?: string
   blindColumnName?: string
   purpose?: string
 }
@@ -259,6 +260,7 @@ export type EncryptedColumnMeta = {
  */
 export type EncryptedColumnOptions = Partial<ColumnOptions> & {
   deterministic?: boolean
+  driver?: string
   blind?: BlindEncryptedColumnOptions
 }
 

--- a/test-helpers/index.ts
+++ b/test-helpers/index.ts
@@ -191,8 +191,9 @@ export async function setup(destroyDb: boolean = true) {
     await db.schema.createTable('users_encrypted', (table) => {
       table.increments()
       table.string('username').unique()
-      table.string('email').nullable()
+      table.text('email').nullable()
       table.string('email_blind').nullable()
+      table.index(['email_blind'])
       table.timestamp('created_at').defaultTo(db.fn.now())
       table.timestamp('updated_at').nullable()
     })

--- a/test-helpers/index.ts
+++ b/test-helpers/index.ts
@@ -186,6 +186,18 @@ export async function setup(destroyDb: boolean = true) {
     })
   }
 
+  const hasEncryptedUsersTable = await db.schema.hasTable('users_encrypted')
+  if (!hasEncryptedUsersTable) {
+    await db.schema.createTable('users_encrypted', (table) => {
+      table.increments()
+      table.string('username').unique()
+      table.string('email').nullable()
+      table.string('email_blind').nullable()
+      table.timestamp('created_at').defaultTo(db.fn.now())
+      table.timestamp('updated_at').nullable()
+    })
+  }
+
   const hasUuidUsers = await db.schema.hasTable('uuid_users')
   if (!hasUuidUsers) {
     await db.schema.createTable('uuid_users', (table) => {
@@ -329,6 +341,7 @@ export async function cleanup(customTables?: string[]) {
   }
 
   await db.schema.dropTableIfExists('users')
+  await db.schema.dropTableIfExists('users_encrypted')
   await db.schema.dropTableIfExists('uuid_users')
   await db.schema.dropTableIfExists('follows')
   await db.schema.dropTableIfExists('friends')
@@ -352,6 +365,7 @@ export async function cleanup(customTables?: string[]) {
 export async function resetTables() {
   const db = getKnex(Object.assign({}, getConfig(), { debug: false }))
   await db.table('users').truncate()
+  await db.table('users_encrypted').truncate()
   await db.table('uuid_users').truncate()
   await db.table('follows').truncate()
   await db.table('friends').truncate()

--- a/test/database/query_client.spec.ts
+++ b/test/database/query_client.spec.ts
@@ -569,6 +569,7 @@ test.group('Query client | get tables', (group) => {
         'skill_user',
         'skills',
         'users',
+        'users_encrypted',
         'uuid_users',
       ])
     } else {
@@ -585,6 +586,7 @@ test.group('Query client | get tables', (group) => {
         'skills',
         'skill_user',
         'users',
+        'users_encrypted',
         'uuid_users',
       ])
     }

--- a/test/orm/base_model.spec.ts
+++ b/test/orm/base_model.spec.ts
@@ -1408,6 +1408,55 @@ test.group('Base Model | persist', (group) => {
     })
   })
 
+  test('prefer computed blind index over manual blind column attributes regardless of assignment order', async ({
+    fs,
+    assert,
+  }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const adapter = new FakeAdapter()
+    const BaseModel = getBaseModel(adapter)
+
+    BaseModel.useEncryption({
+      encrypt: (value, options) => `enc:${options?.driver || 'default'}:${value}`,
+      decrypt: (value) => String(value).replace(/^enc:/, ''),
+      blindIndex: (value, { purpose, driver }) =>
+        `blind:${driver || 'default'}:${purpose}:${value}`,
+      blindIndexes: () => ({}),
+    })
+
+    class User extends BaseModel {
+      @column.encrypted({
+        driver: 'enc-v1',
+        blind: { columnName: 'email_blind', purpose: 'users:email' },
+      })
+      declare email: string
+
+      @column({ columnName: 'email_blind' })
+      declare emailBlind: string
+    }
+
+    const first = new User()
+    first.emailBlind = 'manual:first'
+    first.email = 'virk@adonisjs.com'
+    await first.save()
+
+    const second = new User()
+    second.email = 'nikk@adonisjs.com'
+    second.emailBlind = 'manual:second'
+    await second.save()
+
+    assert.deepEqual(adapter.operations[0].attributes, {
+      email: 'enc:enc-v1:virk@adonisjs.com',
+      email_blind: 'blind:enc-v1:users:email:virk@adonisjs.com',
+    })
+
+    assert.deepEqual(adapter.operations[1].attributes, {
+      email: 'enc:enc-v1:nikk@adonisjs.com',
+      email_blind: 'blind:enc-v1:users:email:nikk@adonisjs.com',
+    })
+  })
+
   test('raise exception when using blind encrypted columns without purpose', async ({
     fs,
     assert,

--- a/test/orm/base_model.spec.ts
+++ b/test/orm/base_model.spec.ts
@@ -1315,6 +1315,143 @@ test.group('Base Model | persist', (group) => {
     assert.deepEqual(user.$original, { username: 'virk', fullName: 'H virk' })
   })
 
+  test('encrypt value before passing encrypted columns to the adapter', async ({ fs, assert }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const adapter = new FakeAdapter()
+    const BaseModel = getBaseModel(adapter)
+
+    BaseModel.useEncryption({
+      encrypt: (value) => `enc:${value}`,
+      decrypt: (value) => String(value).replace(/^enc:/, ''),
+      blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
+      blindIndexes: () => ({}),
+    })
+
+    class User extends BaseModel {
+      @column.encrypted()
+      declare secret: string
+    }
+
+    const user = new User()
+    user.secret = 'super-secret'
+    await user.save()
+
+    assert.deepEqual(adapter.operations[0].attributes, { secret: 'enc:super-secret' })
+  })
+
+  test('encrypt deterministic value before passing encrypted columns to the adapter', async ({
+    fs,
+    assert,
+  }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const adapter = new FakeAdapter()
+    const BaseModel = getBaseModel(adapter)
+
+    BaseModel.useEncryption({
+      encrypt: (value, options) => (options?.deterministic ? `det:${value}` : `enc:${value}`),
+      decrypt: (value) => String(value).replace(/^(enc:|det:)/, ''),
+      blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
+      blindIndexes: () => ({}),
+    })
+
+    class User extends BaseModel {
+      @column.encrypted({ deterministic: true })
+      declare email: string
+    }
+
+    const user = new User()
+    user.email = 'virk@adonisjs.com'
+    await user.save()
+
+    assert.deepEqual(adapter.operations[0].attributes, { email: 'det:virk@adonisjs.com' })
+  })
+
+  test('persist blind index in a dedicated column when using blind encrypted columns', async ({
+    fs,
+    assert,
+  }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const adapter = new FakeAdapter()
+    const BaseModel = getBaseModel(adapter)
+
+    BaseModel.useEncryption({
+      encrypt: (value) => `enc:${value}`,
+      decrypt: (value) => String(value).replace(/^enc:/, ''),
+      blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
+      blindIndexes: () => ({}),
+    })
+
+    class User extends BaseModel {
+      @column.encrypted({ blind: { columnName: 'email_blind', purpose: 'users:email' } })
+      declare email: string
+    }
+
+    const user = new User()
+    user.email = 'virk@adonisjs.com'
+    await user.save()
+
+    assert.deepEqual(adapter.operations[0].attributes, {
+      email: 'enc:virk@adonisjs.com',
+      email_blind: 'blind:users:email:virk@adonisjs.com',
+    })
+  })
+
+  test('raise exception when using blind encrypted columns without purpose', async ({
+    fs,
+    assert,
+  }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const adapter = new FakeAdapter()
+    const BaseModel = getBaseModel(adapter)
+
+    const fn = () => {
+      class User extends BaseModel {
+        @column.encrypted({ blind: { columnName: 'email_blind' } } as any)
+        declare email: string
+      }
+
+      return User
+    }
+
+    assert.throws(
+      fn,
+      'Invalid encrypted column configuration for "User.email". Missing "blind.purpose"'
+    )
+  })
+
+  test('raise exception when encryption provider is missing for encrypted columns', async ({
+    fs,
+    assert,
+  }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const adapter = new FakeAdapter()
+    const BaseModel = getBaseModel(adapter)
+    BaseModel.useEncryption(undefined as any)
+
+    class User extends BaseModel {
+      @column.encrypted()
+      declare secret: string
+    }
+
+    const user = new User()
+    user.secret = 'super-secret'
+
+    try {
+      await user.save()
+      assert.fail('Expected save to fail when encryption provider is missing')
+    } catch (error: any) {
+      assert.equal(
+        error.message,
+        'Cannot use encrypted column "User.secret" without a configured encryption provider. Call "BaseModel.useEncryption()" before querying or persisting encrypted columns'
+      )
+    }
+  })
+
   test('send values mutated by the hooks to the adapter', async ({ fs, assert }) => {
     const app = new AppFactory().create(fs.baseUrl, () => {})
     await app.init()
@@ -1813,6 +1950,33 @@ test.group('Base Model | create from adapter results', (group) => {
     assert.isFalse(user!.$isLocal)
     assert.deepEqual(user!.$attributes, { fullName: 'VIRK' })
     assert.deepEqual(user!.$original, { fullName: 'VIRK' })
+  })
+
+  test('decrypt value when consuming encrypted columns', async ({ fs, assert }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const adapter = new FakeAdapter()
+
+    const BaseModel = getBaseModel(adapter)
+    BaseModel.useEncryption({
+      encrypt: (value) => `enc:${value}`,
+      decrypt: (value) => String(value).replace(/^enc:/, ''),
+      blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
+      blindIndexes: () => ({}),
+    })
+
+    class User extends BaseModel {
+      @column.encrypted()
+      declare secret: string
+    }
+
+    const user = User.$createFromAdapterResult({ secret: 'enc:top-secret' })
+
+    assert.isTrue(user!.$isPersisted)
+    assert.isFalse(user!.$isDirty)
+    assert.isFalse(user!.$isLocal)
+    assert.deepEqual(user!.$attributes, { secret: 'top-secret' })
+    assert.deepEqual(user!.$original, { secret: 'top-secret' })
   })
 
   test('original and attributes should not be shared', async ({ fs, assert }) => {

--- a/test/orm/base_model.spec.ts
+++ b/test/orm/base_model.spec.ts
@@ -1350,14 +1350,17 @@ test.group('Base Model | persist', (group) => {
     const BaseModel = getBaseModel(adapter)
 
     BaseModel.useEncryption({
-      encrypt: (value, options) => (options?.deterministic ? `det:${value}` : `enc:${value}`),
+      encrypt: (value, options) =>
+        options?.deterministic
+          ? `det:${options?.driver || 'default'}:${value}`
+          : `enc:${options?.driver || 'default'}:${value}`,
       decrypt: (value) => String(value).replace(/^(enc:|det:)/, ''),
       blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
       blindIndexes: () => ({}),
     })
 
     class User extends BaseModel {
-      @column.encrypted({ deterministic: true })
+      @column.encrypted({ deterministic: true, driver: 'det-v1' })
       declare email: string
     }
 
@@ -1365,7 +1368,9 @@ test.group('Base Model | persist', (group) => {
     user.email = 'virk@adonisjs.com'
     await user.save()
 
-    assert.deepEqual(adapter.operations[0].attributes, { email: 'det:virk@adonisjs.com' })
+    assert.deepEqual(adapter.operations[0].attributes, {
+      email: 'det:det-v1:virk@adonisjs.com',
+    })
   })
 
   test('persist blind index in a dedicated column when using blind encrypted columns', async ({
@@ -1378,14 +1383,18 @@ test.group('Base Model | persist', (group) => {
     const BaseModel = getBaseModel(adapter)
 
     BaseModel.useEncryption({
-      encrypt: (value) => `enc:${value}`,
+      encrypt: (value, options) => `enc:${options?.driver || 'default'}:${value}`,
       decrypt: (value) => String(value).replace(/^enc:/, ''),
-      blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
+      blindIndex: (value, { purpose, driver }) =>
+        `blind:${driver || 'default'}:${purpose}:${value}`,
       blindIndexes: () => ({}),
     })
 
     class User extends BaseModel {
-      @column.encrypted({ blind: { columnName: 'email_blind', purpose: 'users:email' } })
+      @column.encrypted({
+        driver: 'enc-v1',
+        blind: { columnName: 'email_blind', purpose: 'users:email' },
+      })
       declare email: string
     }
 
@@ -1394,8 +1403,8 @@ test.group('Base Model | persist', (group) => {
     await user.save()
 
     assert.deepEqual(adapter.operations[0].attributes, {
-      email: 'enc:virk@adonisjs.com',
-      email_blind: 'blind:users:email:virk@adonisjs.com',
+      email: 'enc:enc-v1:virk@adonisjs.com',
+      email_blind: 'blind:enc-v1:users:email:virk@adonisjs.com',
     })
   })
 

--- a/test/orm/base_model.spec.ts
+++ b/test/orm/base_model.spec.ts
@@ -2110,6 +2110,39 @@ test.group('Base Model | create from adapter results', (group) => {
     assert.deepEqual(user!.$original, { secret: 'top-secret' })
   })
 
+  test('pass encryption driver when decrypting encrypted columns during consume', async ({
+    fs,
+    assert,
+  }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const adapter = new FakeAdapter()
+
+    const BaseModel = getBaseModel(adapter)
+    let decryptOptions: any
+
+    BaseModel.useEncryption({
+      encrypt: (value, options) => `enc:${options?.driver || 'default'}:${value}`,
+      decrypt: (value, options) => {
+        decryptOptions = options
+        return String(value).replace(/^enc:[^:]+:/, '')
+      },
+      blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
+      blindIndexes: () => ({}),
+    })
+
+    class User extends BaseModel {
+      @column.encrypted({ driver: 'enc-v1' })
+      declare secret: string
+    }
+
+    const user = User.$createFromAdapterResult({ secret: 'enc:enc-v1:top-secret' })
+
+    assert.deepEqual(user!.$attributes, { secret: 'top-secret' })
+    assert.deepEqual(user!.$original, { secret: 'top-secret' })
+    assert.deepEqual(decryptOptions, { driver: 'enc-v1' })
+  })
+
   test('original and attributes should not be shared', async ({ fs, assert }) => {
     const app = new AppFactory().create(fs.baseUrl, () => {})
     await app.init()

--- a/test/orm/base_model.spec.ts
+++ b/test/orm/base_model.spec.ts
@@ -1322,10 +1322,12 @@ test.group('Base Model | persist', (group) => {
     const BaseModel = getBaseModel(adapter)
 
     BaseModel.useEncryption({
-      encrypt: (value) => `enc:${value}`,
-      decrypt: (value) => String(value).replace(/^enc:/, ''),
-      blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
-      blindIndexes: () => ({}),
+      provider: {
+        encrypt: (value) => `enc:${value}`,
+        decrypt: (value) => String(value).replace(/^enc:/, ''),
+        blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
+        blindIndexes: () => ({}),
+      },
     })
 
     class User extends BaseModel {
@@ -1340,6 +1342,41 @@ test.group('Base Model | persist', (group) => {
     assert.deepEqual(adapter.operations[0].attributes, { secret: 'enc:super-secret' })
   })
 
+  test('use standard default driver when encrypted standard columns omit driver', async ({
+    fs,
+    assert,
+  }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const adapter = new FakeAdapter()
+    const BaseModel = getBaseModel(adapter)
+
+    BaseModel.useEncryption({
+      provider: {
+        encrypt: (value, options) => `enc:${options?.driver || 'default'}:${value}`,
+        decrypt: (value) => String(value).replace(/^enc:/, ''),
+        blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
+        blindIndexes: () => ({}),
+      },
+      defaults: {
+        standardDriver: 'std-default',
+      },
+    })
+
+    class User extends BaseModel {
+      @column.encrypted()
+      declare secret: string
+    }
+
+    const user = new User()
+    user.secret = 'super-secret'
+    await user.save()
+
+    assert.deepEqual(adapter.operations[0].attributes, {
+      secret: 'enc:std-default:super-secret',
+    })
+  })
+
   test('allow models booted before useEncryption to pick encryption provider dynamically', async ({
     fs,
     assert,
@@ -1349,7 +1386,7 @@ test.group('Base Model | persist', (group) => {
     const adapter = new FakeAdapter()
     const BaseModel = getBaseModel(adapter)
 
-    BaseModel.useEncryption(undefined as any)
+    BaseModel.useEncryption({ provider: undefined as any })
 
     class User extends BaseModel {
       @column.encrypted()
@@ -1357,10 +1394,12 @@ test.group('Base Model | persist', (group) => {
     }
 
     BaseModel.useEncryption({
-      encrypt: (value) => `enc:${value}`,
-      decrypt: (value) => String(value).replace(/^enc:/, ''),
-      blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
-      blindIndexes: () => ({}),
+      provider: {
+        encrypt: (value) => `enc:${value}`,
+        decrypt: (value) => String(value).replace(/^enc:/, ''),
+        blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
+        blindIndexes: () => ({}),
+      },
     })
 
     const user = new User()
@@ -1380,13 +1419,18 @@ test.group('Base Model | persist', (group) => {
     const BaseModel = getBaseModel(adapter)
 
     BaseModel.useEncryption({
-      encrypt: (value, options) =>
-        options?.deterministic
-          ? `det:${options?.driver || 'default'}:${value}`
-          : `enc:${options?.driver || 'default'}:${value}`,
-      decrypt: (value) => String(value).replace(/^(enc:|det:)/, ''),
-      blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
-      blindIndexes: () => ({}),
+      provider: {
+        encrypt: (value, options) =>
+          options?.deterministic
+            ? `det:${options?.driver || 'default'}:${value}`
+            : `enc:${options?.driver || 'default'}:${value}`,
+        decrypt: (value) => String(value).replace(/^(enc:|det:)/, ''),
+        blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
+        blindIndexes: () => ({}),
+      },
+      defaults: {
+        deterministicDriver: 'det-default',
+      },
     })
 
     class User extends BaseModel {
@@ -1403,6 +1447,44 @@ test.group('Base Model | persist', (group) => {
     })
   })
 
+  test('use deterministic default driver when encrypted deterministic columns omit driver', async ({
+    fs,
+    assert,
+  }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const adapter = new FakeAdapter()
+    const BaseModel = getBaseModel(adapter)
+
+    BaseModel.useEncryption({
+      provider: {
+        encrypt: (value, options) =>
+          options?.deterministic
+            ? `det:${options?.driver || 'default'}:${value}`
+            : `enc:${options?.driver || 'default'}:${value}`,
+        decrypt: (value) => String(value).replace(/^(enc:|det:)/, ''),
+        blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
+        blindIndexes: () => ({}),
+      },
+      defaults: {
+        deterministicDriver: 'det-default',
+      },
+    })
+
+    class User extends BaseModel {
+      @column.encrypted({ deterministic: true })
+      declare email: string
+    }
+
+    const user = new User()
+    user.email = 'virk@adonisjs.com'
+    await user.save()
+
+    assert.deepEqual(adapter.operations[0].attributes, {
+      email: 'det:det-default:virk@adonisjs.com',
+    })
+  })
+
   test('persist blind index in a dedicated column when using blind encrypted columns', async ({
     fs,
     assert,
@@ -1413,11 +1495,16 @@ test.group('Base Model | persist', (group) => {
     const BaseModel = getBaseModel(adapter)
 
     BaseModel.useEncryption({
-      encrypt: (value, options) => `enc:${options?.driver || 'default'}:${value}`,
-      decrypt: (value) => String(value).replace(/^enc:/, ''),
-      blindIndex: (value, { purpose, driver }) =>
-        `blind:${driver || 'default'}:${purpose}:${value}`,
-      blindIndexes: () => ({}),
+      provider: {
+        encrypt: (value, options) => `enc:${options?.driver || 'default'}:${value}`,
+        decrypt: (value) => String(value).replace(/^enc:/, ''),
+        blindIndex: (value, { purpose, driver }) =>
+          `blind:${driver || 'default'}:${purpose}:${value}`,
+        blindIndexes: () => ({}),
+      },
+      defaults: {
+        blindDriver: 'blind-default',
+      },
     })
 
     class User extends BaseModel {
@@ -1438,6 +1525,45 @@ test.group('Base Model | persist', (group) => {
     })
   })
 
+  test('use blind default driver when encrypted blind columns omit driver', async ({
+    fs,
+    assert,
+  }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const adapter = new FakeAdapter()
+    const BaseModel = getBaseModel(adapter)
+
+    BaseModel.useEncryption({
+      provider: {
+        encrypt: (value, options) => `enc:${options?.driver || 'default'}:${value}`,
+        decrypt: (value) => String(value).replace(/^enc:/, ''),
+        blindIndex: (value, { purpose, driver }) =>
+          `blind:${driver || 'default'}:${purpose}:${value}`,
+        blindIndexes: () => ({}),
+      },
+      defaults: {
+        blindDriver: 'blind-default',
+      },
+    })
+
+    class User extends BaseModel {
+      @column.encrypted({
+        blind: { columnName: 'email_blind', purpose: 'users:email' },
+      })
+      declare email: string
+    }
+
+    const user = new User()
+    user.email = 'virk@adonisjs.com'
+    await user.save()
+
+    assert.deepEqual(adapter.operations[0].attributes, {
+      email: 'enc:blind-default:virk@adonisjs.com',
+      email_blind: 'blind:blind-default:users:email:virk@adonisjs.com',
+    })
+  })
+
   test('prefer computed blind index over manual blind column attributes regardless of assignment order', async ({
     fs,
     assert,
@@ -1448,11 +1574,13 @@ test.group('Base Model | persist', (group) => {
     const BaseModel = getBaseModel(adapter)
 
     BaseModel.useEncryption({
-      encrypt: (value, options) => `enc:${options?.driver || 'default'}:${value}`,
-      decrypt: (value) => String(value).replace(/^enc:/, ''),
-      blindIndex: (value, { purpose, driver }) =>
-        `blind:${driver || 'default'}:${purpose}:${value}`,
-      blindIndexes: () => ({}),
+      provider: {
+        encrypt: (value, options) => `enc:${options?.driver || 'default'}:${value}`,
+        decrypt: (value) => String(value).replace(/^enc:/, ''),
+        blindIndex: (value, { purpose, driver }) =>
+          `blind:${driver || 'default'}:${purpose}:${value}`,
+        blindIndexes: () => ({}),
+      },
     })
 
     class User extends BaseModel {
@@ -1521,10 +1649,12 @@ test.group('Base Model | persist', (group) => {
     const BaseModel = getBaseModel(adapter)
 
     BaseModel.useEncryption({
-      encrypt: (value) => `enc:${value}`,
-      decrypt: (value) => String(value).replace(/^enc:/, ''),
-      blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
-      blindIndexes: () => ({}),
+      provider: {
+        encrypt: (value) => `enc:${value}`,
+        decrypt: (value) => String(value).replace(/^enc:/, ''),
+        blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
+        blindIndexes: () => ({}),
+      },
     })
 
     class User extends BaseModel {
@@ -1557,10 +1687,12 @@ test.group('Base Model | persist', (group) => {
     const BaseModel = getBaseModel(adapter)
 
     BaseModel.useEncryption({
-      encrypt: (value) => `enc:${value}`,
-      decrypt: (value) => String(value).replace(/^enc:/, ''),
-      blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
-      blindIndexes: () => ({}),
+      provider: {
+        encrypt: (value) => `enc:${value}`,
+        decrypt: (value) => String(value).replace(/^enc:/, ''),
+        blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
+        blindIndexes: () => ({}),
+      },
     })
 
     class User extends BaseModel {
@@ -1592,7 +1724,7 @@ test.group('Base Model | persist', (group) => {
     await app.init()
     const adapter = new FakeAdapter()
     const BaseModel = getBaseModel(adapter)
-    BaseModel.useEncryption(undefined as any)
+    BaseModel.useEncryption({ provider: undefined as any })
 
     class User extends BaseModel {
       @column.encrypted()
@@ -2120,10 +2252,12 @@ test.group('Base Model | create from adapter results', (group) => {
 
     const BaseModel = getBaseModel(adapter)
     BaseModel.useEncryption({
-      encrypt: (value) => `enc:${value}`,
-      decrypt: (value) => String(value).replace(/^enc:/, ''),
-      blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
-      blindIndexes: () => ({}),
+      provider: {
+        encrypt: (value) => `enc:${value}`,
+        decrypt: (value) => String(value).replace(/^enc:/, ''),
+        blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
+        blindIndexes: () => ({}),
+      },
     })
 
     class User extends BaseModel {
@@ -2152,13 +2286,15 @@ test.group('Base Model | create from adapter results', (group) => {
     let decryptOptions: any
 
     BaseModel.useEncryption({
-      encrypt: (value, options) => `enc:${options?.driver || 'default'}:${value}`,
-      decrypt: (value, options) => {
-        decryptOptions = options
-        return String(value).replace(/^enc:[^:]+:/, '')
+      provider: {
+        encrypt: (value, options) => `enc:${options?.driver || 'default'}:${value}`,
+        decrypt: (value, options) => {
+          decryptOptions = options
+          return String(value).replace(/^enc:[^:]+:/, '')
+        },
+        blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
+        blindIndexes: () => ({}),
       },
-      blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
-      blindIndexes: () => ({}),
     })
 
     class User extends BaseModel {

--- a/test/orm/base_model.spec.ts
+++ b/test/orm/base_model.spec.ts
@@ -1340,6 +1340,36 @@ test.group('Base Model | persist', (group) => {
     assert.deepEqual(adapter.operations[0].attributes, { secret: 'enc:super-secret' })
   })
 
+  test('allow models booted before useEncryption to pick encryption provider dynamically', async ({
+    fs,
+    assert,
+  }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const adapter = new FakeAdapter()
+    const BaseModel = getBaseModel(adapter)
+
+    BaseModel.useEncryption(undefined as any)
+
+    class User extends BaseModel {
+      @column.encrypted()
+      declare secret: string
+    }
+
+    BaseModel.useEncryption({
+      encrypt: (value) => `enc:${value}`,
+      decrypt: (value) => String(value).replace(/^enc:/, ''),
+      blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
+      blindIndexes: () => ({}),
+    })
+
+    const user = new User()
+    user.secret = 'super-secret'
+    await user.save()
+
+    assert.deepEqual(adapter.operations[0].attributes, { secret: 'enc:super-secret' })
+  })
+
   test('encrypt deterministic value before passing encrypted columns to the adapter', async ({
     fs,
     assert,

--- a/test/orm/base_model.spec.ts
+++ b/test/orm/base_model.spec.ts
@@ -1481,6 +1481,79 @@ test.group('Base Model | persist', (group) => {
     )
   })
 
+  test('raise exception when blind encrypted meta is missing blind.columnName at persistence time', async ({
+    fs,
+    assert,
+  }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const adapter = new FakeAdapter()
+    const BaseModel = getBaseModel(adapter)
+
+    BaseModel.useEncryption({
+      encrypt: (value) => `enc:${value}`,
+      decrypt: (value) => String(value).replace(/^enc:/, ''),
+      blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
+      blindIndexes: () => ({}),
+    })
+
+    class User extends BaseModel {
+      @column({
+        meta: {
+          encryption: {
+            mode: 'blind',
+          },
+        },
+      } as any)
+      declare email: string
+    }
+
+    const user = new User()
+    user.email = 'virk@adonisjs.com'
+
+    await assert.rejects(
+      () => user.save(),
+      'Invalid encrypted column configuration for "User.email". Missing "blind.columnName"'
+    )
+  })
+
+  test('raise exception when blind encrypted meta is missing blind.purpose at persistence time', async ({
+    fs,
+    assert,
+  }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const adapter = new FakeAdapter()
+    const BaseModel = getBaseModel(adapter)
+
+    BaseModel.useEncryption({
+      encrypt: (value) => `enc:${value}`,
+      decrypt: (value) => String(value).replace(/^enc:/, ''),
+      blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
+      blindIndexes: () => ({}),
+    })
+
+    class User extends BaseModel {
+      @column({
+        meta: {
+          encryption: {
+            mode: 'blind',
+            blindColumnName: 'email_blind',
+          },
+        },
+      } as any)
+      declare email: string
+    }
+
+    const user = new User()
+    user.email = 'virk@adonisjs.com'
+
+    await assert.rejects(
+      () => user.save(),
+      'Invalid encrypted column configuration for "User.email". Missing "blind.purpose"'
+    )
+  })
+
   test('raise exception when encryption provider is missing for encrypted columns', async ({
     fs,
     assert,

--- a/test/orm/model_query_builder.spec.ts
+++ b/test/orm/model_query_builder.spec.ts
@@ -230,6 +230,59 @@ test.group('Model query builder', (group) => {
     assert.deepEqual(bindings, knexBindings)
   })
 
+  test('rewrite encrypted where clauses using IN and NOT IN operators', async ({ fs, assert }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    BaseModel.useEncryption({
+      encrypt: (value, options) =>
+        options?.deterministic
+          ? `det:${options?.driver || 'default'}:${value}`
+          : `enc:${options?.driver || 'default'}:${value}`,
+      decrypt: (value) => String(value).replace(/^(enc:|det:)/, ''),
+      blindIndex: (value, { purpose, driver }) =>
+        `blind:${driver || 'default'}:${purpose}:${value}`,
+      blindIndexes: () => ({}),
+    })
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column.encrypted({ deterministic: true, driver: 'det-v1' })
+      declare email: string
+
+      @column.encrypted({
+        driver: 'enc-v1',
+        blind: { columnName: 'username_blind', purpose: 'users:username' },
+      })
+      declare username: string
+    }
+
+    const { sql, bindings } = User.query()
+      .where('email', 'IN', ['virk@adonisjs.com', 'nikk@adonisjs.com'])
+      .where('email', 'not in', ['tom@adonisjs.com'])
+      .where('username', 'iN', ['virk'])
+      .where('username', 'NoT   In', ['nikk'])
+      .toSQL()
+
+    const { sql: knexSql, bindings: knexBindings } = db
+      .connection()
+      .getWriteClient()
+      .from('users')
+      .whereIn('email', ['det:det-v1:virk@adonisjs.com', 'det:det-v1:nikk@adonisjs.com'])
+      .whereNotIn('email', ['det:det-v1:tom@adonisjs.com'])
+      .whereIn('username_blind', ['blind:enc-v1:users:username:virk'])
+      .whereNotIn('username_blind', ['blind:enc-v1:users:username:nikk'])
+      .toSQL()
+
+    assert.equal(sql, knexSql)
+    assert.deepEqual(bindings, knexBindings)
+  })
+
   test('rewrite blind encrypted where to whereIn when blindIndexes returns multiple values', async ({
     fs,
     assert,

--- a/test/orm/model_query_builder.spec.ts
+++ b/test/orm/model_query_builder.spec.ts
@@ -45,8 +45,6 @@ test.group('Model query builder', (group) => {
     const BaseModel = getBaseModel(adapter)
 
     class User extends BaseModel {
-      static table = 'users_encrypted'
-
       @column({ isPrimary: true })
       declare id: number
 

--- a/test/orm/model_query_builder.spec.ts
+++ b/test/orm/model_query_builder.spec.ts
@@ -107,13 +107,18 @@ test.group('Model query builder', (group) => {
     const BaseModel = getBaseModel(adapter)
 
     BaseModel.useEncryption({
-      encrypt: (value, options) =>
-        options?.deterministic
-          ? `det:${options?.driver || 'default'}:${value}`
-          : `enc:${options?.driver || 'default'}:${value}`,
-      decrypt: (value) => String(value).replace(/^(enc:|det:)/, ''),
-      blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
-      blindIndexes: () => ({}),
+      provider: {
+        encrypt: (value, options) =>
+          options?.deterministic
+            ? `det:${options?.driver || 'default'}:${value}`
+            : `enc:${options?.driver || 'default'}:${value}`,
+        decrypt: (value) => String(value).replace(/^(enc:|det:)/, ''),
+        blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
+        blindIndexes: () => ({}),
+      },
+      defaults: {
+        deterministicDriver: 'det-default',
+      },
     })
 
     class User extends BaseModel {
@@ -137,6 +142,52 @@ test.group('Model query builder', (group) => {
     assert.deepEqual(bindings, knexBindings)
   })
 
+  test('use deterministic default driver when rewriting deterministic where clauses', async ({
+    fs,
+    assert,
+  }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    BaseModel.useEncryption({
+      provider: {
+        encrypt: (value, options) =>
+          options?.deterministic
+            ? `det:${options?.driver || 'default'}:${value}`
+            : `enc:${options?.driver || 'default'}:${value}`,
+        decrypt: (value) => String(value).replace(/^(enc:|det:)/, ''),
+        blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
+        blindIndexes: () => ({}),
+      },
+      defaults: {
+        deterministicDriver: 'det-default',
+      },
+    })
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column.encrypted({ deterministic: true })
+      declare email: string
+    }
+
+    const { sql, bindings } = User.query().where('email', 'virk@adonisjs.com').toSQL()
+
+    const { sql: knexSql, bindings: knexBindings } = db
+      .connection()
+      .getWriteClient()
+      .from('users')
+      .where('email', 'det:det-default:virk@adonisjs.com')
+      .toSQL()
+
+    assert.equal(sql, knexSql)
+    assert.deepEqual(bindings, knexBindings)
+  })
+
   test('rewrite encrypted andWhere/orWhere clauses for deterministic and blind columns', async ({
     fs,
     assert,
@@ -148,17 +199,19 @@ test.group('Model query builder', (group) => {
     const BaseModel = getBaseModel(adapter)
 
     BaseModel.useEncryption({
-      encrypt: (value, options) =>
-        options?.deterministic
-          ? `det:${options?.driver || 'default'}:${value}`
-          : `enc:${options?.driver || 'default'}:${value}`,
-      decrypt: (value) => String(value).replace(/^(enc:|det:)/, ''),
-      blindIndex: (value, { purpose, driver }) =>
-        `blind:${driver || 'default'}:${purpose}:${value}:single`,
-      blindIndexes: (value, options) => [
-        `blind:${options?.driver || 'default'}:${options?.purpose}:${value}:new`,
-        `blind:${options?.driver || 'default'}:${options?.purpose}:${value}:old`,
-      ],
+      provider: {
+        encrypt: (value, options) =>
+          options?.deterministic
+            ? `det:${options?.driver || 'default'}:${value}`
+            : `enc:${options?.driver || 'default'}:${value}`,
+        decrypt: (value) => String(value).replace(/^(enc:|det:)/, ''),
+        blindIndex: (value, { purpose, driver }) =>
+          `blind:${driver || 'default'}:${purpose}:${value}:single`,
+        blindIndexes: (value, options) => [
+          `blind:${options?.driver || 'default'}:${options?.purpose}:${value}:new`,
+          `blind:${options?.driver || 'default'}:${options?.purpose}:${value}:old`,
+        ],
+      },
     })
 
     class User extends BaseModel {
@@ -215,13 +268,15 @@ test.group('Model query builder', (group) => {
     const BaseModel = getBaseModel(adapter)
 
     BaseModel.useEncryption({
-      encrypt: (value, options) =>
-        options?.deterministic
-          ? `det:${options?.driver || 'default'}:${value}`
-          : `enc:${options?.driver || 'default'}:${value}`,
-      decrypt: (value) => String(value).replace(/^(enc:|det:)/, ''),
-      blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
-      blindIndexes: () => ({}),
+      provider: {
+        encrypt: (value, options) =>
+          options?.deterministic
+            ? `det:${options?.driver || 'default'}:${value}`
+            : `enc:${options?.driver || 'default'}:${value}`,
+        decrypt: (value) => String(value).replace(/^(enc:|det:)/, ''),
+        blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
+        blindIndexes: () => ({}),
+      },
     })
 
     class User extends BaseModel {
@@ -262,13 +317,15 @@ test.group('Model query builder', (group) => {
     const BaseModel = getBaseModel(adapter)
 
     BaseModel.useEncryption({
-      encrypt: (value, options) =>
-        options?.deterministic
-          ? `det:${options?.driver || 'default'}:${value}`
-          : `enc:${options?.driver || 'default'}:${value}`,
-      decrypt: (value) => String(value).replace(/^(enc:|det:)/, ''),
-      blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
-      blindIndexes: () => ({}),
+      provider: {
+        encrypt: (value, options) =>
+          options?.deterministic
+            ? `det:${options?.driver || 'default'}:${value}`
+            : `enc:${options?.driver || 'default'}:${value}`,
+        decrypt: (value) => String(value).replace(/^(enc:|det:)/, ''),
+        blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
+        blindIndexes: () => ({}),
+      },
     })
 
     class User extends BaseModel {
@@ -307,11 +364,16 @@ test.group('Model query builder', (group) => {
     const BaseModel = getBaseModel(adapter)
 
     BaseModel.useEncryption({
-      encrypt: (value, options) => `enc:${options?.driver || 'default'}:${value}`,
-      decrypt: (value) => String(value).replace(/^enc:/, ''),
-      blindIndex: (value, { purpose, driver }) =>
-        `blind:${driver || 'default'}:${purpose}:${value}`,
-      blindIndexes: () => ({}),
+      provider: {
+        encrypt: (value, options) => `enc:${options?.driver || 'default'}:${value}`,
+        decrypt: (value) => String(value).replace(/^enc:/, ''),
+        blindIndex: (value, { purpose, driver }) =>
+          `blind:${driver || 'default'}:${purpose}:${value}`,
+        blindIndexes: () => ({}),
+      },
+      defaults: {
+        blindDriver: 'blind-default',
+      },
     })
 
     class User extends BaseModel {
@@ -345,6 +407,56 @@ test.group('Model query builder', (group) => {
     assert.deepEqual(bindings, knexBindings)
   })
 
+  test('use blind default driver when rewriting blind where clauses', async ({ fs, assert }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    BaseModel.useEncryption({
+      provider: {
+        encrypt: (value, options) => `enc:${options?.driver || 'default'}:${value}`,
+        decrypt: (value) => String(value).replace(/^enc:/, ''),
+        blindIndex: (value, { purpose, driver }) =>
+          `blind:${driver || 'default'}:${purpose}:${value}`,
+        blindIndexes: () => ({}),
+      },
+      defaults: {
+        blindDriver: 'blind-default',
+      },
+    })
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column.encrypted({
+        blind: { columnName: 'email_blind', purpose: 'users:email' },
+      })
+      declare email: string
+    }
+
+    const { sql, bindings } = User.query()
+      .where({ email: 'virk@adonisjs.com' })
+      .whereIn('email', ['virk@adonisjs.com', 'nikk@adonisjs.com'])
+      .toSQL()
+
+    const { sql: knexSql, bindings: knexBindings } = db
+      .connection()
+      .getWriteClient()
+      .from('users')
+      .where('email_blind', 'blind:blind-default:users:email:virk@adonisjs.com')
+      .whereIn('email_blind', [
+        'blind:blind-default:users:email:virk@adonisjs.com',
+        'blind:blind-default:users:email:nikk@adonisjs.com',
+      ])
+      .toSQL()
+
+    assert.equal(sql, knexSql)
+    assert.deepEqual(bindings, knexBindings)
+  })
+
   test('trim blind encrypted metadata values before rewriting where clauses', async ({
     fs,
     assert,
@@ -356,11 +468,13 @@ test.group('Model query builder', (group) => {
     const BaseModel = getBaseModel(adapter)
 
     BaseModel.useEncryption({
-      encrypt: (value, options) => `enc:${options?.driver || 'default'}:${value}`,
-      decrypt: (value) => String(value).replace(/^enc:/, ''),
-      blindIndex: (value, { purpose, driver }) =>
-        `blind:${driver || 'default'}:${purpose}:${value}`,
-      blindIndexes: () => ({}),
+      provider: {
+        encrypt: (value, options) => `enc:${options?.driver || 'default'}:${value}`,
+        decrypt: (value) => String(value).replace(/^enc:/, ''),
+        blindIndex: (value, { purpose, driver }) =>
+          `blind:${driver || 'default'}:${purpose}:${value}`,
+        blindIndexes: () => ({}),
+      },
     })
 
     class User extends BaseModel {
@@ -395,14 +509,16 @@ test.group('Model query builder', (group) => {
     const BaseModel = getBaseModel(adapter)
 
     BaseModel.useEncryption({
-      encrypt: (value, options) =>
-        options?.deterministic
-          ? `det:${options?.driver || 'default'}:${value}`
-          : `enc:${options?.driver || 'default'}:${value}`,
-      decrypt: (value) => String(value).replace(/^(enc:|det:)/, ''),
-      blindIndex: (value, { purpose, driver }) =>
-        `blind:${driver || 'default'}:${purpose}:${value}`,
-      blindIndexes: () => ({}),
+      provider: {
+        encrypt: (value, options) =>
+          options?.deterministic
+            ? `det:${options?.driver || 'default'}:${value}`
+            : `enc:${options?.driver || 'default'}:${value}`,
+        decrypt: (value) => String(value).replace(/^(enc:|det:)/, ''),
+        blindIndex: (value, { purpose, driver }) =>
+          `blind:${driver || 'default'}:${purpose}:${value}`,
+        blindIndexes: () => ({}),
+      },
     })
 
     class User extends BaseModel {
@@ -450,14 +566,16 @@ test.group('Model query builder', (group) => {
     const BaseModel = getBaseModel(adapter)
 
     BaseModel.useEncryption({
-      encrypt: (value, options) =>
-        options?.deterministic
-          ? `det:${options?.driver || 'default'}:${value}`
-          : `enc:${options?.driver || 'default'}:${value}`,
-      decrypt: (value) => String(value).replace(/^(enc:|det:)/, ''),
-      blindIndex: (value, { purpose, driver }) =>
-        `blind:${driver || 'default'}:${purpose}:${value}`,
-      blindIndexes: () => ({}),
+      provider: {
+        encrypt: (value, options) =>
+          options?.deterministic
+            ? `det:${options?.driver || 'default'}:${value}`
+            : `enc:${options?.driver || 'default'}:${value}`,
+        decrypt: (value) => String(value).replace(/^(enc:|det:)/, ''),
+        blindIndex: (value, { purpose, driver }) =>
+          `blind:${driver || 'default'}:${purpose}:${value}`,
+        blindIndexes: () => ({}),
+      },
     })
 
     class User extends BaseModel {
@@ -506,14 +624,16 @@ test.group('Model query builder', (group) => {
     const BaseModel = getBaseModel(adapter)
 
     BaseModel.useEncryption({
-      encrypt: (value, options) =>
-        options?.deterministic
-          ? `det:${options?.driver || 'default'}:${value}`
-          : `enc:${options?.driver || 'default'}:${value}`,
-      decrypt: (value) => String(value).replace(/^(enc:|det:)/, ''),
-      blindIndex: (value, { purpose, driver }) =>
-        `blind:${driver || 'default'}:${purpose}:${value}`,
-      blindIndexes: () => ({}),
+      provider: {
+        encrypt: (value, options) =>
+          options?.deterministic
+            ? `det:${options?.driver || 'default'}:${value}`
+            : `enc:${options?.driver || 'default'}:${value}`,
+        decrypt: (value) => String(value).replace(/^(enc:|det:)/, ''),
+        blindIndex: (value, { purpose, driver }) =>
+          `blind:${driver || 'default'}:${purpose}:${value}`,
+        blindIndexes: () => ({}),
+      },
     })
 
     class User extends BaseModel {
@@ -564,14 +684,16 @@ test.group('Model query builder', (group) => {
     const BaseModel = getBaseModel(adapter)
 
     BaseModel.useEncryption({
-      encrypt: (value, options) => `enc:${options?.driver || 'default'}:${value}`,
-      decrypt: (value) => String(value).replace(/^enc:/, ''),
-      blindIndex: (value, { purpose, driver }) =>
-        `blind:${driver || 'default'}:${purpose}:${value}:single`,
-      blindIndexes: (value, options) => [
-        `blind:${options?.driver || 'default'}:${options?.purpose}:${value}:new`,
-        `blind:${options?.driver || 'default'}:${options?.purpose}:${value}:old`,
-      ],
+      provider: {
+        encrypt: (value, options) => `enc:${options?.driver || 'default'}:${value}`,
+        decrypt: (value) => String(value).replace(/^enc:/, ''),
+        blindIndex: (value, { purpose, driver }) =>
+          `blind:${driver || 'default'}:${purpose}:${value}:single`,
+        blindIndexes: (value, options) => [
+          `blind:${options?.driver || 'default'}:${options?.purpose}:${value}:new`,
+          `blind:${options?.driver || 'default'}:${options?.purpose}:${value}:old`,
+        ],
+      },
     })
 
     class User extends BaseModel {
@@ -612,14 +734,16 @@ test.group('Model query builder', (group) => {
     const BaseModel = getBaseModel(adapter)
 
     BaseModel.useEncryption({
-      encrypt: (value, options) => `enc:${options?.driver || 'default'}:${value}`,
-      decrypt: (value) => String(value).replace(/^enc:/, ''),
-      blindIndex: (value, { purpose, driver }) =>
-        `blind:${driver || 'default'}:${purpose}:${value}:single`,
-      blindIndexes: (value, options) => [
-        `blind:${options?.driver || 'default'}:${options?.purpose}:${value}:new`,
-        `blind:${options?.driver || 'default'}:${options?.purpose}:${value}:old`,
-      ],
+      provider: {
+        encrypt: (value, options) => `enc:${options?.driver || 'default'}:${value}`,
+        decrypt: (value) => String(value).replace(/^enc:/, ''),
+        blindIndex: (value, { purpose, driver }) =>
+          `blind:${driver || 'default'}:${purpose}:${value}:single`,
+        blindIndexes: (value, options) => [
+          `blind:${options?.driver || 'default'}:${options?.purpose}:${value}:new`,
+          `blind:${options?.driver || 'default'}:${options?.purpose}:${value}:old`,
+        ],
+      },
     })
 
     class User extends BaseModel {
@@ -678,10 +802,12 @@ test.group('Model query builder', (group) => {
     const BaseModel = getBaseModel(adapter)
 
     BaseModel.useEncryption({
-      encrypt: (value, options) => (options?.deterministic ? `det:${value}` : `enc:${value}`),
-      decrypt: (value) => String(value).replace(/^(enc:|det:)/, ''),
-      blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
-      blindIndexes: () => ({}),
+      provider: {
+        encrypt: (value, options) => (options?.deterministic ? `det:${value}` : `enc:${value}`),
+        decrypt: (value) => String(value).replace(/^(enc:|det:)/, ''),
+        blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
+        blindIndexes: () => ({}),
+      },
     })
 
     class User extends BaseModel {
@@ -795,11 +921,13 @@ test.group('Model query builder', (group) => {
     const BaseModel = getBaseModel(adapter)
 
     BaseModel.useEncryption({
-      encrypt: (value, options) => `enc:${options?.driver || 'default'}:${value}`,
-      decrypt: (value) => String(value).replace(/^enc:/, ''),
-      blindIndex: (value, { purpose, driver }) =>
-        `blind:${driver || 'default'}:${purpose}:${value}`,
-      blindIndexes: () => ({}),
+      provider: {
+        encrypt: (value, options) => `enc:${options?.driver || 'default'}:${value}`,
+        decrypt: (value) => String(value).replace(/^enc:/, ''),
+        blindIndex: (value, { purpose, driver }) =>
+          `blind:${driver || 'default'}:${purpose}:${value}`,
+        blindIndexes: () => ({}),
+      },
     })
 
     class User extends BaseModel {
@@ -832,11 +960,13 @@ test.group('Model query builder', (group) => {
     const BaseModel = getBaseModel(adapter)
 
     BaseModel.useEncryption({
-      encrypt: (value, options) => `enc:${options?.driver || 'default'}:${value}`,
-      decrypt: (value) => String(value).replace(/^enc:/, ''),
-      blindIndex: (value, { purpose, driver }) =>
-        `blind:${driver || 'default'}:${purpose}:${value}`,
-      blindIndexes: () => ({}),
+      provider: {
+        encrypt: (value, options) => `enc:${options?.driver || 'default'}:${value}`,
+        decrypt: (value) => String(value).replace(/^enc:/, ''),
+        blindIndex: (value, { purpose, driver }) =>
+          `blind:${driver || 'default'}:${purpose}:${value}`,
+        blindIndexes: () => ({}),
+      },
     })
 
     class User extends BaseModel {
@@ -872,11 +1002,13 @@ test.group('Model query builder', (group) => {
     const BaseModel = getBaseModel(adapter)
 
     BaseModel.useEncryption({
-      encrypt: (value, options) => `enc:${options?.driver || 'default'}:${value}`,
-      decrypt: (value) => String(value).replace(/^enc:/, ''),
-      blindIndex: (value, { purpose, driver }) =>
-        `blind:${driver || 'default'}:${purpose}:${value}`,
-      blindIndexes: () => ({}),
+      provider: {
+        encrypt: (value, options) => `enc:${options?.driver || 'default'}:${value}`,
+        decrypt: (value) => String(value).replace(/^enc:/, ''),
+        blindIndex: (value, { purpose, driver }) =>
+          `blind:${driver || 'default'}:${purpose}:${value}`,
+        blindIndexes: () => ({}),
+      },
     })
 
     class User extends BaseModel {
@@ -921,11 +1053,13 @@ test.group('Model query builder', (group) => {
     const BaseModel = getBaseModel(adapter)
 
     BaseModel.useEncryption({
-      encrypt: (value, options) => `enc:${options?.driver || 'default'}:${value}`,
-      decrypt: (value) => String(value).replace(/^enc:/, ''),
-      blindIndex: (value, { purpose, driver }) =>
-        `blind:${driver || 'default'}:${purpose}:${value}`,
-      blindIndexes: () => ({}),
+      provider: {
+        encrypt: (value, options) => `enc:${options?.driver || 'default'}:${value}`,
+        decrypt: (value) => String(value).replace(/^enc:/, ''),
+        blindIndex: (value, { purpose, driver }) =>
+          `blind:${driver || 'default'}:${purpose}:${value}`,
+        blindIndexes: () => ({}),
+      },
     })
 
     class User extends BaseModel {
@@ -1116,14 +1250,16 @@ test.group('Model query builder', (group) => {
     const BaseModel = getBaseModel(adapter)
 
     BaseModel.useEncryption({
-      encrypt: (value, options) =>
-        options?.deterministic
-          ? `det:${options?.driver || 'default'}:${value}`
-          : `enc:${options?.driver || 'default'}:${value}`,
-      decrypt: (value) => String(value).replace(/^(enc:|det:)/, ''),
-      blindIndex: (value, { purpose, driver }) =>
-        `blind:${driver || 'default'}:${purpose}:${value}`,
-      blindIndexes: () => ({}),
+      provider: {
+        encrypt: (value, options) =>
+          options?.deterministic
+            ? `det:${options?.driver || 'default'}:${value}`
+            : `enc:${options?.driver || 'default'}:${value}`,
+        decrypt: (value) => String(value).replace(/^(enc:|det:)/, ''),
+        blindIndex: (value, { purpose, driver }) =>
+          `blind:${driver || 'default'}:${purpose}:${value}`,
+        blindIndexes: () => ({}),
+      },
     })
 
     class User extends BaseModel {

--- a/test/orm/model_query_builder.spec.ts
+++ b/test/orm/model_query_builder.spec.ts
@@ -99,6 +99,114 @@ test.group('Model query builder', (group) => {
     assert.deepEqual(users[0].$attributes, { id: 1, username: 'virk' })
   })
 
+  test('rewrite deterministic encrypted where clauses', async ({ fs, assert }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    BaseModel.useEncryption({
+      encrypt: (value, options) => (options?.deterministic ? `det:${value}` : `enc:${value}`),
+      decrypt: (value) => String(value).replace(/^(enc:|det:)/, ''),
+      blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
+      blindIndexes: () => ({}),
+    })
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column.encrypted({ deterministic: true })
+      declare email: string
+    }
+
+    const { sql, bindings } = User.query().where('email', 'virk@adonisjs.com').toSQL()
+
+    const { sql: knexSql, bindings: knexBindings } = db
+      .connection()
+      .getWriteClient()
+      .from('users')
+      .where('email', 'det:virk@adonisjs.com')
+      .toSQL()
+
+    assert.equal(sql, knexSql)
+    assert.deepEqual(bindings, knexBindings)
+  })
+
+  test('rewrite blind encrypted where and whereIn clauses', async ({ fs, assert }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    BaseModel.useEncryption({
+      encrypt: (value) => `enc:${value}`,
+      decrypt: (value) => String(value).replace(/^enc:/, ''),
+      blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
+      blindIndexes: () => ({}),
+    })
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column.encrypted({ blind: { columnName: 'email_blind', purpose: 'users:email' } })
+      declare email: string
+    }
+
+    const { sql, bindings } = User.query()
+      .where({ email: 'virk@adonisjs.com' })
+      .whereIn('email', ['virk@adonisjs.com', 'nikk@adonisjs.com'])
+      .toSQL()
+
+    const { sql: knexSql, bindings: knexBindings } = db
+      .connection()
+      .getWriteClient()
+      .from('users')
+      .where('email_blind', 'blind:users:email:virk@adonisjs.com')
+      .whereIn('email_blind', [
+        'blind:users:email:virk@adonisjs.com',
+        'blind:users:email:nikk@adonisjs.com',
+      ])
+      .toSQL()
+
+    assert.equal(sql, knexSql)
+    assert.deepEqual(bindings, knexBindings)
+  })
+
+  test('raise when using non equality operators on deterministic encrypted columns', async ({
+    fs,
+    assert,
+  }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    BaseModel.useEncryption({
+      encrypt: (value, options) => (options?.deterministic ? `det:${value}` : `enc:${value}`),
+      decrypt: (value) => String(value).replace(/^(enc:|det:)/, ''),
+      blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
+      blindIndexes: () => ({}),
+    })
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column.encrypted({ deterministic: true })
+      declare email: string
+    }
+
+    assert.throws(
+      () => User.query().whereLike('email', '%virk%'),
+      'Cannot use "whereLike" on encrypted column "User.email". Only equality-based queries are supported'
+    )
+  })
+
   test('pass custom connection to the model instance', async ({ fs, assert }) => {
     const app = new AppFactory().create(fs.baseUrl, () => {})
     await app.init()

--- a/test/orm/model_query_builder.spec.ts
+++ b/test/orm/model_query_builder.spec.ts
@@ -137,6 +137,53 @@ test.group('Model query builder', (group) => {
     assert.deepEqual(bindings, knexBindings)
   })
 
+  test('do not rewrite joined table columns that match encrypted model column names', async ({
+    fs,
+    assert,
+  }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    BaseModel.useEncryption({
+      encrypt: (value, options) =>
+        options?.deterministic
+          ? `det:${options?.driver || 'default'}:${value}`
+          : `enc:${options?.driver || 'default'}:${value}`,
+      decrypt: (value) => String(value).replace(/^(enc:|det:)/, ''),
+      blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
+      blindIndexes: () => ({}),
+    })
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column.encrypted({ deterministic: true, driver: 'det-v1' })
+      declare email: string
+    }
+
+    const { sql, bindings } = User.query()
+      .join('contacts', 'contacts.user_id', 'users.id')
+      .where('contacts.email', 'virk@adonisjs.com')
+      .where('users.email', 'virk@adonisjs.com')
+      .toSQL()
+
+    const { sql: knexSql, bindings: knexBindings } = db
+      .connection()
+      .getWriteClient()
+      .from('users')
+      .join('contacts', 'contacts.user_id', 'users.id')
+      .where('contacts.email', 'virk@adonisjs.com')
+      .where('users.email', 'det:det-v1:virk@adonisjs.com')
+      .toSQL()
+
+    assert.equal(sql, knexSql)
+    assert.deepEqual(bindings, knexBindings)
+  })
+
   test('rewrite blind encrypted where and whereIn clauses', async ({ fs, assert }) => {
     const app = new AppFactory().create(fs.baseUrl, () => {})
     await app.init()

--- a/test/orm/model_query_builder.spec.ts
+++ b/test/orm/model_query_builder.spec.ts
@@ -670,10 +670,7 @@ test.group('Model query builder', (group) => {
     assert.deepEqual(bindings, knexBindings)
   })
 
-  test('raise when using unsupported operators on deterministic and blind encrypted columns', async ({
-    fs,
-    assert,
-  }) => {
+  test('raise when using unsupported operators on encrypted columns', async ({ fs, assert }) => {
     const app = new AppFactory().create(fs.baseUrl, () => {})
     await app.init()
     const db = getDb()
@@ -713,6 +710,15 @@ test.group('Model query builder', (group) => {
     assert.throws(
       () => User.query().whereIn('token', ['a', 'b']),
       'Cannot use "whereIn" on standard encrypted column "User.token". Equality queries require deterministic or blind encryption'
+    )
+
+    assert.throws(
+      () => User.query().whereLike('token', '%secret%'),
+      'Cannot use "whereLike" on encrypted column "User.token". Encrypted columns can only be used with equality-based WHERE clauses'
+    )
+    assert.throws(
+      () => User.query().whereColumn('token', 'id'),
+      'Cannot use "whereColumn" on encrypted column "User.token". Encrypted columns can only be used with equality-based WHERE clauses'
     )
 
     assert.throws(

--- a/test/orm/model_query_builder.spec.ts
+++ b/test/orm/model_query_builder.spec.ts
@@ -137,6 +137,73 @@ test.group('Model query builder', (group) => {
     assert.deepEqual(bindings, knexBindings)
   })
 
+  test('rewrite encrypted andWhere/orWhere clauses for deterministic and blind columns', async ({
+    fs,
+    assert,
+  }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    BaseModel.useEncryption({
+      encrypt: (value, options) =>
+        options?.deterministic
+          ? `det:${options?.driver || 'default'}:${value}`
+          : `enc:${options?.driver || 'default'}:${value}`,
+      decrypt: (value) => String(value).replace(/^(enc:|det:)/, ''),
+      blindIndex: (value, { purpose, driver }) =>
+        `blind:${driver || 'default'}:${purpose}:${value}:single`,
+      blindIndexes: (value, options) => [
+        `blind:${options?.driver || 'default'}:${options?.purpose}:${value}:new`,
+        `blind:${options?.driver || 'default'}:${options?.purpose}:${value}:old`,
+      ],
+    })
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column.encrypted({ deterministic: true, driver: 'det-v1' })
+      declare email: string
+
+      @column.encrypted({
+        driver: 'enc-v1',
+        blind: { columnName: 'username_blind', purpose: 'users:username' },
+      })
+      declare username: string
+    }
+
+    const { sql, bindings } = User.query()
+      .where('id', 1)
+      .andWhere('email', 'virk@adonisjs.com')
+      .andWhere('username', 'virk')
+      .orWhere('email', 'nikk@adonisjs.com')
+      .orWhere('username', 'nikk')
+      .toSQL()
+
+    const { sql: knexSql, bindings: knexBindings } = db
+      .connection()
+      .getWriteClient()
+      .from('users')
+      .where('id', 1)
+      .andWhere('email', 'det:det-v1:virk@adonisjs.com')
+      .whereIn('username_blind', [
+        'blind:enc-v1:users:username:virk:new',
+        'blind:enc-v1:users:username:virk:old',
+      ])
+      .orWhere('email', 'det:det-v1:nikk@adonisjs.com')
+      .orWhereIn('username_blind', [
+        'blind:enc-v1:users:username:nikk:new',
+        'blind:enc-v1:users:username:nikk:old',
+      ])
+      .toSQL()
+
+    assert.equal(sql, knexSql)
+    assert.deepEqual(bindings, knexBindings)
+  })
+
   test('do not rewrite joined table columns that match encrypted model column names', async ({
     fs,
     assert,
@@ -230,6 +297,61 @@ test.group('Model query builder', (group) => {
     assert.deepEqual(bindings, knexBindings)
   })
 
+  test('rewrite all encrypted keys when using object where clauses', async ({ fs, assert }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    BaseModel.useEncryption({
+      encrypt: (value, options) =>
+        options?.deterministic
+          ? `det:${options?.driver || 'default'}:${value}`
+          : `enc:${options?.driver || 'default'}:${value}`,
+      decrypt: (value) => String(value).replace(/^(enc:|det:)/, ''),
+      blindIndex: (value, { purpose, driver }) =>
+        `blind:${driver || 'default'}:${purpose}:${value}`,
+      blindIndexes: () => ({}),
+    })
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column.encrypted({ deterministic: true, driver: 'det-v1' })
+      declare email: string
+
+      @column.encrypted({
+        driver: 'enc-v1',
+        blind: { columnName: 'username_blind', purpose: 'users:username' },
+      })
+      declare username: string
+    }
+
+    const { sql, bindings } = User.query()
+      .where({
+        id: 1,
+        email: 'virk@adonisjs.com',
+        username: 'virk',
+      })
+      .toSQL()
+
+    const { sql: knexSql, bindings: knexBindings } = db
+      .connection()
+      .getWriteClient()
+      .from('users')
+      .where({
+        id: 1,
+        email: 'det:det-v1:virk@adonisjs.com',
+        username_blind: 'blind:enc-v1:users:username:virk',
+      })
+      .toSQL()
+
+    assert.equal(sql, knexSql)
+    assert.deepEqual(bindings, knexBindings)
+  })
+
   test('rewrite encrypted where clauses using IN and NOT IN operators', async ({ fs, assert }) => {
     const app = new AppFactory().create(fs.baseUrl, () => {})
     await app.init()
@@ -277,6 +399,64 @@ test.group('Model query builder', (group) => {
       .whereNotIn('email', ['det:det-v1:tom@adonisjs.com'])
       .whereIn('username_blind', ['blind:enc-v1:users:username:virk'])
       .whereNotIn('username_blind', ['blind:enc-v1:users:username:nikk'])
+      .toSQL()
+
+    assert.equal(sql, knexSql)
+    assert.deepEqual(bindings, knexBindings)
+  })
+
+  test('rewrite encrypted andWhere/orWhere clauses using IN and NOT IN operators', async ({
+    fs,
+    assert,
+  }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    BaseModel.useEncryption({
+      encrypt: (value, options) =>
+        options?.deterministic
+          ? `det:${options?.driver || 'default'}:${value}`
+          : `enc:${options?.driver || 'default'}:${value}`,
+      decrypt: (value) => String(value).replace(/^(enc:|det:)/, ''),
+      blindIndex: (value, { purpose, driver }) =>
+        `blind:${driver || 'default'}:${purpose}:${value}`,
+      blindIndexes: () => ({}),
+    })
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column.encrypted({ deterministic: true, driver: 'det-v1' })
+      declare email: string
+
+      @column.encrypted({
+        driver: 'enc-v1',
+        blind: { columnName: 'username_blind', purpose: 'users:username' },
+      })
+      declare username: string
+    }
+
+    const { sql, bindings } = User.query()
+      .where('id', 1)
+      .andWhere('email', 'IN', ['virk@adonisjs.com', 'nikk@adonisjs.com'])
+      .orWhere('email', 'Not In', ['tom@adonisjs.com'])
+      .andWhere('username', 'in', ['virk'])
+      .orWhere('username', 'NOT IN', ['nikk'])
+      .toSQL()
+
+    const { sql: knexSql, bindings: knexBindings } = db
+      .connection()
+      .getWriteClient()
+      .from('users')
+      .where('id', 1)
+      .whereIn('email', ['det:det-v1:virk@adonisjs.com', 'det:det-v1:nikk@adonisjs.com'])
+      .orWhereNotIn('email', ['det:det-v1:tom@adonisjs.com'])
+      .whereIn('username_blind', ['blind:enc-v1:users:username:virk'])
+      .orWhereNotIn('username_blind', ['blind:enc-v1:users:username:nikk'])
       .toSQL()
 
     assert.equal(sql, knexSql)

--- a/test/orm/model_query_builder.spec.ts
+++ b/test/orm/model_query_builder.spec.ts
@@ -45,6 +45,8 @@ test.group('Model query builder', (group) => {
     const BaseModel = getBaseModel(adapter)
 
     class User extends BaseModel {
+      static table = 'users_encrypted'
+
       @column({ isPrimary: true })
       declare id: number
 
@@ -390,6 +392,63 @@ test.group('Model query builder', (group) => {
 
     assert.equal(sql, knexSql)
     assert.deepEqual(bindings, knexBindings)
+  })
+
+  test('prefer computed blind index over manual blind column updates regardless of key order', async ({
+    fs,
+    assert,
+  }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    BaseModel.useEncryption({
+      encrypt: (value, options) => `enc:${options?.driver || 'default'}:${value}`,
+      decrypt: (value) => String(value).replace(/^enc:/, ''),
+      blindIndex: (value, { purpose, driver }) =>
+        `blind:${driver || 'default'}:${purpose}:${value}`,
+      blindIndexes: () => ({}),
+    })
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare username: string
+
+      @column.encrypted({
+        driver: 'enc-v1',
+        blind: { columnName: 'email_blind', purpose: 'users_encrypted:email' },
+      })
+      declare email: string
+    }
+    User.table = 'users_encrypted'
+
+    await db
+      .insertQuery()
+      .table('users_encrypted')
+      .insert([{ username: 'virk' }])
+
+    await User.query().where('username', 'virk').update({
+      email_blind: 'manual:first',
+      email: 'virk@adonisjs.com',
+    })
+
+    let user = await db.from('users_encrypted').where('username', 'virk').first()
+    assert.equal(user!.email, 'enc:enc-v1:virk@adonisjs.com')
+    assert.equal(user!.email_blind, 'blind:enc-v1:users_encrypted:email:virk@adonisjs.com')
+
+    await User.query().where('username', 'virk').update({
+      email: 'nikk@adonisjs.com',
+      email_blind: 'manual:second',
+    })
+
+    user = await db.from('users_encrypted').where('username', 'virk').first()
+    assert.equal(user!.email, 'enc:enc-v1:nikk@adonisjs.com')
+    assert.equal(user!.email_blind, 'blind:enc-v1:users_encrypted:email:nikk@adonisjs.com')
   })
 
   test('pass custom connection to the model instance', async ({ fs, assert }) => {

--- a/test/orm/model_query_builder.spec.ts
+++ b/test/orm/model_query_builder.spec.ts
@@ -665,6 +665,15 @@ test.group('Model query builder', (group) => {
     }
 
     assert.throws(
+      () => User.query().where('token', 'super-secret'),
+      'Cannot use "where" on standard encrypted column "User.token". Equality queries require deterministic or blind encryption'
+    )
+    assert.throws(
+      () => User.query().whereIn('token', ['a', 'b']),
+      'Cannot use "whereIn" on standard encrypted column "User.token". Equality queries require deterministic or blind encryption'
+    )
+
+    assert.throws(
       () => User.query().whereLike('email', '%virk%'),
       'Cannot use "whereLike" on encrypted column "User.email". Only equality-based queries are supported'
     )

--- a/test/orm/model_query_builder.spec.ts
+++ b/test/orm/model_query_builder.spec.ts
@@ -251,6 +251,54 @@ test.group('Model query builder', (group) => {
     assert.deepEqual(bindings, knexBindings)
   })
 
+  test('rewrite only model alias columns and ignore joined aliases with same column name', async ({
+    fs,
+    assert,
+  }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    BaseModel.useEncryption({
+      encrypt: (value, options) =>
+        options?.deterministic
+          ? `det:${options?.driver || 'default'}:${value}`
+          : `enc:${options?.driver || 'default'}:${value}`,
+      decrypt: (value) => String(value).replace(/^(enc:|det:)/, ''),
+      blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
+      blindIndexes: () => ({}),
+    })
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column.encrypted({ deterministic: true, driver: 'det-v1' })
+      declare email: string
+    }
+
+    const { sql, bindings } = User.query()
+      .from({ u: 'users' })
+      .join('contacts as c', 'c.user_id', 'u.id')
+      .where('c.email', 'virk@adonisjs.com')
+      .where('u.email', 'virk@adonisjs.com')
+      .toSQL()
+
+    const { sql: knexSql, bindings: knexBindings } = db
+      .connection()
+      .getWriteClient()
+      .from({ u: 'users' })
+      .join('contacts as c', 'c.user_id', 'u.id')
+      .where('c.email', 'virk@adonisjs.com')
+      .where('u.email', 'det:det-v1:virk@adonisjs.com')
+      .toSQL()
+
+    assert.equal(sql, knexSql)
+    assert.deepEqual(bindings, knexBindings)
+  })
+
   test('rewrite blind encrypted where and whereIn clauses', async ({ fs, assert }) => {
     const app = new AppFactory().create(fs.baseUrl, () => {})
     await app.init()

--- a/test/orm/model_query_builder.spec.ts
+++ b/test/orm/model_query_builder.spec.ts
@@ -345,6 +345,48 @@ test.group('Model query builder', (group) => {
     assert.deepEqual(bindings, knexBindings)
   })
 
+  test('trim blind encrypted metadata values before rewriting where clauses', async ({
+    fs,
+    assert,
+  }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    BaseModel.useEncryption({
+      encrypt: (value, options) => `enc:${options?.driver || 'default'}:${value}`,
+      decrypt: (value) => String(value).replace(/^enc:/, ''),
+      blindIndex: (value, { purpose, driver }) =>
+        `blind:${driver || 'default'}:${purpose}:${value}`,
+      blindIndexes: () => ({}),
+    })
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column.encrypted({
+        driver: 'enc-v1',
+        blind: { columnName: ' email_blind ', purpose: ' users:email ' },
+      })
+      declare email: string
+    }
+
+    const { sql, bindings } = User.query().where('email', 'virk@adonisjs.com').toSQL()
+
+    const { sql: knexSql, bindings: knexBindings } = db
+      .connection()
+      .getWriteClient()
+      .from('users')
+      .where('email_blind', 'blind:enc-v1:users:email:virk@adonisjs.com')
+      .toSQL()
+
+    assert.equal(sql, knexSql)
+    assert.deepEqual(bindings, knexBindings)
+  })
+
   test('rewrite all encrypted keys when using object where clauses', async ({ fs, assert }) => {
     const app = new AppFactory().create(fs.baseUrl, () => {})
     await app.init()

--- a/test/orm/model_query_builder.spec.ts
+++ b/test/orm/model_query_builder.spec.ts
@@ -1100,6 +1100,18 @@ test.group('Model query builder', (group) => {
       () => User.query().increment('tokens', 1),
       'Cannot use "increment" on encrypted column "User.tokens". Only equality-based queries are supported'
     )
+    assert.throws(
+      () => User.query().increment({ points: 1 }),
+      'Cannot use "increment" on encrypted column "User.points". Only equality-based queries are supported'
+    )
+    assert.throws(
+      () => User.query().decrement({ score: 1 }),
+      'Cannot use "decrement" on encrypted column "User.score". Only equality-based queries are supported'
+    )
+    assert.throws(
+      () => User.query().increment({ tokens: 1 }),
+      'Cannot use "increment" on encrypted column "User.tokens". Only equality-based queries are supported'
+    )
   })
 
   test('delete in bulk', async ({ fs, assert }) => {

--- a/test/orm/model_query_builder.spec.ts
+++ b/test/orm/model_query_builder.spec.ts
@@ -751,6 +751,46 @@ test.group('Model query builder', (group) => {
     assert.equal(user!.email, 'enc:enc-v1:virk@adonisjs.com')
   })
 
+  test('encrypt key/value updates with returning for encrypted columns', async ({ fs, assert }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    BaseModel.useEncryption({
+      encrypt: (value, options) => `enc:${options?.driver || 'default'}:${value}`,
+      decrypt: (value) => String(value).replace(/^enc:/, ''),
+      blindIndex: (value, { purpose, driver }) =>
+        `blind:${driver || 'default'}:${purpose}:${value}`,
+      blindIndexes: () => ({}),
+    })
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column.encrypted({ driver: 'enc-v1' })
+      declare email: string
+    }
+
+    const { sql, bindings } = User.query()
+      .where('id', 1)
+      .update('email', 'virk@adonisjs.com', ['id'])
+      .toSQL()
+
+    const { sql: knexSql, bindings: knexBindings } = db
+      .connection()
+      .getWriteClient()
+      .from('users')
+      .where('id', 1)
+      .update('email', 'enc:enc-v1:virk@adonisjs.com', ['id'])
+      .toSQL()
+
+    assert.equal(sql, knexSql)
+    assert.deepEqual(bindings, knexBindings)
+  })
+
   test('sync blind index when updating blind encrypted columns', async ({ fs, assert }) => {
     const app = new AppFactory().create(fs.baseUrl, () => {})
     await app.init()

--- a/test/orm/model_query_builder.spec.ts
+++ b/test/orm/model_query_builder.spec.ts
@@ -262,6 +262,89 @@ test.group('Model query builder', (group) => {
     )
   })
 
+  test('encrypt encrypted column values when performing updates', async ({ fs, assert }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    BaseModel.useEncryption({
+      encrypt: (value, options) => `enc:${options?.driver || 'default'}:${value}`,
+      decrypt: (value) => String(value).replace(/^enc:/, ''),
+      blindIndex: (value, { purpose, driver }) =>
+        `blind:${driver || 'default'}:${purpose}:${value}`,
+      blindIndexes: () => ({}),
+    })
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare username: string
+
+      @column.encrypted({ driver: 'enc-v1' })
+      declare email: string
+    }
+
+    await db
+      .insertQuery()
+      .table('users')
+      .insert([{ username: 'virk' }])
+
+    await User.query().where('username', 'virk').update({ email: 'virk@adonisjs.com' })
+
+    const user = await db.from('users').where('username', 'virk').first()
+    assert.equal(user!.email, 'enc:enc-v1:virk@adonisjs.com')
+  })
+
+  test('sync blind index when updating blind encrypted columns', async ({ fs, assert }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    BaseModel.useEncryption({
+      encrypt: (value, options) => `enc:${options?.driver || 'default'}:${value}`,
+      decrypt: (value) => String(value).replace(/^enc:/, ''),
+      blindIndex: (value, { purpose, driver }) =>
+        `blind:${driver || 'default'}:${purpose}:${value}`,
+      blindIndexes: () => ({}),
+    })
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column.encrypted({
+        driver: 'enc-v1',
+        blind: { columnName: 'email_blind', purpose: 'users:email' },
+      })
+      declare email: string
+    }
+
+    const { sql, bindings } = User.query()
+      .where('id', 1)
+      .update({ email: 'virk@adonisjs.com' })
+      .toSQL()
+
+    const { sql: knexSql, bindings: knexBindings } = db
+      .connection()
+      .getWriteClient()
+      .from('users')
+      .where('id', 1)
+      .update({
+        email: 'enc:enc-v1:virk@adonisjs.com',
+        email_blind: 'blind:enc-v1:users:email:virk@adonisjs.com',
+      })
+      .toSQL()
+
+    assert.equal(sql, knexSql)
+    assert.deepEqual(bindings, knexBindings)
+  })
+
   test('pass custom connection to the model instance', async ({ fs, assert }) => {
     const app = new AppFactory().create(fs.baseUrl, () => {})
     await app.init()

--- a/test/orm/model_query_builder.spec.ts
+++ b/test/orm/model_query_builder.spec.ts
@@ -511,6 +511,75 @@ test.group('Model query builder', (group) => {
     assert.deepEqual(bindings, knexBindings)
   })
 
+  test('rewrite object where variants for blind columns when blindIndexes returns multiple values', async ({
+    fs,
+    assert,
+  }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    BaseModel.useEncryption({
+      encrypt: (value, options) => `enc:${options?.driver || 'default'}:${value}`,
+      decrypt: (value) => String(value).replace(/^enc:/, ''),
+      blindIndex: (value, { purpose, driver }) =>
+        `blind:${driver || 'default'}:${purpose}:${value}:single`,
+      blindIndexes: (value, options) => [
+        `blind:${options?.driver || 'default'}:${options?.purpose}:${value}:new`,
+        `blind:${options?.driver || 'default'}:${options?.purpose}:${value}:old`,
+      ],
+    })
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column.encrypted({
+        driver: 'enc-v1',
+        blind: { columnName: 'email_blind', purpose: 'users:email' },
+      })
+      declare email: string
+    }
+
+    const { sql, bindings } = User.query()
+      .where('id', 1)
+      .where({ email: 'a@adonisjs.com' })
+      .orWhere({ email: 'b@adonisjs.com' })
+      .whereNot({ email: 'c@adonisjs.com' })
+      .orWhereNot({ email: 'd@adonisjs.com' })
+      .toSQL()
+
+    const { sql: knexSql, bindings: knexBindings } = db
+      .connection()
+      .getWriteClient()
+      .from('users')
+      .where('id', 1)
+      .whereIn('email_blind', [
+        'blind:enc-v1:users:email:a@adonisjs.com:new',
+        'blind:enc-v1:users:email:a@adonisjs.com:old',
+      ])
+      .orWhere((query) => {
+        query.whereIn('email_blind', [
+          'blind:enc-v1:users:email:b@adonisjs.com:new',
+          'blind:enc-v1:users:email:b@adonisjs.com:old',
+        ])
+      })
+      .whereNotIn('email_blind', [
+        'blind:enc-v1:users:email:c@adonisjs.com:new',
+        'blind:enc-v1:users:email:c@adonisjs.com:old',
+      ])
+      .orWhereNotIn('email_blind', [
+        'blind:enc-v1:users:email:d@adonisjs.com:new',
+        'blind:enc-v1:users:email:d@adonisjs.com:old',
+      ])
+      .toSQL()
+
+    assert.equal(sql, knexSql)
+    assert.deepEqual(bindings, knexBindings)
+  })
+
   test('raise when using unsupported operators on deterministic and blind encrypted columns', async ({
     fs,
     assert,

--- a/test/orm/model_query_builder.spec.ts
+++ b/test/orm/model_query_builder.spec.ts
@@ -107,7 +107,10 @@ test.group('Model query builder', (group) => {
     const BaseModel = getBaseModel(adapter)
 
     BaseModel.useEncryption({
-      encrypt: (value, options) => (options?.deterministic ? `det:${value}` : `enc:${value}`),
+      encrypt: (value, options) =>
+        options?.deterministic
+          ? `det:${options?.driver || 'default'}:${value}`
+          : `enc:${options?.driver || 'default'}:${value}`,
       decrypt: (value) => String(value).replace(/^(enc:|det:)/, ''),
       blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
       blindIndexes: () => ({}),
@@ -117,7 +120,7 @@ test.group('Model query builder', (group) => {
       @column({ isPrimary: true })
       declare id: number
 
-      @column.encrypted({ deterministic: true })
+      @column.encrypted({ deterministic: true, driver: 'det-v1' })
       declare email: string
     }
 
@@ -127,7 +130,7 @@ test.group('Model query builder', (group) => {
       .connection()
       .getWriteClient()
       .from('users')
-      .where('email', 'det:virk@adonisjs.com')
+      .where('email', 'det:det-v1:virk@adonisjs.com')
       .toSQL()
 
     assert.equal(sql, knexSql)
@@ -142,9 +145,10 @@ test.group('Model query builder', (group) => {
     const BaseModel = getBaseModel(adapter)
 
     BaseModel.useEncryption({
-      encrypt: (value) => `enc:${value}`,
+      encrypt: (value, options) => `enc:${options?.driver || 'default'}:${value}`,
       decrypt: (value) => String(value).replace(/^enc:/, ''),
-      blindIndex: (value, { purpose }) => `blind:${purpose}:${value}`,
+      blindIndex: (value, { purpose, driver }) =>
+        `blind:${driver || 'default'}:${purpose}:${value}`,
       blindIndexes: () => ({}),
     })
 
@@ -152,7 +156,10 @@ test.group('Model query builder', (group) => {
       @column({ isPrimary: true })
       declare id: number
 
-      @column.encrypted({ blind: { columnName: 'email_blind', purpose: 'users:email' } })
+      @column.encrypted({
+        driver: 'enc-v1',
+        blind: { columnName: 'email_blind', purpose: 'users:email' },
+      })
       declare email: string
     }
 
@@ -165,10 +172,58 @@ test.group('Model query builder', (group) => {
       .connection()
       .getWriteClient()
       .from('users')
-      .where('email_blind', 'blind:users:email:virk@adonisjs.com')
+      .where('email_blind', 'blind:enc-v1:users:email:virk@adonisjs.com')
       .whereIn('email_blind', [
-        'blind:users:email:virk@adonisjs.com',
-        'blind:users:email:nikk@adonisjs.com',
+        'blind:enc-v1:users:email:virk@adonisjs.com',
+        'blind:enc-v1:users:email:nikk@adonisjs.com',
+      ])
+      .toSQL()
+
+    assert.equal(sql, knexSql)
+    assert.deepEqual(bindings, knexBindings)
+  })
+
+  test('rewrite blind encrypted where to whereIn when blindIndexes returns multiple values', async ({
+    fs,
+    assert,
+  }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    BaseModel.useEncryption({
+      encrypt: (value, options) => `enc:${options?.driver || 'default'}:${value}`,
+      decrypt: (value) => String(value).replace(/^enc:/, ''),
+      blindIndex: (value, { purpose, driver }) =>
+        `blind:${driver || 'default'}:${purpose}:${value}:single`,
+      blindIndexes: (value, options) => [
+        `blind:${options?.driver || 'default'}:${options?.purpose}:${value}:new`,
+        `blind:${options?.driver || 'default'}:${options?.purpose}:${value}:old`,
+      ],
+    })
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column.encrypted({
+        driver: 'enc-v1',
+        blind: { columnName: 'email_blind', purpose: 'users:email' },
+      })
+      declare email: string
+    }
+
+    const { sql, bindings } = User.query().where('email', 'virk@adonisjs.com').toSQL()
+
+    const { sql: knexSql, bindings: knexBindings } = db
+      .connection()
+      .getWriteClient()
+      .from('users')
+      .whereIn('email_blind', [
+        'blind:enc-v1:users:email:virk@adonisjs.com:new',
+        'blind:enc-v1:users:email:virk@adonisjs.com:old',
       ])
       .toSQL()
 

--- a/test/orm/model_query_builder.spec.ts
+++ b/test/orm/model_query_builder.spec.ts
@@ -717,67 +717,67 @@ test.group('Model query builder', (group) => {
 
     assert.throws(
       () => User.query().whereLike('email', '%virk%'),
-      'Cannot use "whereLike" on encrypted column "User.email". Only equality-based queries are supported'
+      'Cannot use "whereLike" on encrypted column "User.email". Encrypted columns can only be used with equality-based WHERE clauses'
     )
     assert.throws(
       () => User.query().whereBetween('email', ['a', 'z']),
-      'Cannot use "whereBetween" on encrypted column "User.email". Only equality-based queries are supported'
+      'Cannot use "whereBetween" on encrypted column "User.email". Encrypted columns can only be used with equality-based WHERE clauses'
     )
     assert.throws(
       () => User.query().whereJson('email', { value: 'virk' }),
-      'Cannot use "whereJson" on encrypted column "User.email". Only equality-based queries are supported'
+      'Cannot use "whereJson" on encrypted column "User.email". Encrypted columns can only be used with equality-based WHERE clauses'
     )
 
     assert.throws(
       () => User.query().whereBetween('username', ['a', 'z']),
-      'Cannot use "whereBetween" on encrypted column "User.username". Only equality-based queries are supported'
+      'Cannot use "whereBetween" on encrypted column "User.username". Encrypted columns can only be used with equality-based WHERE clauses'
     )
     assert.throws(
       () => User.query().whereJson('username', { value: 'virk' }),
-      'Cannot use "whereJson" on encrypted column "User.username". Only equality-based queries are supported'
+      'Cannot use "whereJson" on encrypted column "User.username". Encrypted columns can only be used with equality-based WHERE clauses'
     )
 
     assert.throws(
       () => User.query().orderBy('token'),
-      'Cannot use "orderBy" on encrypted column "User.token". Only equality-based queries are supported'
+      'Cannot use "orderBy" on encrypted column "User.token". Encrypted columns can only be used with equality-based WHERE clauses'
     )
     assert.throws(
       () => User.query().groupBy('email'),
-      'Cannot use "groupBy" on encrypted column "User.email". Only equality-based queries are supported'
+      'Cannot use "groupBy" on encrypted column "User.email". Encrypted columns can only be used with equality-based WHERE clauses'
     )
     assert.throws(
       () => User.query().orderBy([{ column: 'username', order: 'asc' }]),
-      'Cannot use "orderBy" on encrypted column "User.username". Only equality-based queries are supported'
+      'Cannot use "orderBy" on encrypted column "User.username". Encrypted columns can only be used with equality-based WHERE clauses'
     )
 
     assert.throws(
       () => User.query().whereColumn('email', 'username'),
-      'Cannot use "whereColumn" on encrypted column "User.email". Only equality-based queries are supported'
+      'Cannot use "whereColumn" on encrypted column "User.email". Encrypted columns can only be used with equality-based WHERE clauses'
     )
     assert.throws(
       () => User.query().whereColumn('id', 'email'),
-      'Cannot use "whereColumn" on encrypted column "User.email". Only equality-based queries are supported'
+      'Cannot use "whereColumn" on encrypted column "User.email". Encrypted columns can only be used with equality-based WHERE clauses'
     )
     assert.throws(
       () => User.query().orWhereColumn('id', 'username'),
-      'Cannot use "orWhereColumn" on encrypted column "User.username". Only equality-based queries are supported'
+      'Cannot use "orWhereColumn" on encrypted column "User.username". Encrypted columns can only be used with equality-based WHERE clauses'
     )
     assert.throws(
       () => User.query().whereNotColumn('email', 'id'),
-      'Cannot use "whereNotColumn" on encrypted column "User.email". Only equality-based queries are supported'
+      'Cannot use "whereNotColumn" on encrypted column "User.email". Encrypted columns can only be used with equality-based WHERE clauses'
     )
     assert.throws(
       () => User.query().orWhereNotColumn('id', 'username'),
-      'Cannot use "orWhereNotColumn" on encrypted column "User.username". Only equality-based queries are supported'
+      'Cannot use "orWhereNotColumn" on encrypted column "User.username". Encrypted columns can only be used with equality-based WHERE clauses'
     )
 
     assert.throws(
       () => User.query().andWhereLike('email', '%virk%'),
-      'Cannot use "whereLike" on encrypted column "User.email". Only equality-based queries are supported'
+      'Cannot use "whereLike" on encrypted column "User.email". Encrypted columns can only be used with equality-based WHERE clauses'
     )
     assert.throws(
       () => User.query().andWhereBetween('username', ['a', 'z']),
-      'Cannot use "whereBetween" on encrypted column "User.username". Only equality-based queries are supported'
+      'Cannot use "whereBetween" on encrypted column "User.username". Encrypted columns can only be used with equality-based WHERE clauses'
     )
   })
 
@@ -1141,27 +1141,27 @@ test.group('Model query builder', (group) => {
 
     assert.throws(
       () => User.query().increment('points', 1),
-      'Cannot use "increment" on encrypted column "User.points". Only equality-based queries are supported'
+      'Cannot use "increment" on encrypted column "User.points". Encrypted columns can only be used with equality-based WHERE clauses'
     )
     assert.throws(
       () => User.query().decrement('score', 1),
-      'Cannot use "decrement" on encrypted column "User.score". Only equality-based queries are supported'
+      'Cannot use "decrement" on encrypted column "User.score". Encrypted columns can only be used with equality-based WHERE clauses'
     )
     assert.throws(
       () => User.query().increment('tokens', 1),
-      'Cannot use "increment" on encrypted column "User.tokens". Only equality-based queries are supported'
+      'Cannot use "increment" on encrypted column "User.tokens". Encrypted columns can only be used with equality-based WHERE clauses'
     )
     assert.throws(
       () => User.query().increment({ points: 1 }),
-      'Cannot use "increment" on encrypted column "User.points". Only equality-based queries are supported'
+      'Cannot use "increment" on encrypted column "User.points". Encrypted columns can only be used with equality-based WHERE clauses'
     )
     assert.throws(
       () => User.query().decrement({ score: 1 }),
-      'Cannot use "decrement" on encrypted column "User.score". Only equality-based queries are supported'
+      'Cannot use "decrement" on encrypted column "User.score". Encrypted columns can only be used with equality-based WHERE clauses'
     )
     assert.throws(
       () => User.query().increment({ tokens: 1 }),
-      'Cannot use "increment" on encrypted column "User.tokens". Only equality-based queries are supported'
+      'Cannot use "increment" on encrypted column "User.tokens". Encrypted columns can only be used with equality-based WHERE clauses'
     )
   })
 

--- a/test/orm/model_query_builder.spec.ts
+++ b/test/orm/model_query_builder.spec.ts
@@ -634,6 +634,36 @@ test.group('Model query builder', (group) => {
       () => User.query().whereJson('username', { value: 'virk' }),
       'Cannot use "whereJson" on encrypted column "User.username". Only equality-based queries are supported'
     )
+
+    assert.throws(
+      () => User.query().whereColumn('email', 'username'),
+      'Cannot use "whereColumn" on encrypted column "User.email". Only equality-based queries are supported'
+    )
+    assert.throws(
+      () => User.query().whereColumn('id', 'email'),
+      'Cannot use "whereColumn" on encrypted column "User.email". Only equality-based queries are supported'
+    )
+    assert.throws(
+      () => User.query().orWhereColumn('id', 'username'),
+      'Cannot use "orWhereColumn" on encrypted column "User.username". Only equality-based queries are supported'
+    )
+    assert.throws(
+      () => User.query().whereNotColumn('email', 'id'),
+      'Cannot use "whereNotColumn" on encrypted column "User.email". Only equality-based queries are supported'
+    )
+    assert.throws(
+      () => User.query().orWhereNotColumn('id', 'username'),
+      'Cannot use "orWhereNotColumn" on encrypted column "User.username". Only equality-based queries are supported'
+    )
+
+    assert.throws(
+      () => User.query().andWhereLike('email', '%virk%'),
+      'Cannot use "whereLike" on encrypted column "User.email". Only equality-based queries are supported'
+    )
+    assert.throws(
+      () => User.query().andWhereBetween('username', ['a', 'z']),
+      'Cannot use "whereBetween" on encrypted column "User.username". Only equality-based queries are supported'
+    )
   })
 
   test('encrypt encrypted column values when performing updates', async ({ fs, assert }) => {

--- a/test/orm/model_query_builder.spec.ts
+++ b/test/orm/model_query_builder.spec.ts
@@ -331,7 +331,7 @@ test.group('Model query builder', (group) => {
     assert.deepEqual(bindings, knexBindings)
   })
 
-  test('raise when using non equality operators on deterministic encrypted columns', async ({
+  test('raise when using unsupported operators on deterministic and blind encrypted columns', async ({
     fs,
     assert,
   }) => {
@@ -354,11 +354,36 @@ test.group('Model query builder', (group) => {
 
       @column.encrypted({ deterministic: true })
       declare email: string
+
+      @column.encrypted({
+        blind: {
+          columnName: 'username_blind',
+          purpose: 'users:username',
+        },
+      })
+      declare username: string
     }
 
     assert.throws(
       () => User.query().whereLike('email', '%virk%'),
       'Cannot use "whereLike" on encrypted column "User.email". Only equality-based queries are supported'
+    )
+    assert.throws(
+      () => User.query().whereBetween('email', ['a', 'z']),
+      'Cannot use "whereBetween" on encrypted column "User.email". Only equality-based queries are supported'
+    )
+    assert.throws(
+      () => User.query().whereJson('email', { value: 'virk' }),
+      'Cannot use "whereJson" on encrypted column "User.email". Only equality-based queries are supported'
+    )
+
+    assert.throws(
+      () => User.query().whereBetween('username', ['a', 'z']),
+      'Cannot use "whereBetween" on encrypted column "User.username". Only equality-based queries are supported'
+    )
+    assert.throws(
+      () => User.query().whereJson('username', { value: 'virk' }),
+      'Cannot use "whereJson" on encrypted column "User.username". Only equality-based queries are supported'
     )
   })
 

--- a/test/orm/model_query_builder.spec.ts
+++ b/test/orm/model_query_builder.spec.ts
@@ -1035,6 +1035,57 @@ test.group('Model query builder', (group) => {
     assert.equal(user!.points, 2)
   })
 
+  test('raise when using increment/decrement on encrypted columns', async ({ fs, assert }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    BaseModel.useEncryption({
+      encrypt: (value, options) =>
+        options?.deterministic
+          ? `det:${options?.driver || 'default'}:${value}`
+          : `enc:${options?.driver || 'default'}:${value}`,
+      decrypt: (value) => String(value).replace(/^(enc:|det:)/, ''),
+      blindIndex: (value, { purpose, driver }) =>
+        `blind:${driver || 'default'}:${purpose}:${value}`,
+      blindIndexes: () => ({}),
+    })
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column.encrypted()
+      declare points: number
+
+      @column.encrypted({ deterministic: true })
+      declare score: number
+
+      @column.encrypted({
+        blind: {
+          columnName: 'tokens_blind',
+          purpose: 'users:tokens',
+        },
+      })
+      declare tokens: string
+    }
+
+    assert.throws(
+      () => User.query().increment('points', 1),
+      'Cannot use "increment" on encrypted column "User.points". Only equality-based queries are supported'
+    )
+    assert.throws(
+      () => User.query().decrement('score', 1),
+      'Cannot use "decrement" on encrypted column "User.score". Only equality-based queries are supported'
+    )
+    assert.throws(
+      () => User.query().increment('tokens', 1),
+      'Cannot use "increment" on encrypted column "User.tokens". Only equality-based queries are supported'
+    )
+  })
+
   test('delete in bulk', async ({ fs, assert }) => {
     const app = new AppFactory().create(fs.baseUrl, () => {})
     await app.init()

--- a/test/orm/model_query_builder.spec.ts
+++ b/test/orm/model_query_builder.spec.ts
@@ -649,6 +649,9 @@ test.group('Model query builder', (group) => {
       @column({ isPrimary: true })
       declare id: number
 
+      @column.encrypted()
+      declare token: string
+
       @column.encrypted({ deterministic: true })
       declare email: string
 
@@ -681,6 +684,19 @@ test.group('Model query builder', (group) => {
     assert.throws(
       () => User.query().whereJson('username', { value: 'virk' }),
       'Cannot use "whereJson" on encrypted column "User.username". Only equality-based queries are supported'
+    )
+
+    assert.throws(
+      () => User.query().orderBy('token'),
+      'Cannot use "orderBy" on encrypted column "User.token". Only equality-based queries are supported'
+    )
+    assert.throws(
+      () => User.query().groupBy('email'),
+      'Cannot use "groupBy" on encrypted column "User.email". Only equality-based queries are supported'
+    )
+    assert.throws(
+      () => User.query().orderBy([{ column: 'username', order: 'asc' }]),
+      'Cannot use "orderBy" on encrypted column "User.username". Only equality-based queries are supported'
     )
 
     assert.throws(


### PR DESCRIPTION
Hey there! 👋🏻 
This PR adds encrypted columns to Lucid via a new `@column.encrypted(...)` decorator with three modes: standard, deterministic, and blind index, plus per-column driver selection.

- `@column.encrypted({ deterministic: true, driver })` keeps encrypted persistence and enables equality queries by rewriting query values with deterministic encryption on the selected driver.
- `@column.encrypted({ blind: { columnName, purpose }, driver })` stores the main value with standard encryption and writes a blind index to another column, then rewrites equality queries to target that blind column.
- `blind.purpose` is required.
- `blind.columnName` and `blind.purpose` are normalized (`trim`) when stored in metadata.

Lucid relies on an injectable `ModelEncryptionContract` (`encrypt`, `decrypt`, `blindIndex`, `blindIndexes`) bound via `BaseModel.useEncryption(...)`.

If encrypted columns are used without an encryption provider, Lucid throws a dedicated error.

The encryption provider is dynamically inherited, so models booted before `BaseModel.useEncryption(...)` still pick it up later.

Query rewriting is implemented for equality-style WHERE methods on deterministic/blind encrypted columns:
- `where`, `orWhere`, `whereNot`, `orWhereNot`
- `whereIn`, `orWhereIn`, `whereNotIn`, `orWhereNotIn`
- object-style clauses like `where({ email: 'x' })`
- `where('col', 'in', [...])` / `where('col', 'not in', [...])`

Blind indexes support both `blindIndex()` and `blindIndexes()` (for key rotation). When multiple indexes are returned, clauses are automatically rewritten to `whereIn`/`whereNotIn`.

Standard encrypted columns are explicitly rejected in `where*` and `whereIn*` with a dedicated error, instead of silently generating wrong queries.

Unsupported operations now throw clear errors for encrypted columns, including non-equality and JSON operators (`whereLike`, `whereBetween`, `whereJson`, etc.), column-to-column comparisons (`whereColumn`, `orWhereColumn`, `whereNotColumn`, `orWhereNotColumn`), ordering/grouping (`orderBy`, `groupBy`), and arithmetic updates (`increment`, `decrement`) including object payload forms.

Write-path hardening was also added. `User.query().where(...).update({...})` and key/value `update` paths now apply encryption consistently, and blind-index persistence on update is stable regardless of object key order (computed blind values always win over manually provided blind columns).

```ts
BaseModel.useEncryption(encryptionProvider)

class User extends BaseModel {
  @column.encrypted()
  declare secret: string

  @column.encrypted({ deterministic: true, driver: 'det-v1' })
  declare ssn: string

  @column.encrypted({
    driver: 'enc-v1',
    blind: { columnName: 'email_bidx', purpose: 'users:email' },
  })
  declare email: string
}
```

```ts
// Deterministic encrypted column
const byDeterministic = await User.query().where('ssn', '211-61-2524')

// Supports `in` and `not in` operator forms too
const manySsn = await User.query().where('ssn', 'in', ['211-61-2524', '111-22-3333'])

// Blind encrypted column (rewritten internally to email_bidx lookups)
const byBlind = await User.query().where('email', 'romain@adonisjs.com')

// Also works with object clauses
const byObjectClause = await User.query().where({ email: 'romain@adonisjs.com' })

// Works with IN queries and blind index rotation
const byManyBlind = await User.query().whereIn('email', [
  'romain@adonisjs.com',
  'virk@adonisjs.com',
])
```