### PR TITLE
feat(schema_generator): format generated schema with prettier

### DIFF
--- a/src/orm/schema_generator/generator.ts
+++ b/src/orm/schema_generator/generator.ts
@@ -112,6 +112,25 @@ export class OrmSchemaGenerator extends EventEmitter<{
   }
 
   /**
+   * Format the content using prettier.
+   *
+   * @param content
+   * @private
+   */
+  private async formatWithPrettier(content: string): Promise<string> {
+    try {
+      const { format, resolveConfig } = await import('prettier')
+      const config = await resolveConfig('@adonisjs/prettier-config')
+      content = await format(content, {
+        ...config,
+        parser: 'typescript',
+      })
+    } catch {}
+
+    return content
+  }
+
+  /**
    * Generate schemas and write to output file
    */
   async generate(): Promise<void> {
@@ -144,7 +163,10 @@ export class OrmSchemaGenerator extends EventEmitter<{
       ' * Run "node ace migration:run" command to re-generate this file',
       ' */',
     ].join('\n')
-    await writeFile(this.config.outputPath, `${comment}\n\n${output}`, 'utf-8')
+
+    const formattedContent = await this.formatWithPrettier(`${comment}\n\n${output}`)
+
+    await writeFile(this.config.outputPath, formattedContent, 'utf-8')
   }
 
   /**


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Formats the generated schema file using the default prettier config

When we have several database table columns, the columns are listed on 1 line and can become unreadable. It also violates the lint config.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
