### PR TITLE
feat: add option to truncate a single table via db:truncate

### DIFF
--- a/commands/db_truncate.ts
+++ b/commands/db_truncate.ts
@@ -32,6 +32,19 @@ export default class DbTruncate extends BaseCommand {
   declare force: boolean
 
   /**
+   * Define a specific table to truncate. Otherwise truncate all
+   * tables
+   */
+  @flags.string({ description: 'Define a specific table to truncate' })
+  declare table: string
+
+  /**
+   * Cascade truncation to related tables
+   */
+  @flags.boolean({ description: 'Cascade truncation to related tables' })
+  declare cascade: boolean
+
+  /**
    * Not a valid connection
    */
   private printNotAValidConnection(connection: string) {
@@ -60,7 +73,11 @@ export default class DbTruncate extends BaseCommand {
     schemas: string[],
     excludeTables: string[]
   ) {
-    await client.truncateAllTables(excludeTables, schemas)
+    if (this.table) {
+      await client.truncate(this.table, this.cascade)
+    } else {
+      await client.truncateAllTables(excludeTables, schemas)
+    }
     this.logger.success('Truncated tables successfully')
   }
 

--- a/commands/db_truncate.ts
+++ b/commands/db_truncate.ts
@@ -76,6 +76,9 @@ export default class DbTruncate extends BaseCommand {
     if (this.table) {
       await client.truncate(this.table, this.cascade)
     } else {
+      if (this.cascade) {
+        this.logger.warning('--cascade is only supported with --table. Ignoring --cascade')
+      }
       await client.truncateAllTables(excludeTables, schemas)
     }
     this.logger.success('Truncated tables successfully')

--- a/docs/AI-REFERENCE-COMMANDS.md
+++ b/docs/AI-REFERENCE-COMMANDS.md
@@ -420,7 +420,9 @@ node ace db:truncate
 
 # Options
 --connection=<name>     # Use specific connection
---force                # Force in production
+--force                 # Force in production
+--table=<table name>    # Define a specific table to truncate
+--cascade               # Cascade truncation to related tables. Only works when specifying --table
 ```
 
 **Examples:**

--- a/test/commands/db_truncate.spec.ts
+++ b/test/commands/db_truncate.spec.ts
@@ -44,6 +44,27 @@ test.group('db:truncate', (group) => {
     assert.equal(friendsCount[0]['total'], 0)
   })
 
+  test('should truncate a single table when --table flag is provided', async ({ fs, assert }) => {
+    const db = getDb()
+    const ace = await new AceFactory().make(fs.baseUrl, { importer: () => {} })
+    await ace.app.init()
+    ace.app.container.singleton('lucid.db', () => db)
+    ace.ui.switchMode('raw')
+
+    await db.table('users').insert({ username: 'bonjour' })
+    await db.table('users').insert({ username: 'bonjour2' })
+    await db.table('friends').insert({ username: 'bonjour' })
+
+    const command = await ace.create(DbTruncate, ['--table=users'])
+    await command.exec()
+
+    const usersCount = await db.from('users').count('*', 'total')
+    const friendsCount = await db.from('friends').count('*', 'total')
+
+    assert.equal(usersCount[0]['total'], 0)
+    assert.equal(friendsCount[0]['total'], 1)
+  })
+
   test('should not truncate adonis migrations tables', async ({ fs, assert }) => {
     const db = getDb()
     const ace = await new AceFactory().make(fs.baseUrl, { importer: () => {} })


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

N/A - This was a small change and if it's unwanted I'm fine with the work being discarded

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds the ability to truncate a single table with `--table <table>` instead of all tables, optionally cascading via `--cascade`

I added this to my project locally first as I was refining some seed scripts and wanted to repeatedly seed and then drop a specific table, without losing and having to re-create other tables. This meant constantly switching to an sql client to run `TRUNCATE mytable CASCADE;`

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Example output (including a cascade error)
```
> node ace db:truncate --help

Description:
  Truncate all tables in database

Usage:
  node ace db:truncate [options]

Options:
  -c, --connection[=CONNECTION]  Define a custom database connection
  --force                        Explicitly force command to run in production
  --table[=TABLE]                Define a specific table to truncate
  --cascade                      Cascade truncation to related tables
> node ace db:truncate --table mytable

ℹ error: TRUNCATE "mytable"; - cannot truncate a table referenced in a foreign key constraint

◉ Truncate table "mytable_somerelations" at the same time, or use TRUNCATE ... CASCADE.

 ⁃ at parseErrorMessage (path-to-lucid/lucid/node_modules/pg-protocol/src/parser.ts:394:9)

   391 ┃    const message =
   392 ┃      name === 'notice'
   393 ┃        ? new NoticeMessage(LATEINIT_LENGTH, messageValue)
 ❯ 394 ┃        : new DatabaseError(messageValue, LATEINIT_LENGTH, name)

 ⁃ at Parser.handlePacket (path-to-lucid/lucid/node_modules/pg-protocol/src/parser.ts:212:19)
 ⁃ at Parser.parse (path-to-lucid/lucid/node_modules/pg-protocol/src/parser.ts:105:30)
...[stack trace]...

> node ace db:truncate --table mytable --cascade
[ success ] Truncated tables successfully
```

Questions:
- It only allows truncating a single table, rather than comma delimited etc. Is this sufficient?
- Is the error reporting (letting lucid errors bubble up) sufficient or do we need anything more specific?

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
  - Done for AI docs, will do main docs if this is given the go-ahead, as they seem to be in another repo?
