### PR TITLE
fix: with count query

### DIFF
--- a/src/orm/query_builder/index.ts
+++ b/src/orm/query_builder/index.ts
@@ -551,6 +551,9 @@ export class ModelQueryBuilder
        * Count "*"
        */
       if (!subQuery.hasAggregates) {
+        subQuery.clearOrder()
+        subQuery.clearLimit()
+        subQuery.clearOffset()
         subQuery.count('*')
       }
 

--- a/test/orm/model_belongs_to.spec.ts
+++ b/test/orm/model_belongs_to.spec.ts
@@ -1761,6 +1761,50 @@ test.group('Model | BelongsTo | withCount', (group) => {
     assert.equal(profiles[0].$extras.user_count, 1)
   })
 
+  test('ignore relation order and pagination when using withCount', async ({ assert, fs }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+    }
+
+    class Profile extends BaseModel {
+      @column()
+      declare userId: number
+
+      @belongsTo(() => User, {
+        onQuery: (query) => {
+          query.orderBy('id', 'asc').limit(1).offset(1)
+        },
+      })
+      declare user: BelongsTo<typeof User>
+    }
+
+    await db
+      .insertQuery()
+      .table('users')
+      .multiInsert([{ username: 'virk' }, { username: 'nikk' }])
+    await db
+      .insertQuery()
+      .table('profiles')
+      .multiInsert([
+        { display_name: 'Hvirk', user_id: 1 },
+        { display_name: 'Nikk', user_id: 2 },
+      ])
+
+    const query = Profile.query().withCount('user').orderBy('id', 'asc')
+
+    const profiles = await query
+    assert.lengthOf(profiles, 2)
+    assert.equal(Number(profiles[0].$extras.user_count), 1)
+    assert.equal(Number(profiles[1].$extras.user_count), 1)
+  })
+
   test('allow cherry picking columns', async ({ assert, fs }) => {
     const app = new AppFactory().create(fs.baseUrl, () => {})
     await app.init()

--- a/test/orm/model_has_many.spec.ts
+++ b/test/orm/model_has_many.spec.ts
@@ -1676,6 +1676,72 @@ test.group('Model | HasMany | withCount', (group) => {
     assert.deepEqual(Number(users[1].$extras.posts_count), 1)
   })
 
+  test('ignore relation order and pagination when using withCount', async ({ fs, assert }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    class Post extends BaseModel {
+      @column()
+      declare userId: number
+    }
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @hasMany(() => Post, {
+        onQuery: (query) => {
+          query.orderBy('id', 'asc').limit(1).offset(1)
+        },
+      })
+      declare posts: HasMany<typeof Post>
+    }
+
+    User.$getRelation('posts')!.boot()
+
+    await db
+      .insertQuery()
+      .table('users')
+      .insert([{ username: 'virk' }, { username: 'nikk' }])
+
+    const [user0, user1] = await db.query().from('users').orderBy('id', 'asc')
+    await db
+      .insertQuery()
+      .table('posts')
+      .insert([
+        {
+          user_id: user0.id,
+          title: 'Adonis 101',
+        },
+        {
+          user_id: user0.id,
+          title: 'Adonis 102',
+        },
+        {
+          user_id: user0.id,
+          title: 'Adonis 103',
+        },
+        {
+          user_id: user1.id,
+          title: 'Lucid 101',
+        },
+        {
+          user_id: user1.id,
+          title: 'Lucid 102',
+        },
+      ])
+
+    const query = User.query().withCount('posts').orderBy('id', 'asc')
+
+    const users = await query
+    assert.lengthOf(users, 2)
+    assert.deepEqual(Number(users[0].$extras.posts_count), 3)
+    assert.deepEqual(Number(users[1].$extras.posts_count), 2)
+  })
+
   test('apply constraints to the withCount subquery', async ({ fs, assert }) => {
     const app = new AppFactory().create(fs.baseUrl, () => {})
     await app.init()

--- a/test/orm/model_has_many_through.spec.ts
+++ b/test/orm/model_has_many_through.spec.ts
@@ -1615,6 +1615,78 @@ test.group('Model | Has Many Through | withCount', (group) => {
     assert.equal(countries[1].$extras.posts_count, 2)
   })
 
+  test('ignore relation order and pagination when using withCount', async ({ fs, assert }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare countryId: number
+    }
+
+    class Post extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare userId: number
+
+      @column()
+      declare title: string
+    }
+
+    class Country extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @hasManyThrough([() => Post, () => User], {
+        onQuery: (query) => {
+          query.orderBy('posts.id', 'asc').limit(1).offset(1)
+        },
+      })
+      declare posts: HasManyThrough<typeof Post>
+    }
+
+    await db
+      .insertQuery()
+      .table('countries')
+      .insert([{ name: 'India' }, { name: 'Switzerland' }])
+
+    await db
+      .insertQuery()
+      .table('users')
+      .multiInsert([
+        { username: 'virk', country_id: 1 },
+        { username: 'nikk', country_id: 1 },
+        { username: 'romain', country_id: 2 },
+        { username: 'joe', country_id: 2 },
+      ])
+
+    await db
+      .insertQuery()
+      .table('posts')
+      .multiInsert([
+        { title: 'Adonis 101', user_id: 1 },
+        { title: 'Lucid 101', user_id: 1 },
+        { title: 'Adonis5', user_id: 2 },
+        { title: 'Validations 101', user_id: 3 },
+        { title: 'Assets 101', user_id: 4 },
+      ])
+
+    const query = Country.query().withCount('posts').orderBy('id', 'asc')
+
+    const countries = await query
+    assert.lengthOf(countries, 2)
+    assert.equal(Number(countries[0].$extras.posts_count), 3)
+    assert.equal(Number(countries[1].$extras.posts_count), 2)
+  })
+
   test('apply constraints to the withCount subquery', async ({ fs, assert }) => {
     const app = new AppFactory().create(fs.baseUrl, () => {})
     await app.init()

--- a/test/orm/model_has_one.spec.ts
+++ b/test/orm/model_has_one.spec.ts
@@ -1776,6 +1776,64 @@ test.group('Model | HasOne | withCount', (group) => {
     assert.equal(users[1].$extras.profile_count, 1)
   })
 
+  test('ignore relation order and pagination when using withCount', async ({ fs, assert }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    class Profile extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare userId: number
+
+      @column()
+      declare displayName: string
+    }
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @hasOne(() => Profile, {
+        onQuery: (query) => {
+          query.orderBy('id', 'asc').limit(1).offset(1)
+        },
+      })
+      declare profile: HasOne<typeof Profile>
+    }
+
+    await db
+      .insertQuery()
+      .table('users')
+      .insert([{ username: 'virk' }, { username: 'nikk' }])
+
+    const [user0, user1] = await db.query().from('users')
+    await db
+      .insertQuery()
+      .table('profiles')
+      .insert([
+        {
+          user_id: user0.id,
+          display_name: 'virk',
+        },
+        {
+          user_id: user1.id,
+          display_name: 'nikk',
+        },
+      ])
+
+    const query = User.query().withCount('profile').orderBy('id', 'asc')
+
+    const users = await query
+    assert.lengthOf(users, 2)
+    assert.equal(Number(users[0].$extras.profile_count), 1)
+    assert.equal(Number(users[1].$extras.profile_count), 1)
+  })
+
   test('allow cherry picking columns', async ({ fs, assert }) => {
     const app = new AppFactory().create(fs.baseUrl, () => {})
     await app.init()

--- a/test/orm/model_many_to_many.spec.ts
+++ b/test/orm/model_many_to_many.spec.ts
@@ -1917,6 +1917,69 @@ test.group('Model | ManyToMany | withCount', (group) => {
     assert.deepEqual(Number(users[1].$extras.skills_count), 1)
   })
 
+  test('ignore relation order and pagination when using withCount', async ({ fs, assert }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    class Skill extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare name: string
+    }
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @manyToMany(() => Skill, {
+        onQuery: (query) => {
+          query.orderBy('skills.id', 'asc').limit(1).offset(1)
+        },
+      })
+      declare skills: ManyToMany<typeof Skill>
+    }
+
+    await db
+      .insertQuery()
+      .table('users')
+      .insert([{ username: 'virk' }, { username: 'nikk' }])
+
+    await db
+      .insertQuery()
+      .table('skills')
+      .insert([{ name: 'Programming' }, { name: 'Dancing' }, { name: 'Singing' }])
+
+    await db
+      .insertQuery()
+      .table('skill_user')
+      .insert([
+        {
+          user_id: 1,
+          skill_id: 1,
+        },
+        {
+          user_id: 1,
+          skill_id: 2,
+        },
+        {
+          user_id: 2,
+          skill_id: 2,
+        },
+      ])
+
+    const query = User.query().withCount('skills').orderBy('id', 'asc')
+
+    const users = await query
+    assert.lengthOf(users, 2)
+    assert.deepEqual(Number(users[0].$extras.skills_count), 2)
+    assert.deepEqual(Number(users[1].$extras.skills_count), 1)
+  })
+
   test('apply constraints to the withCount subquery', async ({ fs, assert }) => {
     const app = new AppFactory().create(fs.baseUrl, () => {})
     await app.init()


### PR DESCRIPTION
### 🔗 Linked issue
https://github.com/adonisjs/lucid/issues/1155

### ❓ Type of change
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Ensure withCount ignores relation orderBy/limit/offset (defined on onQuery) so the generated count(*) subquery is valid and always returns the true total number of related records.

### 📝 Checklist
- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
