### PR TITLE
feat: assertion testing helpers

### DIFF
--- a/commands/migration/_base.ts
+++ b/commands/migration/_base.ts
@@ -231,6 +231,10 @@ export default abstract class MigrationsBase extends BaseCommand {
      * Run migrations
      */
     await migrator.run()
+    if (migrator.error) {
+      this.error = migrator.error
+      this.exitCode = 1
+    }
 
     /**
      * Log all pending files. This will happen, when one of the migration

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "./orm": "./build/src/orm/main.js",
     "./orm/relations": "./build/src/orm/relations/main.js",
     "./seeders": "./build/src/seeders/main.js",
+    "./plugins/db": "./build/src/plugins/japa/db.js",
     "./services/*": "./build/services/*.js",
     "./types/*": "./build/src/types/*.js",
     "./migration": "./build/src/migration/main.js",

--- a/src/plugins/japa/db.ts
+++ b/src/plugins/japa/db.ts
@@ -1,0 +1,29 @@
+/*
+ * @adonisjs/lucid
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import type { PluginFn } from '@japa/runner/types'
+import { TestContext } from '@japa/runner/core'
+import type { ApplicationService } from '@adonisjs/core/types'
+import { DatabaseTestAssertions } from '../../test_utils/assertions.js'
+
+declare module '@japa/runner/core' {
+  interface TestContext {
+    db: DatabaseTestAssertions
+  }
+}
+
+/**
+ * Japa plugin that adds database assertion methods
+ * to the test context via `({ db }) => { ... }`.
+ */
+export function dbAssertions(app: ApplicationService): PluginFn {
+  return function () {
+    TestContext.getter('db', () => new DatabaseTestAssertions(app), true)
+  }
+}

--- a/src/test_utils/assertions.ts
+++ b/src/test_utils/assertions.ts
@@ -1,0 +1,168 @@
+/*
+ * @adonisjs/lucid
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { AssertionError } from 'node:assert'
+import { type ApplicationService } from '@adonisjs/core/types'
+import { type LucidRow, type LucidModel } from '../types/model.js'
+import { type Database } from '../database/main.js'
+
+/**
+ * Provides database assertion methods for use inside test bodies.
+ * Exposed on Japa's TestContext as `db`.
+ */
+export class DatabaseTestAssertions {
+  constructor(
+    protected app: ApplicationService,
+    protected connectionName?: string
+  ) {}
+
+  /**
+   * Returns the Database instance from the container
+   */
+  async #getDb(): Promise<Database> {
+    return this.app.container.make('lucid.db')
+  }
+
+  /**
+   * Returns a query client for the configured connection
+   */
+  async #getConnection() {
+    const db = await this.#getDb()
+    return db.connection(this.connectionName)
+  }
+
+  /**
+   * Assert that the given table has rows matching the provided data.
+   * When `count` is provided, asserts that exactly that many matching rows exist.
+   */
+  async assertHas(table: string, data: Record<string, any>, count?: number) {
+    const connection = await this.#getConnection()
+    const result: any = await connection.query().from(table).where(data).count('* as count')
+    const actualCount = Number(result[0].count)
+
+    if (count !== undefined && actualCount !== count) {
+      throw new AssertionError({
+        message: `Expected table '${table}' to have ${count} rows matching ${JSON.stringify(data)}, but found ${actualCount}`,
+        actual: actualCount,
+        expected: count,
+        operator: 'assertHas',
+      })
+    }
+
+    if (count === undefined && actualCount === 0) {
+      throw new AssertionError({
+        message: `Expected table '${table}' to have rows matching ${JSON.stringify(data)}, but none were found`,
+        actual: 0,
+        expected: '>= 1',
+        operator: 'assertHas',
+      })
+    }
+  }
+
+  /**
+   * Assert that the given table has no rows matching the provided data.
+   */
+  async assertMissing(table: string, data: Record<string, any>) {
+    const connection = await this.#getConnection()
+    const result: any = await connection.query().from(table).where(data).count('* as count')
+    const actualCount = Number(result[0].count)
+
+    if (actualCount > 0) {
+      throw new AssertionError({
+        message: `Expected table '${table}' to have no rows matching ${JSON.stringify(data)}, but found ${actualCount}`,
+        actual: actualCount,
+        expected: 0,
+        operator: 'assertMissing',
+      })
+    }
+  }
+
+  /**
+   * Assert that the given table has exactly the expected number of rows.
+   */
+  async assertCount(table: string, expectedCount: number) {
+    const connection = await this.#getConnection()
+    const result: any = await connection.query().from(table).count('* as count')
+    const actualCount = Number(result[0].count)
+
+    if (actualCount !== expectedCount) {
+      throw new AssertionError({
+        message: `Expected table '${table}' to have ${expectedCount} rows, but found ${actualCount}`,
+        actual: actualCount,
+        expected: expectedCount,
+        operator: 'assertCount',
+      })
+    }
+  }
+
+  /**
+   * Assert that the given table is empty (has no rows).
+   */
+  async assertEmpty(table: string) {
+    return this.assertCount(table, 0)
+  }
+
+  /**
+   * Assert that a model instance exists in the database.
+   */
+  async assertModelExists(model: LucidRow) {
+    const Model = model.constructor as LucidModel
+    const primaryKeyValue = model.$primaryKeyValue
+
+    if (primaryKeyValue === undefined) {
+      throw new Error(`Cannot assert model existence: primary key value is undefined`)
+    }
+
+    const connection = await this.#getConnection()
+    const result: any = await connection
+      .query()
+      .from(Model.table)
+      .where(Model.primaryKey, primaryKeyValue)
+      .count('* as count')
+    const actualCount = Number(result[0].count)
+
+    if (actualCount === 0) {
+      throw new AssertionError({
+        message: `Expected '${Model.name}' model with primary key ${primaryKeyValue} to exist, but it was not found`,
+        actual: 'missing',
+        expected: 'exists',
+        operator: 'assertModelExists',
+      })
+    }
+  }
+
+  /**
+   * Assert that a model instance does not exist in the database.
+   */
+  async assertModelMissing(model: LucidRow) {
+    const Model = model.constructor as LucidModel
+    const primaryKeyValue = model.$primaryKeyValue
+
+    if (primaryKeyValue === undefined) {
+      throw new Error(`Cannot assert model absence: primary key value is undefined`)
+    }
+
+    const connection = await this.#getConnection()
+    const result: any = await connection
+      .query()
+      .from(Model.table)
+      .where(Model.primaryKey, primaryKeyValue)
+      .count('* as count')
+    const actualCount = Number(result[0].count)
+
+    if (actualCount > 0) {
+      throw new AssertionError({
+        message: `Expected '${Model.name}' model with primary key ${primaryKeyValue} to not exist, but it was found`,
+        actual: 'exists',
+        expected: 'missing',
+        operator: 'assertModelMissing',
+      })
+    }
+  }
+}

--- a/src/test_utils/assertions.ts
+++ b/src/test_utils/assertions.ts
@@ -22,6 +22,13 @@ export class DatabaseTestAssertions {
   ) {}
 
   /**
+   * Returns a new instance of assertions configured for the given connection
+   */
+  connection(connectionName: string) {
+    return new DatabaseTestAssertions(this.app, connectionName)
+  }
+
+  /**
    * Returns the Database instance from the container
    */
   async #getDb() {

--- a/src/test_utils/assertions.ts
+++ b/src/test_utils/assertions.ts
@@ -118,7 +118,7 @@ export class DatabaseTestAssertions {
       throw new Error(`Cannot assert model existence: primary key value is undefined`)
     }
 
-    const result = await Model.find(primaryKeyValue)
+    const result = await Model.find(primaryKeyValue, { connection: this.connectionName })
 
     if (!result) {
       throw new AssertionError({
@@ -141,7 +141,7 @@ export class DatabaseTestAssertions {
       throw new Error(`Cannot assert model absence: primary key value is undefined`)
     }
 
-    const result = await Model.find(primaryKeyValue)
+    const result = await Model.find(primaryKeyValue, { connection: this.connectionName })
 
     if (result) {
       throw new AssertionError({

--- a/src/test_utils/assertions.ts
+++ b/src/test_utils/assertions.ts
@@ -10,7 +10,6 @@
 import { AssertionError } from 'node:assert'
 import { type ApplicationService } from '@adonisjs/core/types'
 import { type LucidRow, type LucidModel } from '../types/model.js'
-import { type Database } from '../database/main.js'
 
 /**
  * Provides database assertion methods for use inside test bodies.
@@ -25,7 +24,7 @@ export class DatabaseTestAssertions {
   /**
    * Returns the Database instance from the container
    */
-  async #getDb(): Promise<Database> {
+  async #getDb() {
     return this.app.container.make('lucid.db')
   }
 
@@ -119,15 +118,9 @@ export class DatabaseTestAssertions {
       throw new Error(`Cannot assert model existence: primary key value is undefined`)
     }
 
-    const connection = await this.#getConnection()
-    const result: any = await connection
-      .query()
-      .from(Model.table)
-      .where(Model.primaryKey, primaryKeyValue)
-      .count('* as count')
-    const actualCount = Number(result[0].count)
+    const result = await Model.find(primaryKeyValue)
 
-    if (actualCount === 0) {
+    if (!result) {
       throw new AssertionError({
         message: `Expected '${Model.name}' model with primary key ${primaryKeyValue} to exist, but it was not found`,
         actual: 'missing',
@@ -148,15 +141,9 @@ export class DatabaseTestAssertions {
       throw new Error(`Cannot assert model absence: primary key value is undefined`)
     }
 
-    const connection = await this.#getConnection()
-    const result: any = await connection
-      .query()
-      .from(Model.table)
-      .where(Model.primaryKey, primaryKeyValue)
-      .count('* as count')
-    const actualCount = Number(result[0].count)
+    const result = await Model.find(primaryKeyValue)
 
-    if (actualCount > 0) {
+    if (result) {
       throw new AssertionError({
         message: `Expected '${Model.name}' model with primary key ${primaryKeyValue} to not exist, but it was found`,
         actual: 'exists',

--- a/src/test_utils/database.ts
+++ b/src/test_utils/database.ts
@@ -7,7 +7,10 @@
  * file that was distributed with this source code.
  */
 
+import { AssertionError } from 'node:assert'
 import { type ApplicationService } from '@adonisjs/core/types'
+import { type LucidRow, type LucidModel } from '../types/model.js'
+import { type Database } from '../database/main.js'
 
 /**
  * Database test utils are meant to be used during testing to
@@ -18,6 +21,21 @@ export class DatabaseTestUtils {
     protected app: ApplicationService,
     protected connectionName?: string
   ) {}
+
+  /**
+   * Returns the Database instance from the container
+   */
+  async #getDb(): Promise<Database> {
+    return this.app.container.make('lucid.db')
+  }
+
+  /**
+   * Returns a query client for the configured connection
+   */
+  async #getConnection() {
+    const db = await this.#getDb()
+    return db.connection(this.connectionName)
+  }
 
   /**
    * Runs a command through Ace
@@ -84,5 +102,134 @@ export class DatabaseTestUtils {
    */
   async withGlobalTransaction() {
     return this.wrapInGlobalTransaction()
+  }
+
+  /**
+   * Assert that the given table has rows matching the provided data.
+   * When `count` is provided, asserts that exactly that many matching rows exist.
+   */
+  async assertHas(table: string, data: Record<string, any>, count?: number) {
+    const connection = await this.#getConnection()
+    const result: any = await connection.query().from(table).where(data).count('* as count')
+    const actualCount = Number(result[0].count)
+
+    if (count !== undefined && actualCount !== count) {
+      throw new AssertionError({
+        message: `Expected table '${table}' to have ${count} rows matching ${JSON.stringify(data)}, but found ${actualCount}`,
+        actual: actualCount,
+        expected: count,
+        operator: 'assertHas',
+      })
+    }
+
+    if (count === undefined && actualCount === 0) {
+      throw new AssertionError({
+        message: `Expected table '${table}' to have rows matching ${JSON.stringify(data)}, but none were found`,
+        actual: 0,
+        expected: '>= 1',
+        operator: 'assertHas',
+      })
+    }
+  }
+
+  /**
+   * Assert that the given table has no rows matching the provided data.
+   */
+  async assertMissing(table: string, data: Record<string, any>) {
+    const connection = await this.#getConnection()
+    const result: any = await connection.query().from(table).where(data).count('* as count')
+    const actualCount = Number(result[0].count)
+
+    if (actualCount > 0) {
+      throw new AssertionError({
+        message: `Expected table '${table}' to have no rows matching ${JSON.stringify(data)}, but found ${actualCount}`,
+        actual: actualCount,
+        expected: 0,
+        operator: 'assertMissing',
+      })
+    }
+  }
+
+  /**
+   * Assert that the given table has exactly the expected number of rows.
+   */
+  async assertCount(table: string, expectedCount: number) {
+    const connection = await this.#getConnection()
+    const result: any = await connection.query().from(table).count('* as count')
+    const actualCount = Number(result[0].count)
+
+    if (actualCount !== expectedCount) {
+      throw new AssertionError({
+        message: `Expected table '${table}' to have ${expectedCount} rows, but found ${actualCount}`,
+        actual: actualCount,
+        expected: expectedCount,
+        operator: 'assertCount',
+      })
+    }
+  }
+
+  /**
+   * Assert that the given table is empty (has no rows).
+   */
+  async assertEmpty(table: string) {
+    return this.assertCount(table, 0)
+  }
+
+  /**
+   * Assert that a model instance exists in the database.
+   */
+  async assertModelExists(model: LucidRow) {
+    const Model = model.constructor as LucidModel
+    const primaryKeyValue = model.$primaryKeyValue
+
+    if (primaryKeyValue === undefined) {
+      throw new Error(`Cannot assert model existence: primary key value is undefined`)
+    }
+
+    const connection = await this.#getConnection()
+    const result: any = await connection
+      .query()
+      .from(Model.table)
+      .where(Model.primaryKey, primaryKeyValue)
+      .count('* as count')
+    const actualCount = Number(result[0].count)
+
+    if (actualCount === 0) {
+      throw new AssertionError({
+        message: `Expected '${Model.name}' model with primary key ${primaryKeyValue} to exist, but it was not found`,
+        actual: 'missing',
+        expected: 'exists',
+        operator: 'assertModelExists',
+      })
+    }
+  }
+
+  /**
+   * Assert that a model instance does not exist in the database.
+   */
+  async assertModelMissing(model: LucidRow) {
+    const Model = model.constructor as LucidModel
+    const primaryKeyValue = model.$primaryKeyValue
+
+    if (primaryKeyValue === undefined) {
+      throw new Error(`Cannot assert model absence: primary key value is undefined`)
+    }
+
+    const connection = await this.#getConnection()
+    const result: any = await connection
+      .query()
+      .from(Model.table)
+      .where(Model.primaryKey, primaryKeyValue)
+      .count('* as count')
+    const actualCount = Number(result[0].count)
+
+    if (actualCount > 0) {
+      throw new AssertionError({
+        message: `Expected '${Model.name}' model with primary key ${primaryKeyValue} to not exist, but it was found`,
+        actual: 'exists',
+        expected: 'missing',
+        operator: 'assertModelMissing',
+      })
+    }
   }
 }

--- a/src/test_utils/database.ts
+++ b/src/test_utils/database.ts
@@ -7,10 +7,7 @@
  * file that was distributed with this source code.
  */
 
-import { AssertionError } from 'node:assert'
 import { type ApplicationService } from '@adonisjs/core/types'
-import { type LucidRow, type LucidModel } from '../types/model.js'
-import { type Database } from '../database/main.js'
 
 /**
  * Database test utils are meant to be used during testing to
@@ -21,21 +18,6 @@ export class DatabaseTestUtils {
     protected app: ApplicationService,
     protected connectionName?: string
   ) {}
-
-  /**
-   * Returns the Database instance from the container
-   */
-  async #getDb(): Promise<Database> {
-    return this.app.container.make('lucid.db')
-  }
-
-  /**
-   * Returns a query client for the configured connection
-   */
-  async #getConnection() {
-    const db = await this.#getDb()
-    return db.connection(this.connectionName)
-  }
 
   /**
    * Runs a command through Ace
@@ -102,134 +84,5 @@ export class DatabaseTestUtils {
    */
   async withGlobalTransaction() {
     return this.wrapInGlobalTransaction()
-  }
-
-  /**
-   * Assert that the given table has rows matching the provided data.
-   * When `count` is provided, asserts that exactly that many matching rows exist.
-   */
-  async assertHas(table: string, data: Record<string, any>, count?: number) {
-    const connection = await this.#getConnection()
-    const result: any = await connection.query().from(table).where(data).count('* as count')
-    const actualCount = Number(result[0].count)
-
-    if (count !== undefined && actualCount !== count) {
-      throw new AssertionError({
-        message: `Expected table '${table}' to have ${count} rows matching ${JSON.stringify(data)}, but found ${actualCount}`,
-        actual: actualCount,
-        expected: count,
-        operator: 'assertHas',
-      })
-    }
-
-    if (count === undefined && actualCount === 0) {
-      throw new AssertionError({
-        message: `Expected table '${table}' to have rows matching ${JSON.stringify(data)}, but none were found`,
-        actual: 0,
-        expected: '>= 1',
-        operator: 'assertHas',
-      })
-    }
-  }
-
-  /**
-   * Assert that the given table has no rows matching the provided data.
-   */
-  async assertMissing(table: string, data: Record<string, any>) {
-    const connection = await this.#getConnection()
-    const result: any = await connection.query().from(table).where(data).count('* as count')
-    const actualCount = Number(result[0].count)
-
-    if (actualCount > 0) {
-      throw new AssertionError({
-        message: `Expected table '${table}' to have no rows matching ${JSON.stringify(data)}, but found ${actualCount}`,
-        actual: actualCount,
-        expected: 0,
-        operator: 'assertMissing',
-      })
-    }
-  }
-
-  /**
-   * Assert that the given table has exactly the expected number of rows.
-   */
-  async assertCount(table: string, expectedCount: number) {
-    const connection = await this.#getConnection()
-    const result: any = await connection.query().from(table).count('* as count')
-    const actualCount = Number(result[0].count)
-
-    if (actualCount !== expectedCount) {
-      throw new AssertionError({
-        message: `Expected table '${table}' to have ${expectedCount} rows, but found ${actualCount}`,
-        actual: actualCount,
-        expected: expectedCount,
-        operator: 'assertCount',
-      })
-    }
-  }
-
-  /**
-   * Assert that the given table is empty (has no rows).
-   */
-  async assertEmpty(table: string) {
-    return this.assertCount(table, 0)
-  }
-
-  /**
-   * Assert that a model instance exists in the database.
-   */
-  async assertModelExists(model: LucidRow) {
-    const Model = model.constructor as LucidModel
-    const primaryKeyValue = model.$primaryKeyValue
-
-    if (primaryKeyValue === undefined) {
-      throw new Error(`Cannot assert model existence: primary key value is undefined`)
-    }
-
-    const connection = await this.#getConnection()
-    const result: any = await connection
-      .query()
-      .from(Model.table)
-      .where(Model.primaryKey, primaryKeyValue)
-      .count('* as count')
-    const actualCount = Number(result[0].count)
-
-    if (actualCount === 0) {
-      throw new AssertionError({
-        message: `Expected '${Model.name}' model with primary key ${primaryKeyValue} to exist, but it was not found`,
-        actual: 'missing',
-        expected: 'exists',
-        operator: 'assertModelExists',
-      })
-    }
-  }
-
-  /**
-   * Assert that a model instance does not exist in the database.
-   */
-  async assertModelMissing(model: LucidRow) {
-    const Model = model.constructor as LucidModel
-    const primaryKeyValue = model.$primaryKeyValue
-
-    if (primaryKeyValue === undefined) {
-      throw new Error(`Cannot assert model absence: primary key value is undefined`)
-    }
-
-    const connection = await this.#getConnection()
-    const result: any = await connection
-      .query()
-      .from(Model.table)
-      .where(Model.primaryKey, primaryKeyValue)
-      .count('* as count')
-    const actualCount = Number(result[0].count)
-
-    if (actualCount > 0) {
-      throw new AssertionError({
-        message: `Expected '${Model.name}' model with primary key ${primaryKeyValue} to not exist, but it was found`,
-        actual: 'exists',
-        expected: 'missing',
-        operator: 'assertModelMissing',
-      })
-    }
   }
 }

--- a/test-helpers/index.ts
+++ b/test-helpers/index.ts
@@ -12,11 +12,11 @@ import { Chance } from 'chance'
 import { join } from 'node:path'
 import knex, { type Knex } from 'knex'
 import { fileURLToPath } from 'node:url'
-import { getActiveTest, getActiveTestOrFail } from '@japa/runner'
 import { Logger } from '@adonisjs/core/logger'
 import { Emitter } from '@adonisjs/core/events'
 import { type Application } from '@adonisjs/core/app'
 import { AppFactory } from '@adonisjs/core/factories/app'
+import { getActiveTest, getActiveTestOrFail } from '@japa/runner'
 
 import {
   type DatabaseConfig,

--- a/test-helpers/index.ts
+++ b/test-helpers/index.ts
@@ -55,10 +55,10 @@ export const logger = new Logger({})
 export const createEmitter = () => new Emitter<any>(app)
 
 /**
- * Returns config based upon DB set in environment variables
+ * Returns config for a given database dialect
  */
-export function getConfig(): ConnectionConfig {
-  switch (process.env.DB) {
+export function getConfigForDb(db: string): ConnectionConfig {
+  switch (db) {
     case 'sqlite':
       return {
         client: 'sqlite3',
@@ -145,8 +145,15 @@ export function getConfig(): ConnectionConfig {
         },
       }
     default:
-      throw new Error(`Missing test config for ${process.env.DB} connection`)
+      throw new Error(`Missing test config for ${db} connection`)
   }
+}
+
+/**
+ * Returns config based upon DB set in environment variables
+ */
+export function getConfig(): ConnectionConfig {
+  return getConfigForDb(process.env.DB!)
 }
 
 /**
@@ -166,11 +173,9 @@ export function getKnex(config: Knex.Config): Knex {
 }
 
 /**
- * Does base setup by creating databases
+ * Creates all test tables on the given knex connection
  */
-export async function setup(destroyDb: boolean = true) {
-  const db = getKnex(Object.assign({}, getConfig(), { debug: false }))
-
+export async function setupDb(db: Knex, destroyDb: boolean = true) {
   const hasUsersTable = await db.schema.hasTable('users')
   if (!hasUsersTable) {
     await db.schema.createTable('users', (table) => {
@@ -313,6 +318,14 @@ export async function setup(destroyDb: boolean = true) {
   if (destroyDb) {
     await db.destroy()
   }
+}
+
+/**
+ * Does base setup by creating databases
+ */
+export async function setup(destroyDb: boolean = true) {
+  const db = getKnex(Object.assign({}, getConfig(), { debug: false }))
+  await setupDb(db, destroyDb)
 }
 
 /**
@@ -484,6 +497,40 @@ export function getDb(eventEmitter?: Emitter<any>, config?: DatabaseConfig) {
   const test = getActiveTest()
   test?.cleanup(() => {
     return db.manager.closeAll()
+  })
+
+  return db
+}
+
+/**
+ * Returns a Database instance with two connections backed by different
+ * databases (SQLite for primary, PostgreSQL for secondary).
+ * Both databases are set up with all test tables.
+ */
+export async function getMultiConnectionDb() {
+  const primaryConfig = getConfigForDb('sqlite')
+  const secondaryConfig = getConfigForDb('pg')
+
+  const primaryKnex = getKnex(Object.assign({}, primaryConfig, { debug: false }))
+  const secondaryKnex = getKnex(Object.assign({}, secondaryConfig, { debug: false }))
+  await setupDb(primaryKnex)
+  await setupDb(secondaryKnex)
+
+  const db = new Database(
+    {
+      connection: 'primary',
+      connections: {
+        primary: primaryConfig,
+        secondary: secondaryConfig,
+      },
+    },
+    logger,
+    createEmitter()
+  )
+
+  const test = getActiveTest()
+  test?.cleanup(async () => {
+    await db.manager.closeAll()
   })
 
   return db

--- a/test/bindings/transformer.spec.ts
+++ b/test/bindings/transformer.spec.ts
@@ -99,7 +99,7 @@ test.group('Transformer | withCount | HasMany', (group) => {
         { user_id: 2, title: 'Adonis 102' },
       ])
 
-    const users = await User.query().withCount('posts')
+    const users = await User.query().orderBy('id', 'asc').withCount('posts')
     const result = await serializer.serialize(UserTransformer.transform(users))
 
     assert.lengthOf(result, 2)

--- a/test/test_utils.spec.ts
+++ b/test/test_utils.spec.ts
@@ -20,11 +20,15 @@ import Rollback from '../commands/migration/rollback.js'
 import { AppFactory } from '@adonisjs/core/factories/app'
 import { type ApplicationService } from '@adonisjs/core/types'
 import { DatabaseTestUtils } from '../src/test_utils/database.js'
+import { column } from '../src/orm/decorators/index.js'
 import {
   cleanupSchemaArtifacts,
   cleanupTestDatabase,
   createMigrationFile,
+  getBaseModel,
   getDb,
+  ormAdapter,
+  resetTables,
   setup,
   supportsSchemaDump,
 } from '../test-helpers/index.js'
@@ -461,4 +465,307 @@ test.group('Database Test Utils', (group) => {
       ]
     )
   }).skip(!supportsSchemaDump, 'Schema dumps are not supported for the current database dialect')
+})
+
+test.group('Database Test Utils | Assertions', (group) => {
+  group.each.disableTimeout()
+
+  group.each.setup(async () => {
+    await setup()
+    return async () => await resetTables()
+  })
+
+  test('assertHas should pass when matching rows exist', async () => {
+    const db = getDb()
+    await db.table('users').insert({ username: 'jul', email: 'jul@adonisjs.com' })
+
+    const app = new AppFactory().create(
+      new URL('./', import.meta.url),
+      () => {}
+    ) as ApplicationService
+    await app.init()
+    app.container.bind('lucid.db', () => db)
+
+    const dbTestUtils = new DatabaseTestUtils(app)
+    await dbTestUtils.assertHas('users', { username: 'jul' })
+  })
+
+  test('assertHas should fail when no matching rows exist', async () => {
+    const db = getDb()
+    const app = new AppFactory().create(
+      new URL('./', import.meta.url),
+      () => {}
+    ) as ApplicationService
+    await app.init()
+    app.container.bind('lucid.db', () => db)
+
+    const dbTestUtils = new DatabaseTestUtils(app)
+    await dbTestUtils.assertHas('users', { username: 'nonexistent' })
+  }).throws(
+    `Expected table 'users' to have rows matching {"username":"nonexistent"}, but none were found`
+  )
+
+  test('assertHas should pass when matching exact count', async () => {
+    const db = getDb()
+    await db.table('users').multiInsert([
+      { username: 'jul', email: 'jul@adonisjs.com', points: 10 },
+      { username: 'romain', email: 'romain@adonisjs.com', points: 10 },
+    ])
+
+    const app = new AppFactory().create(
+      new URL('./', import.meta.url),
+      () => {}
+    ) as ApplicationService
+    await app.init()
+    app.container.bind('lucid.db', () => db)
+
+    const dbTestUtils = new DatabaseTestUtils(app)
+    await dbTestUtils.assertHas('users', { points: 10 }, 2)
+  })
+
+  test('assertHas should fail when count does not match', async () => {
+    const db = getDb()
+    await db.table('users').insert({ username: 'jul', email: 'jul@adonisjs.com', points: 10 })
+
+    const app = new AppFactory().create(
+      new URL('./', import.meta.url),
+      () => {}
+    ) as ApplicationService
+    await app.init()
+    app.container.bind('lucid.db', () => db)
+
+    const dbTestUtils = new DatabaseTestUtils(app)
+    await dbTestUtils.assertHas('users', { points: 10 }, 5)
+  }).throws(`Expected table 'users' to have 5 rows matching {"points":10}, but found 1`)
+
+  test('assertMissing should pass when no matching rows exist', async () => {
+    const db = getDb()
+    const app = new AppFactory().create(
+      new URL('./', import.meta.url),
+      () => {}
+    ) as ApplicationService
+    await app.init()
+    app.container.bind('lucid.db', () => db)
+
+    const dbTestUtils = new DatabaseTestUtils(app)
+    await dbTestUtils.assertMissing('users', { username: 'jul' })
+  })
+
+  test('assertMissing should fail when matching rows exist', async () => {
+    const db = getDb()
+    await db.table('users').insert({ username: 'jul', email: 'jul@adonisjs.com' })
+
+    const app = new AppFactory().create(
+      new URL('./', import.meta.url),
+      () => {}
+    ) as ApplicationService
+    await app.init()
+    app.container.bind('lucid.db', () => db)
+
+    const dbTestUtils = new DatabaseTestUtils(app)
+    await dbTestUtils.assertMissing('users', { username: 'jul' })
+  }).throws(`Expected table 'users' to have no rows matching {"username":"jul"}, but found 1`)
+
+  test('assertCount should pass with correct count', async () => {
+    const db = getDb()
+    await db.table('users').multiInsert([
+      { username: 'jul', email: 'jul@adonisjs.com' },
+      { username: 'romain', email: 'romain@adonisjs.com' },
+    ])
+
+    const app = new AppFactory().create(
+      new URL('./', import.meta.url),
+      () => {}
+    ) as ApplicationService
+    await app.init()
+    app.container.bind('lucid.db', () => db)
+
+    const dbTestUtils = new DatabaseTestUtils(app)
+    await dbTestUtils.assertCount('users', 2)
+  })
+
+  test('assertCount should fail with incorrect count', async () => {
+    const db = getDb()
+    await db.table('users').insert({ username: 'jul', email: 'jul@adonisjs.com' })
+
+    const app = new AppFactory().create(
+      new URL('./', import.meta.url),
+      () => {}
+    ) as ApplicationService
+    await app.init()
+    app.container.bind('lucid.db', () => db)
+
+    const dbTestUtils = new DatabaseTestUtils(app)
+    await dbTestUtils.assertCount('users', 5)
+  }).throws("Expected table 'users' to have 5 rows, but found 1")
+
+  test('assertEmpty should pass on empty table', async () => {
+    const db = getDb()
+    const app = new AppFactory().create(
+      new URL('./', import.meta.url),
+      () => {}
+    ) as ApplicationService
+    await app.init()
+    app.container.bind('lucid.db', () => db)
+
+    const dbTestUtils = new DatabaseTestUtils(app)
+    await dbTestUtils.assertEmpty('users')
+  })
+
+  test('assertEmpty should fail on non-empty table', async () => {
+    const db = getDb()
+    await db.table('users').insert({ username: 'jul', email: 'jul@adonisjs.com' })
+
+    const app = new AppFactory().create(
+      new URL('./', import.meta.url),
+      () => {}
+    ) as ApplicationService
+    await app.init()
+    app.container.bind('lucid.db', () => db)
+
+    const dbTestUtils = new DatabaseTestUtils(app)
+    await dbTestUtils.assertEmpty('users')
+  }).throws("Expected table 'users' to have 0 rows, but found 1")
+
+  test('assertModelExists should pass when model exists in db', async () => {
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    class User extends BaseModel {
+      static table = 'users'
+
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare username: string
+
+      @column()
+      declare email: string
+    }
+
+    const user = new User()
+    user.fill({ username: 'jul', email: 'jul@adonisjs.com' })
+    await user.save()
+
+    const app = new AppFactory().create(
+      new URL('./', import.meta.url),
+      () => {}
+    ) as ApplicationService
+    await app.init()
+    app.container.bind('lucid.db', () => db)
+
+    const dbTestUtils = new DatabaseTestUtils(app)
+    await dbTestUtils.assertModelExists(user)
+  })
+
+  test('assertModelExists should fail when model does not exist in db', async ({ assert }) => {
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    class User extends BaseModel {
+      static table = 'users'
+
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare username: string
+
+      @column()
+      declare email: string
+    }
+
+    const user = new User()
+    user.fill({ username: 'jul', email: 'jul@adonisjs.com' })
+    await user.save()
+
+    const primaryKey = user.$primaryKeyValue
+    await user.delete()
+
+    const app = new AppFactory().create(
+      new URL('./', import.meta.url),
+      () => {}
+    ) as ApplicationService
+    await app.init()
+    app.container.bind('lucid.db', () => db)
+
+    const dbTestUtils = new DatabaseTestUtils(app)
+    await assert.rejects(
+      () => dbTestUtils.assertModelExists(user),
+      `Expected 'User' model with primary key ${primaryKey} to exist, but it was not found`
+    )
+  })
+
+  test('assertModelMissing should pass when model does not exist in db', async () => {
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    class User extends BaseModel {
+      static table = 'users'
+
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare username: string
+
+      @column()
+      declare email: string
+    }
+
+    const user = new User()
+    user.fill({ username: 'jul', email: 'jul@adonisjs.com' })
+    await user.save()
+    await user.delete()
+
+    const app = new AppFactory().create(
+      new URL('./', import.meta.url),
+      () => {}
+    ) as ApplicationService
+    await app.init()
+    app.container.bind('lucid.db', () => db)
+
+    const dbTestUtils = new DatabaseTestUtils(app)
+    await dbTestUtils.assertModelMissing(user)
+  })
+
+  test('assertModelMissing should fail when model still exists in db', async ({ assert }) => {
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    class User extends BaseModel {
+      static table = 'users'
+
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare username: string
+
+      @column()
+      declare email: string
+    }
+
+    const user = new User()
+    user.fill({ username: 'jul', email: 'jul@adonisjs.com' })
+    await user.save()
+
+    const app = new AppFactory().create(
+      new URL('./', import.meta.url),
+      () => {}
+    ) as ApplicationService
+    await app.init()
+    app.container.bind('lucid.db', () => db)
+
+    const dbTestUtils = new DatabaseTestUtils(app)
+    await assert.rejects(
+      () => dbTestUtils.assertModelMissing(user),
+      `Expected 'User' model with primary key ${user.$primaryKeyValue} to not exist, but it was found`
+    )
+  })
 })

--- a/test/test_utils.spec.ts
+++ b/test/test_utils.spec.ts
@@ -20,6 +20,7 @@ import Rollback from '../commands/migration/rollback.js'
 import { AppFactory } from '@adonisjs/core/factories/app'
 import { type ApplicationService } from '@adonisjs/core/types'
 import { DatabaseTestUtils } from '../src/test_utils/database.js'
+import { DatabaseTestAssertions } from '../src/test_utils/assertions.js'
 import { column } from '../src/orm/decorators/index.js'
 import {
   cleanupSchemaArtifacts,
@@ -467,7 +468,7 @@ test.group('Database Test Utils', (group) => {
   }).skip(!supportsSchemaDump, 'Schema dumps are not supported for the current database dialect')
 })
 
-test.group('Database Test Utils | Assertions', (group) => {
+test.group('Database Test Assertions', (group) => {
   group.each.disableTimeout()
 
   group.each.setup(async () => {
@@ -486,8 +487,8 @@ test.group('Database Test Utils | Assertions', (group) => {
     await app.init()
     app.container.bind('lucid.db', () => db)
 
-    const dbTestUtils = new DatabaseTestUtils(app)
-    await dbTestUtils.assertHas('users', { username: 'jul' })
+    const dbAssertions = new DatabaseTestAssertions(app)
+    await dbAssertions.assertHas('users', { username: 'jul' })
   })
 
   test('assertHas should fail when no matching rows exist', async () => {
@@ -499,8 +500,8 @@ test.group('Database Test Utils | Assertions', (group) => {
     await app.init()
     app.container.bind('lucid.db', () => db)
 
-    const dbTestUtils = new DatabaseTestUtils(app)
-    await dbTestUtils.assertHas('users', { username: 'nonexistent' })
+    const dbAssertions = new DatabaseTestAssertions(app)
+    await dbAssertions.assertHas('users', { username: 'nonexistent' })
   }).throws(
     `Expected table 'users' to have rows matching {"username":"nonexistent"}, but none were found`
   )
@@ -519,8 +520,8 @@ test.group('Database Test Utils | Assertions', (group) => {
     await app.init()
     app.container.bind('lucid.db', () => db)
 
-    const dbTestUtils = new DatabaseTestUtils(app)
-    await dbTestUtils.assertHas('users', { points: 10 }, 2)
+    const dbAssertions = new DatabaseTestAssertions(app)
+    await dbAssertions.assertHas('users', { points: 10 }, 2)
   })
 
   test('assertHas should fail when count does not match', async () => {
@@ -534,8 +535,8 @@ test.group('Database Test Utils | Assertions', (group) => {
     await app.init()
     app.container.bind('lucid.db', () => db)
 
-    const dbTestUtils = new DatabaseTestUtils(app)
-    await dbTestUtils.assertHas('users', { points: 10 }, 5)
+    const dbAssertions = new DatabaseTestAssertions(app)
+    await dbAssertions.assertHas('users', { points: 10 }, 5)
   }).throws(`Expected table 'users' to have 5 rows matching {"points":10}, but found 1`)
 
   test('assertMissing should pass when no matching rows exist', async () => {
@@ -547,8 +548,8 @@ test.group('Database Test Utils | Assertions', (group) => {
     await app.init()
     app.container.bind('lucid.db', () => db)
 
-    const dbTestUtils = new DatabaseTestUtils(app)
-    await dbTestUtils.assertMissing('users', { username: 'jul' })
+    const dbAssertions = new DatabaseTestAssertions(app)
+    await dbAssertions.assertMissing('users', { username: 'jul' })
   })
 
   test('assertMissing should fail when matching rows exist', async () => {
@@ -562,8 +563,8 @@ test.group('Database Test Utils | Assertions', (group) => {
     await app.init()
     app.container.bind('lucid.db', () => db)
 
-    const dbTestUtils = new DatabaseTestUtils(app)
-    await dbTestUtils.assertMissing('users', { username: 'jul' })
+    const dbAssertions = new DatabaseTestAssertions(app)
+    await dbAssertions.assertMissing('users', { username: 'jul' })
   }).throws(`Expected table 'users' to have no rows matching {"username":"jul"}, but found 1`)
 
   test('assertCount should pass with correct count', async () => {
@@ -580,8 +581,8 @@ test.group('Database Test Utils | Assertions', (group) => {
     await app.init()
     app.container.bind('lucid.db', () => db)
 
-    const dbTestUtils = new DatabaseTestUtils(app)
-    await dbTestUtils.assertCount('users', 2)
+    const dbAssertions = new DatabaseTestAssertions(app)
+    await dbAssertions.assertCount('users', 2)
   })
 
   test('assertCount should fail with incorrect count', async () => {
@@ -595,8 +596,8 @@ test.group('Database Test Utils | Assertions', (group) => {
     await app.init()
     app.container.bind('lucid.db', () => db)
 
-    const dbTestUtils = new DatabaseTestUtils(app)
-    await dbTestUtils.assertCount('users', 5)
+    const dbAssertions = new DatabaseTestAssertions(app)
+    await dbAssertions.assertCount('users', 5)
   }).throws("Expected table 'users' to have 5 rows, but found 1")
 
   test('assertEmpty should pass on empty table', async () => {
@@ -608,8 +609,8 @@ test.group('Database Test Utils | Assertions', (group) => {
     await app.init()
     app.container.bind('lucid.db', () => db)
 
-    const dbTestUtils = new DatabaseTestUtils(app)
-    await dbTestUtils.assertEmpty('users')
+    const dbAssertions = new DatabaseTestAssertions(app)
+    await dbAssertions.assertEmpty('users')
   })
 
   test('assertEmpty should fail on non-empty table', async () => {
@@ -623,8 +624,8 @@ test.group('Database Test Utils | Assertions', (group) => {
     await app.init()
     app.container.bind('lucid.db', () => db)
 
-    const dbTestUtils = new DatabaseTestUtils(app)
-    await dbTestUtils.assertEmpty('users')
+    const dbAssertions = new DatabaseTestAssertions(app)
+    await dbAssertions.assertEmpty('users')
   }).throws("Expected table 'users' to have 0 rows, but found 1")
 
   test('assertModelExists should pass when model exists in db', async () => {
@@ -656,8 +657,8 @@ test.group('Database Test Utils | Assertions', (group) => {
     await app.init()
     app.container.bind('lucid.db', () => db)
 
-    const dbTestUtils = new DatabaseTestUtils(app)
-    await dbTestUtils.assertModelExists(user)
+    const dbAssertions = new DatabaseTestAssertions(app)
+    await dbAssertions.assertModelExists(user)
   })
 
   test('assertModelExists should fail when model does not exist in db', async ({ assert }) => {
@@ -692,9 +693,9 @@ test.group('Database Test Utils | Assertions', (group) => {
     await app.init()
     app.container.bind('lucid.db', () => db)
 
-    const dbTestUtils = new DatabaseTestUtils(app)
+    const dbAssertions = new DatabaseTestAssertions(app)
     await assert.rejects(
-      () => dbTestUtils.assertModelExists(user),
+      () => dbAssertions.assertModelExists(user),
       `Expected 'User' model with primary key ${primaryKey} to exist, but it was not found`
     )
   })
@@ -729,8 +730,8 @@ test.group('Database Test Utils | Assertions', (group) => {
     await app.init()
     app.container.bind('lucid.db', () => db)
 
-    const dbTestUtils = new DatabaseTestUtils(app)
-    await dbTestUtils.assertModelMissing(user)
+    const dbAssertions = new DatabaseTestAssertions(app)
+    await dbAssertions.assertModelMissing(user)
   })
 
   test('assertModelMissing should fail when model still exists in db', async ({ assert }) => {
@@ -762,9 +763,9 @@ test.group('Database Test Utils | Assertions', (group) => {
     await app.init()
     app.container.bind('lucid.db', () => db)
 
-    const dbTestUtils = new DatabaseTestUtils(app)
+    const dbAssertions = new DatabaseTestAssertions(app)
     await assert.rejects(
-      () => dbTestUtils.assertModelMissing(user),
+      () => dbAssertions.assertModelMissing(user),
       `Expected 'User' model with primary key ${user.$primaryKeyValue} to not exist, but it was found`
     )
   })

--- a/test/test_utils.spec.ts
+++ b/test/test_utils.spec.ts
@@ -471,6 +471,7 @@ test.group('Database Test Utils', (group) => {
 
 test.group('Database Test Assertions', (group) => {
   group.each.disableTimeout()
+  group.each.skip(process.env.DB !== 'pg')
 
   group.each.setup(async () => {
     await setup()

--- a/test/test_utils.spec.ts
+++ b/test/test_utils.spec.ts
@@ -469,540 +469,540 @@ test.group('Database Test Utils', (group) => {
   }).skip(!supportsSchemaDump, 'Schema dumps are not supported for the current database dialect')
 })
 
-test.group('Database Test Assertions', (group) => {
-  group.each.disableTimeout()
-  group.each.skip(process.env.DB !== 'pg')
+if (process.env.DB === 'pg') {
+  test.group('Database Test Assertions', (group) => {
+    group.each.disableTimeout()
+    group.each.setup(async () => {
+      await setup()
+      return async () => await resetTables()
+    })
 
-  group.each.setup(async () => {
-    await setup()
-    return async () => await resetTables()
-  })
+    test('assertHas should pass when matching rows exist', async () => {
+      const db = getDb()
+      await db.table('users').insert({ username: 'jul', email: 'jul@adonisjs.com' })
 
-  test('assertHas should pass when matching rows exist', async () => {
-    const db = getDb()
-    await db.table('users').insert({ username: 'jul', email: 'jul@adonisjs.com' })
+      const app = new AppFactory().create(
+        new URL('./', import.meta.url),
+        () => {}
+      ) as ApplicationService
+      await app.init()
+      app.container.bind('lucid.db', () => db)
 
-    const app = new AppFactory().create(
-      new URL('./', import.meta.url),
-      () => {}
-    ) as ApplicationService
-    await app.init()
-    app.container.bind('lucid.db', () => db)
+      const dbAssertions = new DatabaseTestAssertions(app)
+      await dbAssertions.assertHas('users', { username: 'jul' })
+    })
 
-    const dbAssertions = new DatabaseTestAssertions(app)
-    await dbAssertions.assertHas('users', { username: 'jul' })
-  })
+    test('assertHas should fail when no matching rows exist', async () => {
+      const db = getDb()
+      const app = new AppFactory().create(
+        new URL('./', import.meta.url),
+        () => {}
+      ) as ApplicationService
+      await app.init()
+      app.container.bind('lucid.db', () => db)
 
-  test('assertHas should fail when no matching rows exist', async () => {
-    const db = getDb()
-    const app = new AppFactory().create(
-      new URL('./', import.meta.url),
-      () => {}
-    ) as ApplicationService
-    await app.init()
-    app.container.bind('lucid.db', () => db)
-
-    const dbAssertions = new DatabaseTestAssertions(app)
-    await dbAssertions.assertHas('users', { username: 'nonexistent' })
-  }).throws(
-    `Expected table 'users' to have rows matching {"username":"nonexistent"}, but none were found`
-  )
-
-  test('assertHas should pass when matching exact count', async () => {
-    const db = getDb()
-    await db.table('users').multiInsert([
-      { username: 'jul', email: 'jul@adonisjs.com', points: 10 },
-      { username: 'romain', email: 'romain@adonisjs.com', points: 10 },
-    ])
-
-    const app = new AppFactory().create(
-      new URL('./', import.meta.url),
-      () => {}
-    ) as ApplicationService
-    await app.init()
-    app.container.bind('lucid.db', () => db)
-
-    const dbAssertions = new DatabaseTestAssertions(app)
-    await dbAssertions.assertHas('users', { points: 10 }, 2)
-  })
-
-  test('assertHas should fail when count does not match', async () => {
-    const db = getDb()
-    await db.table('users').insert({ username: 'jul', email: 'jul@adonisjs.com', points: 10 })
-
-    const app = new AppFactory().create(
-      new URL('./', import.meta.url),
-      () => {}
-    ) as ApplicationService
-    await app.init()
-    app.container.bind('lucid.db', () => db)
-
-    const dbAssertions = new DatabaseTestAssertions(app)
-    await dbAssertions.assertHas('users', { points: 10 }, 5)
-  }).throws(`Expected table 'users' to have 5 rows matching {"points":10}, but found 1`)
-
-  test('assertMissing should pass when no matching rows exist', async () => {
-    const db = getDb()
-    const app = new AppFactory().create(
-      new URL('./', import.meta.url),
-      () => {}
-    ) as ApplicationService
-    await app.init()
-    app.container.bind('lucid.db', () => db)
-
-    const dbAssertions = new DatabaseTestAssertions(app)
-    await dbAssertions.assertMissing('users', { username: 'jul' })
-  })
-
-  test('assertMissing should fail when matching rows exist', async () => {
-    const db = getDb()
-    await db.table('users').insert({ username: 'jul', email: 'jul@adonisjs.com' })
-
-    const app = new AppFactory().create(
-      new URL('./', import.meta.url),
-      () => {}
-    ) as ApplicationService
-    await app.init()
-    app.container.bind('lucid.db', () => db)
-
-    const dbAssertions = new DatabaseTestAssertions(app)
-    await dbAssertions.assertMissing('users', { username: 'jul' })
-  }).throws(`Expected table 'users' to have no rows matching {"username":"jul"}, but found 1`)
-
-  test('assertCount should pass with correct count', async () => {
-    const db = getDb()
-    await db.table('users').multiInsert([
-      { username: 'jul', email: 'jul@adonisjs.com' },
-      { username: 'romain', email: 'romain@adonisjs.com' },
-    ])
-
-    const app = new AppFactory().create(
-      new URL('./', import.meta.url),
-      () => {}
-    ) as ApplicationService
-    await app.init()
-    app.container.bind('lucid.db', () => db)
-
-    const dbAssertions = new DatabaseTestAssertions(app)
-    await dbAssertions.assertCount('users', 2)
-  })
-
-  test('assertCount should fail with incorrect count', async () => {
-    const db = getDb()
-    await db.table('users').insert({ username: 'jul', email: 'jul@adonisjs.com' })
-
-    const app = new AppFactory().create(
-      new URL('./', import.meta.url),
-      () => {}
-    ) as ApplicationService
-    await app.init()
-    app.container.bind('lucid.db', () => db)
-
-    const dbAssertions = new DatabaseTestAssertions(app)
-    await dbAssertions.assertCount('users', 5)
-  }).throws("Expected table 'users' to have 5 rows, but found 1")
-
-  test('assertEmpty should pass on empty table', async () => {
-    const db = getDb()
-    const app = new AppFactory().create(
-      new URL('./', import.meta.url),
-      () => {}
-    ) as ApplicationService
-    await app.init()
-    app.container.bind('lucid.db', () => db)
-
-    const dbAssertions = new DatabaseTestAssertions(app)
-    await dbAssertions.assertEmpty('users')
-  })
-
-  test('assertEmpty should fail on non-empty table', async () => {
-    const db = getDb()
-    await db.table('users').insert({ username: 'jul', email: 'jul@adonisjs.com' })
-
-    const app = new AppFactory().create(
-      new URL('./', import.meta.url),
-      () => {}
-    ) as ApplicationService
-    await app.init()
-    app.container.bind('lucid.db', () => db)
-
-    const dbAssertions = new DatabaseTestAssertions(app)
-    await dbAssertions.assertEmpty('users')
-  }).throws("Expected table 'users' to have 0 rows, but found 1")
-
-  test('assertModelExists should pass when model exists in db', async () => {
-    const db = getDb()
-    const adapter = ormAdapter(db)
-    const BaseModel = getBaseModel(adapter)
-
-    class User extends BaseModel {
-      static table = 'users'
-
-      @column({ isPrimary: true })
-      declare id: number
-
-      @column()
-      declare username: string
-
-      @column()
-      declare email: string
-    }
-
-    const user = new User()
-    user.fill({ username: 'jul', email: 'jul@adonisjs.com' })
-    await user.save()
-
-    const app = new AppFactory().create(
-      new URL('./', import.meta.url),
-      () => {}
-    ) as ApplicationService
-    await app.init()
-    app.container.bind('lucid.db', () => db)
-
-    const dbAssertions = new DatabaseTestAssertions(app)
-    await dbAssertions.assertModelExists(user)
-  })
-
-  test('assertModelExists should fail when model does not exist in db', async ({ assert }) => {
-    const db = getDb()
-    const adapter = ormAdapter(db)
-    const BaseModel = getBaseModel(adapter)
-
-    class User extends BaseModel {
-      static table = 'users'
-
-      @column({ isPrimary: true })
-      declare id: number
-
-      @column()
-      declare username: string
-
-      @column()
-      declare email: string
-    }
-
-    const user = new User()
-    user.fill({ username: 'jul', email: 'jul@adonisjs.com' })
-    await user.save()
-
-    const primaryKey = user.$primaryKeyValue
-    await user.delete()
-
-    const app = new AppFactory().create(
-      new URL('./', import.meta.url),
-      () => {}
-    ) as ApplicationService
-    await app.init()
-    app.container.bind('lucid.db', () => db)
-
-    const dbAssertions = new DatabaseTestAssertions(app)
-    await assert.rejects(
-      () => dbAssertions.assertModelExists(user),
-      `Expected 'User' model with primary key ${primaryKey} to exist, but it was not found`
+      const dbAssertions = new DatabaseTestAssertions(app)
+      await dbAssertions.assertHas('users', { username: 'nonexistent' })
+    }).throws(
+      `Expected table 'users' to have rows matching {"username":"nonexistent"}, but none were found`
     )
-  })
 
-  test('assertModelMissing should pass when model does not exist in db', async () => {
-    const db = getDb()
-    const adapter = ormAdapter(db)
-    const BaseModel = getBaseModel(adapter)
+    test('assertHas should pass when matching exact count', async () => {
+      const db = getDb()
+      await db.table('users').multiInsert([
+        { username: 'jul', email: 'jul@adonisjs.com', points: 10 },
+        { username: 'romain', email: 'romain@adonisjs.com', points: 10 },
+      ])
 
-    class User extends BaseModel {
-      static table = 'users'
+      const app = new AppFactory().create(
+        new URL('./', import.meta.url),
+        () => {}
+      ) as ApplicationService
+      await app.init()
+      app.container.bind('lucid.db', () => db)
 
-      @column({ isPrimary: true })
-      declare id: number
+      const dbAssertions = new DatabaseTestAssertions(app)
+      await dbAssertions.assertHas('users', { points: 10 }, 2)
+    })
 
-      @column()
-      declare username: string
+    test('assertHas should fail when count does not match', async () => {
+      const db = getDb()
+      await db.table('users').insert({ username: 'jul', email: 'jul@adonisjs.com', points: 10 })
 
-      @column()
-      declare email: string
-    }
+      const app = new AppFactory().create(
+        new URL('./', import.meta.url),
+        () => {}
+      ) as ApplicationService
+      await app.init()
+      app.container.bind('lucid.db', () => db)
 
-    const user = new User()
-    user.fill({ username: 'jul', email: 'jul@adonisjs.com' })
-    await user.save()
-    await user.delete()
+      const dbAssertions = new DatabaseTestAssertions(app)
+      await dbAssertions.assertHas('users', { points: 10 }, 5)
+    }).throws(`Expected table 'users' to have 5 rows matching {"points":10}, but found 1`)
 
-    const app = new AppFactory().create(
-      new URL('./', import.meta.url),
-      () => {}
-    ) as ApplicationService
-    await app.init()
-    app.container.bind('lucid.db', () => db)
+    test('assertMissing should pass when no matching rows exist', async () => {
+      const db = getDb()
+      const app = new AppFactory().create(
+        new URL('./', import.meta.url),
+        () => {}
+      ) as ApplicationService
+      await app.init()
+      app.container.bind('lucid.db', () => db)
 
-    const dbAssertions = new DatabaseTestAssertions(app)
-    await dbAssertions.assertModelMissing(user)
-  })
+      const dbAssertions = new DatabaseTestAssertions(app)
+      await dbAssertions.assertMissing('users', { username: 'jul' })
+    })
 
-  test('assertModelExists should respect beforeFind hooks', async ({ assert }) => {
-    const db = getDb()
-    const adapter = ormAdapter(db)
-    const BaseModel = getBaseModel(adapter)
+    test('assertMissing should fail when matching rows exist', async () => {
+      const db = getDb()
+      await db.table('users').insert({ username: 'jul', email: 'jul@adonisjs.com' })
 
-    class User extends BaseModel {
-      static table = 'users'
+      const app = new AppFactory().create(
+        new URL('./', import.meta.url),
+        () => {}
+      ) as ApplicationService
+      await app.init()
+      app.container.bind('lucid.db', () => db)
 
-      @column({ isPrimary: true })
-      declare id: number
+      const dbAssertions = new DatabaseTestAssertions(app)
+      await dbAssertions.assertMissing('users', { username: 'jul' })
+    }).throws(`Expected table 'users' to have no rows matching {"username":"jul"}, but found 1`)
 
-      @column()
-      declare username: string
+    test('assertCount should pass with correct count', async () => {
+      const db = getDb()
+      await db.table('users').multiInsert([
+        { username: 'jul', email: 'jul@adonisjs.com' },
+        { username: 'romain', email: 'romain@adonisjs.com' },
+      ])
 
-      @column()
-      declare email: string
+      const app = new AppFactory().create(
+        new URL('./', import.meta.url),
+        () => {}
+      ) as ApplicationService
+      await app.init()
+      app.container.bind('lucid.db', () => db)
 
-      @column()
-      declare points: number
+      const dbAssertions = new DatabaseTestAssertions(app)
+      await dbAssertions.assertCount('users', 2)
+    })
 
-      @beforeFind()
-      static applyActiveFilter(query: any) {
-        query.where('points', '>', 0)
+    test('assertCount should fail with incorrect count', async () => {
+      const db = getDb()
+      await db.table('users').insert({ username: 'jul', email: 'jul@adonisjs.com' })
+
+      const app = new AppFactory().create(
+        new URL('./', import.meta.url),
+        () => {}
+      ) as ApplicationService
+      await app.init()
+      app.container.bind('lucid.db', () => db)
+
+      const dbAssertions = new DatabaseTestAssertions(app)
+      await dbAssertions.assertCount('users', 5)
+    }).throws("Expected table 'users' to have 5 rows, but found 1")
+
+    test('assertEmpty should pass on empty table', async () => {
+      const db = getDb()
+      const app = new AppFactory().create(
+        new URL('./', import.meta.url),
+        () => {}
+      ) as ApplicationService
+      await app.init()
+      app.container.bind('lucid.db', () => db)
+
+      const dbAssertions = new DatabaseTestAssertions(app)
+      await dbAssertions.assertEmpty('users')
+    })
+
+    test('assertEmpty should fail on non-empty table', async () => {
+      const db = getDb()
+      await db.table('users').insert({ username: 'jul', email: 'jul@adonisjs.com' })
+
+      const app = new AppFactory().create(
+        new URL('./', import.meta.url),
+        () => {}
+      ) as ApplicationService
+      await app.init()
+      app.container.bind('lucid.db', () => db)
+
+      const dbAssertions = new DatabaseTestAssertions(app)
+      await dbAssertions.assertEmpty('users')
+    }).throws("Expected table 'users' to have 0 rows, but found 1")
+
+    test('assertModelExists should pass when model exists in db', async () => {
+      const db = getDb()
+      const adapter = ormAdapter(db)
+      const BaseModel = getBaseModel(adapter)
+
+      class User extends BaseModel {
+        static table = 'users'
+
+        @column({ isPrimary: true })
+        declare id: number
+
+        @column()
+        declare username: string
+
+        @column()
+        declare email: string
       }
-    }
 
-    const user = new User()
-    user.fill({ username: 'jul', email: 'jul@adonisjs.com', points: 0 })
-    await user.save()
+      const user = new User()
+      user.fill({ username: 'jul', email: 'jul@adonisjs.com' })
+      await user.save()
 
-    const app = new AppFactory().create(
-      new URL('./', import.meta.url),
-      () => {}
-    ) as ApplicationService
-    await app.init()
-    app.container.bind('lucid.db', () => db)
+      const app = new AppFactory().create(
+        new URL('./', import.meta.url),
+        () => {}
+      ) as ApplicationService
+      await app.init()
+      app.container.bind('lucid.db', () => db)
 
-    const dbAssertions = new DatabaseTestAssertions(app)
+      const dbAssertions = new DatabaseTestAssertions(app)
+      await dbAssertions.assertModelExists(user)
+    })
 
-    await assert.rejects(
-      () => dbAssertions.assertModelExists(user),
-      `Expected 'User' model with primary key ${user.$primaryKeyValue} to exist, but it was not found`
-    )
-  })
+    test('assertModelExists should fail when model does not exist in db', async ({ assert }) => {
+      const db = getDb()
+      const adapter = ormAdapter(db)
+      const BaseModel = getBaseModel(adapter)
 
-  test('assertModelMissing should respect beforeFind hooks', async () => {
-    const db = getDb()
-    const adapter = ormAdapter(db)
-    const BaseModel = getBaseModel(adapter)
+      class User extends BaseModel {
+        static table = 'users'
 
-    class User extends BaseModel {
-      static table = 'users'
+        @column({ isPrimary: true })
+        declare id: number
 
-      @column({ isPrimary: true })
-      declare id: number
+        @column()
+        declare username: string
 
-      @column()
-      declare username: string
-
-      @column()
-      declare email: string
-
-      @column()
-      declare points: number
-
-      @beforeFind()
-      static applyActiveFilter(query: any) {
-        query.where('points', '>', 0)
+        @column()
+        declare email: string
       }
-    }
 
-    const user = new User()
-    user.fill({ username: 'jul', email: 'jul@adonisjs.com', points: 0 })
-    await user.save()
+      const user = new User()
+      user.fill({ username: 'jul', email: 'jul@adonisjs.com' })
+      await user.save()
 
-    const app = new AppFactory().create(
-      new URL('./', import.meta.url),
-      () => {}
-    ) as ApplicationService
-    await app.init()
-    app.container.bind('lucid.db', () => db)
+      const primaryKey = user.$primaryKeyValue
+      await user.delete()
 
-    const dbAssertions = new DatabaseTestAssertions(app)
-    await dbAssertions.assertModelMissing(user)
+      const app = new AppFactory().create(
+        new URL('./', import.meta.url),
+        () => {}
+      ) as ApplicationService
+      await app.init()
+      app.container.bind('lucid.db', () => db)
+
+      const dbAssertions = new DatabaseTestAssertions(app)
+      await assert.rejects(
+        () => dbAssertions.assertModelExists(user),
+        `Expected 'User' model with primary key ${primaryKey} to exist, but it was not found`
+      )
+    })
+
+    test('assertModelMissing should pass when model does not exist in db', async () => {
+      const db = getDb()
+      const adapter = ormAdapter(db)
+      const BaseModel = getBaseModel(adapter)
+
+      class User extends BaseModel {
+        static table = 'users'
+
+        @column({ isPrimary: true })
+        declare id: number
+
+        @column()
+        declare username: string
+
+        @column()
+        declare email: string
+      }
+
+      const user = new User()
+      user.fill({ username: 'jul', email: 'jul@adonisjs.com' })
+      await user.save()
+      await user.delete()
+
+      const app = new AppFactory().create(
+        new URL('./', import.meta.url),
+        () => {}
+      ) as ApplicationService
+      await app.init()
+      app.container.bind('lucid.db', () => db)
+
+      const dbAssertions = new DatabaseTestAssertions(app)
+      await dbAssertions.assertModelMissing(user)
+    })
+
+    test('assertModelExists should respect beforeFind hooks', async ({ assert }) => {
+      const db = getDb()
+      const adapter = ormAdapter(db)
+      const BaseModel = getBaseModel(adapter)
+
+      class User extends BaseModel {
+        static table = 'users'
+
+        @column({ isPrimary: true })
+        declare id: number
+
+        @column()
+        declare username: string
+
+        @column()
+        declare email: string
+
+        @column()
+        declare points: number
+
+        @beforeFind()
+        static applyActiveFilter(query: any) {
+          query.where('points', '>', 0)
+        }
+      }
+
+      const user = new User()
+      user.fill({ username: 'jul', email: 'jul@adonisjs.com', points: 0 })
+      await user.save()
+
+      const app = new AppFactory().create(
+        new URL('./', import.meta.url),
+        () => {}
+      ) as ApplicationService
+      await app.init()
+      app.container.bind('lucid.db', () => db)
+
+      const dbAssertions = new DatabaseTestAssertions(app)
+
+      await assert.rejects(
+        () => dbAssertions.assertModelExists(user),
+        `Expected 'User' model with primary key ${user.$primaryKeyValue} to exist, but it was not found`
+      )
+    })
+
+    test('assertModelMissing should respect beforeFind hooks', async () => {
+      const db = getDb()
+      const adapter = ormAdapter(db)
+      const BaseModel = getBaseModel(adapter)
+
+      class User extends BaseModel {
+        static table = 'users'
+
+        @column({ isPrimary: true })
+        declare id: number
+
+        @column()
+        declare username: string
+
+        @column()
+        declare email: string
+
+        @column()
+        declare points: number
+
+        @beforeFind()
+        static applyActiveFilter(query: any) {
+          query.where('points', '>', 0)
+        }
+      }
+
+      const user = new User()
+      user.fill({ username: 'jul', email: 'jul@adonisjs.com', points: 0 })
+      await user.save()
+
+      const app = new AppFactory().create(
+        new URL('./', import.meta.url),
+        () => {}
+      ) as ApplicationService
+      await app.init()
+      app.container.bind('lucid.db', () => db)
+
+      const dbAssertions = new DatabaseTestAssertions(app)
+      await dbAssertions.assertModelMissing(user)
+    })
+
+    test('assertModelMissing should fail when model still exists in db', async ({ assert }) => {
+      const db = getDb()
+      const adapter = ormAdapter(db)
+      const BaseModel = getBaseModel(adapter)
+
+      class User extends BaseModel {
+        static table = 'users'
+
+        @column({ isPrimary: true })
+        declare id: number
+
+        @column()
+        declare username: string
+
+        @column()
+        declare email: string
+      }
+
+      const user = new User()
+      user.fill({ username: 'jul', email: 'jul@adonisjs.com' })
+      await user.save()
+
+      const app = new AppFactory().create(
+        new URL('./', import.meta.url),
+        () => {}
+      ) as ApplicationService
+      await app.init()
+      app.container.bind('lucid.db', () => db)
+
+      const dbAssertions = new DatabaseTestAssertions(app)
+      await assert.rejects(
+        () => dbAssertions.assertModelMissing(user),
+        `Expected 'User' model with primary key ${user.$primaryKeyValue} to not exist, but it was found`
+      )
+    })
   })
 
-  test('assertModelMissing should fail when model still exists in db', async ({ assert }) => {
-    const db = getDb()
-    const adapter = ormAdapter(db)
-    const BaseModel = getBaseModel(adapter)
+  test.group('Database Test Assertions | connection', (group) => {
+    group.each.disableTimeout()
 
-    class User extends BaseModel {
-      static table = 'users'
+    group.each.setup(async () => {
+      const db = await getMultiConnectionDb()
+      return async () => {
+        await db.connection('primary').from('users').del()
+        await db.connection('secondary').from('users').del()
+      }
+    })
 
-      @column({ isPrimary: true })
-      declare id: number
+    test('assertHas should query the configured connection', async ({ assert }) => {
+      const db = await getMultiConnectionDb()
+      await db
+        .connection('primary')
+        .table('users')
+        .insert({ username: 'jul', email: 'jul@adonisjs.com' })
 
-      @column()
-      declare username: string
+      const app = new AppFactory().create(
+        new URL('./', import.meta.url),
+        () => {}
+      ) as ApplicationService
+      await app.init()
+      app.container.bind('lucid.db', () => db)
 
-      @column()
-      declare email: string
-    }
+      const dbAssertions = new DatabaseTestAssertions(app)
+      await dbAssertions.connection('primary').assertHas('users', { username: 'jul' })
 
-    const user = new User()
-    user.fill({ username: 'jul', email: 'jul@adonisjs.com' })
-    await user.save()
+      await assert.rejects(
+        () => dbAssertions.connection('secondary').assertHas('users', { username: 'jul' }),
+        /Expected table 'users' to have rows matching/
+      )
+    })
 
-    const app = new AppFactory().create(
-      new URL('./', import.meta.url),
-      () => {}
-    ) as ApplicationService
-    await app.init()
-    app.container.bind('lucid.db', () => db)
+    test('assertMissing should query the configured connection', async () => {
+      const db = await getMultiConnectionDb()
+      await db
+        .connection('primary')
+        .table('users')
+        .insert({ username: 'jul', email: 'jul@adonisjs.com' })
 
-    const dbAssertions = new DatabaseTestAssertions(app)
-    await assert.rejects(
-      () => dbAssertions.assertModelMissing(user),
-      `Expected 'User' model with primary key ${user.$primaryKeyValue} to not exist, but it was found`
-    )
+      const app = new AppFactory().create(
+        new URL('./', import.meta.url),
+        () => {}
+      ) as ApplicationService
+      await app.init()
+      app.container.bind('lucid.db', () => db)
+
+      const dbAssertions = new DatabaseTestAssertions(app)
+      await dbAssertions.connection('secondary').assertMissing('users', { username: 'jul' })
+    })
+
+    test('assertCount should query the configured connection', async () => {
+      const db = await getMultiConnectionDb()
+      await db
+        .connection('primary')
+        .table('users')
+        .insert({ username: 'jul', email: 'jul@adonisjs.com' })
+
+      const app = new AppFactory().create(
+        new URL('./', import.meta.url),
+        () => {}
+      ) as ApplicationService
+      await app.init()
+      app.container.bind('lucid.db', () => db)
+
+      const dbAssertions = new DatabaseTestAssertions(app)
+      await dbAssertions.connection('primary').assertCount('users', 1)
+      await dbAssertions.connection('secondary').assertCount('users', 0)
+    })
+
+    test('assertModelExists should query the configured connection', async ({ assert }) => {
+      const db = await getMultiConnectionDb()
+      const adapter = ormAdapter(db)
+      const BaseModel = getBaseModel(adapter)
+
+      class User extends BaseModel {
+        static table = 'users'
+
+        @column({ isPrimary: true })
+        declare id: number
+
+        @column()
+        declare username: string
+
+        @column()
+        declare email: string
+      }
+
+      const user = new User()
+      user.fill({ username: 'jul', email: 'jul@adonisjs.com' })
+      await user.save()
+
+      const app = new AppFactory().create(
+        new URL('./', import.meta.url),
+        () => {}
+      ) as ApplicationService
+      await app.init()
+      app.container.bind('lucid.db', () => db)
+
+      const dbAssertions = new DatabaseTestAssertions(app)
+      await dbAssertions.connection('primary').assertModelExists(user)
+
+      await assert.rejects(
+        () => dbAssertions.connection('secondary').assertModelExists(user),
+        /Expected 'User' model with primary key .+ to exist, but it was not found/
+      )
+    })
+
+    test('assertModelMissing should query the configured connection', async ({ assert }) => {
+      const db = await getMultiConnectionDb()
+      const adapter = ormAdapter(db)
+      const BaseModel = getBaseModel(adapter)
+
+      class User extends BaseModel {
+        static table = 'users'
+
+        @column({ isPrimary: true })
+        declare id: number
+
+        @column()
+        declare username: string
+
+        @column()
+        declare email: string
+      }
+
+      const user = new User()
+      user.fill({ username: 'jul', email: 'jul@adonisjs.com' })
+      await user.save()
+
+      const app = new AppFactory().create(
+        new URL('./', import.meta.url),
+        () => {}
+      ) as ApplicationService
+      await app.init()
+      app.container.bind('lucid.db', () => db)
+
+      const dbAssertions = new DatabaseTestAssertions(app)
+      await dbAssertions.connection('secondary').assertModelMissing(user)
+
+      await assert.rejects(
+        () => dbAssertions.connection('primary').assertModelMissing(user),
+        /Expected 'User' model with primary key .+ to not exist, but it was found/
+      )
+    })
   })
-})
-
-test.group('Database Test Assertions | connection', (group) => {
-  group.each.disableTimeout()
-
-  group.each.setup(async () => {
-    const db = await getMultiConnectionDb()
-    return async () => {
-      await db.connection('primary').from('users').del()
-      await db.connection('secondary').from('users').del()
-    }
-  })
-
-  test('assertHas should query the configured connection', async ({ assert }) => {
-    const db = await getMultiConnectionDb()
-    await db
-      .connection('primary')
-      .table('users')
-      .insert({ username: 'jul', email: 'jul@adonisjs.com' })
-
-    const app = new AppFactory().create(
-      new URL('./', import.meta.url),
-      () => {}
-    ) as ApplicationService
-    await app.init()
-    app.container.bind('lucid.db', () => db)
-
-    const dbAssertions = new DatabaseTestAssertions(app)
-    await dbAssertions.connection('primary').assertHas('users', { username: 'jul' })
-
-    await assert.rejects(
-      () => dbAssertions.connection('secondary').assertHas('users', { username: 'jul' }),
-      /Expected table 'users' to have rows matching/
-    )
-  })
-
-  test('assertMissing should query the configured connection', async () => {
-    const db = await getMultiConnectionDb()
-    await db
-      .connection('primary')
-      .table('users')
-      .insert({ username: 'jul', email: 'jul@adonisjs.com' })
-
-    const app = new AppFactory().create(
-      new URL('./', import.meta.url),
-      () => {}
-    ) as ApplicationService
-    await app.init()
-    app.container.bind('lucid.db', () => db)
-
-    const dbAssertions = new DatabaseTestAssertions(app)
-    await dbAssertions.connection('secondary').assertMissing('users', { username: 'jul' })
-  })
-
-  test('assertCount should query the configured connection', async () => {
-    const db = await getMultiConnectionDb()
-    await db
-      .connection('primary')
-      .table('users')
-      .insert({ username: 'jul', email: 'jul@adonisjs.com' })
-
-    const app = new AppFactory().create(
-      new URL('./', import.meta.url),
-      () => {}
-    ) as ApplicationService
-    await app.init()
-    app.container.bind('lucid.db', () => db)
-
-    const dbAssertions = new DatabaseTestAssertions(app)
-    await dbAssertions.connection('primary').assertCount('users', 1)
-    await dbAssertions.connection('secondary').assertCount('users', 0)
-  })
-
-  test('assertModelExists should query the configured connection', async ({ assert }) => {
-    const db = await getMultiConnectionDb()
-    const adapter = ormAdapter(db)
-    const BaseModel = getBaseModel(adapter)
-
-    class User extends BaseModel {
-      static table = 'users'
-
-      @column({ isPrimary: true })
-      declare id: number
-
-      @column()
-      declare username: string
-
-      @column()
-      declare email: string
-    }
-
-    const user = new User()
-    user.fill({ username: 'jul', email: 'jul@adonisjs.com' })
-    await user.save()
-
-    const app = new AppFactory().create(
-      new URL('./', import.meta.url),
-      () => {}
-    ) as ApplicationService
-    await app.init()
-    app.container.bind('lucid.db', () => db)
-
-    const dbAssertions = new DatabaseTestAssertions(app)
-    await dbAssertions.connection('primary').assertModelExists(user)
-
-    await assert.rejects(
-      () => dbAssertions.connection('secondary').assertModelExists(user),
-      /Expected 'User' model with primary key .+ to exist, but it was not found/
-    )
-  })
-
-  test('assertModelMissing should query the configured connection', async ({ assert }) => {
-    const db = await getMultiConnectionDb()
-    const adapter = ormAdapter(db)
-    const BaseModel = getBaseModel(adapter)
-
-    class User extends BaseModel {
-      static table = 'users'
-
-      @column({ isPrimary: true })
-      declare id: number
-
-      @column()
-      declare username: string
-
-      @column()
-      declare email: string
-    }
-
-    const user = new User()
-    user.fill({ username: 'jul', email: 'jul@adonisjs.com' })
-    await user.save()
-
-    const app = new AppFactory().create(
-      new URL('./', import.meta.url),
-      () => {}
-    ) as ApplicationService
-    await app.init()
-    app.container.bind('lucid.db', () => db)
-
-    const dbAssertions = new DatabaseTestAssertions(app)
-    await dbAssertions.connection('secondary').assertModelMissing(user)
-
-    await assert.rejects(
-      () => dbAssertions.connection('primary').assertModelMissing(user),
-      /Expected 'User' model with primary key .+ to not exist, but it was found/
-    )
-  })
-})
+}

--- a/test/test_utils.spec.ts
+++ b/test/test_utils.spec.ts
@@ -871,7 +871,10 @@ test.group('Database Test Assertions | connection', (group) => {
 
   test('assertHas should query the configured connection', async ({ assert }) => {
     const db = await getMultiConnectionDb()
-    await db.connection('primary').table('users').insert({ username: 'jul', email: 'jul@adonisjs.com' })
+    await db
+      .connection('primary')
+      .table('users')
+      .insert({ username: 'jul', email: 'jul@adonisjs.com' })
 
     const app = new AppFactory().create(
       new URL('./', import.meta.url),
@@ -880,19 +883,21 @@ test.group('Database Test Assertions | connection', (group) => {
     await app.init()
     app.container.bind('lucid.db', () => db)
 
-    const primaryAssertions = new DatabaseTestAssertions(app, 'primary')
-    await primaryAssertions.assertHas('users', { username: 'jul' })
+    const dbAssertions = new DatabaseTestAssertions(app)
+    await dbAssertions.connection('primary').assertHas('users', { username: 'jul' })
 
-    const secondaryAssertions = new DatabaseTestAssertions(app, 'secondary')
     await assert.rejects(
-      () => secondaryAssertions.assertHas('users', { username: 'jul' }),
+      () => dbAssertions.connection('secondary').assertHas('users', { username: 'jul' }),
       /Expected table 'users' to have rows matching/
     )
   })
 
   test('assertMissing should query the configured connection', async () => {
     const db = await getMultiConnectionDb()
-    await db.connection('primary').table('users').insert({ username: 'jul', email: 'jul@adonisjs.com' })
+    await db
+      .connection('primary')
+      .table('users')
+      .insert({ username: 'jul', email: 'jul@adonisjs.com' })
 
     const app = new AppFactory().create(
       new URL('./', import.meta.url),
@@ -901,13 +906,16 @@ test.group('Database Test Assertions | connection', (group) => {
     await app.init()
     app.container.bind('lucid.db', () => db)
 
-    const secondaryAssertions = new DatabaseTestAssertions(app, 'secondary')
-    await secondaryAssertions.assertMissing('users', { username: 'jul' })
+    const dbAssertions = new DatabaseTestAssertions(app)
+    await dbAssertions.connection('secondary').assertMissing('users', { username: 'jul' })
   })
 
   test('assertCount should query the configured connection', async () => {
     const db = await getMultiConnectionDb()
-    await db.connection('primary').table('users').insert({ username: 'jul', email: 'jul@adonisjs.com' })
+    await db
+      .connection('primary')
+      .table('users')
+      .insert({ username: 'jul', email: 'jul@adonisjs.com' })
 
     const app = new AppFactory().create(
       new URL('./', import.meta.url),
@@ -916,11 +924,9 @@ test.group('Database Test Assertions | connection', (group) => {
     await app.init()
     app.container.bind('lucid.db', () => db)
 
-    const primaryAssertions = new DatabaseTestAssertions(app, 'primary')
-    await primaryAssertions.assertCount('users', 1)
-
-    const secondaryAssertions = new DatabaseTestAssertions(app, 'secondary')
-    await secondaryAssertions.assertCount('users', 0)
+    const dbAssertions = new DatabaseTestAssertions(app)
+    await dbAssertions.connection('primary').assertCount('users', 1)
+    await dbAssertions.connection('secondary').assertCount('users', 0)
   })
 
   test('assertModelExists should query the configured connection', async ({ assert }) => {
@@ -952,12 +958,11 @@ test.group('Database Test Assertions | connection', (group) => {
     await app.init()
     app.container.bind('lucid.db', () => db)
 
-    const primaryAssertions = new DatabaseTestAssertions(app, 'primary')
-    await primaryAssertions.assertModelExists(user)
+    const dbAssertions = new DatabaseTestAssertions(app)
+    await dbAssertions.connection('primary').assertModelExists(user)
 
-    const secondaryAssertions = new DatabaseTestAssertions(app, 'secondary')
     await assert.rejects(
-      () => secondaryAssertions.assertModelExists(user),
+      () => dbAssertions.connection('secondary').assertModelExists(user),
       /Expected 'User' model with primary key .+ to exist, but it was not found/
     )
   })
@@ -991,12 +996,11 @@ test.group('Database Test Assertions | connection', (group) => {
     await app.init()
     app.container.bind('lucid.db', () => db)
 
-    const secondaryAssertions = new DatabaseTestAssertions(app, 'secondary')
-    await secondaryAssertions.assertModelMissing(user)
+    const dbAssertions = new DatabaseTestAssertions(app)
+    await dbAssertions.connection('secondary').assertModelMissing(user)
 
-    const primaryAssertions = new DatabaseTestAssertions(app, 'primary')
     await assert.rejects(
-      () => primaryAssertions.assertModelMissing(user),
+      () => dbAssertions.connection('primary').assertModelMissing(user),
       /Expected 'User' model with primary key .+ to not exist, but it was found/
     )
   })

--- a/test/test_utils.spec.ts
+++ b/test/test_utils.spec.ts
@@ -28,6 +28,7 @@ import {
   createMigrationFile,
   getBaseModel,
   getDb,
+  getMultiConnectionDb,
   ormAdapter,
   resetTables,
   setup,
@@ -853,6 +854,150 @@ test.group('Database Test Assertions', (group) => {
     await assert.rejects(
       () => dbAssertions.assertModelMissing(user),
       `Expected 'User' model with primary key ${user.$primaryKeyValue} to not exist, but it was found`
+    )
+  })
+})
+
+test.group('Database Test Assertions | connection', (group) => {
+  group.each.disableTimeout()
+
+  group.each.setup(async () => {
+    const db = await getMultiConnectionDb()
+    return async () => {
+      await db.connection('primary').from('users').del()
+      await db.connection('secondary').from('users').del()
+    }
+  })
+
+  test('assertHas should query the configured connection', async ({ assert }) => {
+    const db = await getMultiConnectionDb()
+    await db.connection('primary').table('users').insert({ username: 'jul', email: 'jul@adonisjs.com' })
+
+    const app = new AppFactory().create(
+      new URL('./', import.meta.url),
+      () => {}
+    ) as ApplicationService
+    await app.init()
+    app.container.bind('lucid.db', () => db)
+
+    const primaryAssertions = new DatabaseTestAssertions(app, 'primary')
+    await primaryAssertions.assertHas('users', { username: 'jul' })
+
+    const secondaryAssertions = new DatabaseTestAssertions(app, 'secondary')
+    await assert.rejects(
+      () => secondaryAssertions.assertHas('users', { username: 'jul' }),
+      /Expected table 'users' to have rows matching/
+    )
+  })
+
+  test('assertMissing should query the configured connection', async () => {
+    const db = await getMultiConnectionDb()
+    await db.connection('primary').table('users').insert({ username: 'jul', email: 'jul@adonisjs.com' })
+
+    const app = new AppFactory().create(
+      new URL('./', import.meta.url),
+      () => {}
+    ) as ApplicationService
+    await app.init()
+    app.container.bind('lucid.db', () => db)
+
+    const secondaryAssertions = new DatabaseTestAssertions(app, 'secondary')
+    await secondaryAssertions.assertMissing('users', { username: 'jul' })
+  })
+
+  test('assertCount should query the configured connection', async () => {
+    const db = await getMultiConnectionDb()
+    await db.connection('primary').table('users').insert({ username: 'jul', email: 'jul@adonisjs.com' })
+
+    const app = new AppFactory().create(
+      new URL('./', import.meta.url),
+      () => {}
+    ) as ApplicationService
+    await app.init()
+    app.container.bind('lucid.db', () => db)
+
+    const primaryAssertions = new DatabaseTestAssertions(app, 'primary')
+    await primaryAssertions.assertCount('users', 1)
+
+    const secondaryAssertions = new DatabaseTestAssertions(app, 'secondary')
+    await secondaryAssertions.assertCount('users', 0)
+  })
+
+  test('assertModelExists should query the configured connection', async ({ assert }) => {
+    const db = await getMultiConnectionDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    class User extends BaseModel {
+      static table = 'users'
+
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare username: string
+
+      @column()
+      declare email: string
+    }
+
+    const user = new User()
+    user.fill({ username: 'jul', email: 'jul@adonisjs.com' })
+    await user.save()
+
+    const app = new AppFactory().create(
+      new URL('./', import.meta.url),
+      () => {}
+    ) as ApplicationService
+    await app.init()
+    app.container.bind('lucid.db', () => db)
+
+    const primaryAssertions = new DatabaseTestAssertions(app, 'primary')
+    await primaryAssertions.assertModelExists(user)
+
+    const secondaryAssertions = new DatabaseTestAssertions(app, 'secondary')
+    await assert.rejects(
+      () => secondaryAssertions.assertModelExists(user),
+      /Expected 'User' model with primary key .+ to exist, but it was not found/
+    )
+  })
+
+  test('assertModelMissing should query the configured connection', async ({ assert }) => {
+    const db = await getMultiConnectionDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    class User extends BaseModel {
+      static table = 'users'
+
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare username: string
+
+      @column()
+      declare email: string
+    }
+
+    const user = new User()
+    user.fill({ username: 'jul', email: 'jul@adonisjs.com' })
+    await user.save()
+
+    const app = new AppFactory().create(
+      new URL('./', import.meta.url),
+      () => {}
+    ) as ApplicationService
+    await app.init()
+    app.container.bind('lucid.db', () => db)
+
+    const secondaryAssertions = new DatabaseTestAssertions(app, 'secondary')
+    await secondaryAssertions.assertModelMissing(user)
+
+    const primaryAssertions = new DatabaseTestAssertions(app, 'primary')
+    await assert.rejects(
+      () => primaryAssertions.assertModelMissing(user),
+      /Expected 'User' model with primary key .+ to not exist, but it was found/
     )
   })
 })

--- a/test/test_utils.spec.ts
+++ b/test/test_utils.spec.ts
@@ -21,7 +21,7 @@ import { AppFactory } from '@adonisjs/core/factories/app'
 import { type ApplicationService } from '@adonisjs/core/types'
 import { DatabaseTestUtils } from '../src/test_utils/database.js'
 import { DatabaseTestAssertions } from '../src/test_utils/assertions.js'
-import { column } from '../src/orm/decorators/index.js'
+import { beforeFind, column } from '../src/orm/decorators/index.js'
 import {
   cleanupSchemaArtifacts,
   cleanupTestDatabase,
@@ -722,6 +722,92 @@ test.group('Database Test Assertions', (group) => {
     user.fill({ username: 'jul', email: 'jul@adonisjs.com' })
     await user.save()
     await user.delete()
+
+    const app = new AppFactory().create(
+      new URL('./', import.meta.url),
+      () => {}
+    ) as ApplicationService
+    await app.init()
+    app.container.bind('lucid.db', () => db)
+
+    const dbAssertions = new DatabaseTestAssertions(app)
+    await dbAssertions.assertModelMissing(user)
+  })
+
+  test('assertModelExists should respect beforeFind hooks', async ({ assert }) => {
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    class User extends BaseModel {
+      static table = 'users'
+
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare username: string
+
+      @column()
+      declare email: string
+
+      @column()
+      declare points: number
+
+      @beforeFind()
+      static applyActiveFilter(query: any) {
+        query.where('points', '>', 0)
+      }
+    }
+
+    const user = new User()
+    user.fill({ username: 'jul', email: 'jul@adonisjs.com', points: 0 })
+    await user.save()
+
+    const app = new AppFactory().create(
+      new URL('./', import.meta.url),
+      () => {}
+    ) as ApplicationService
+    await app.init()
+    app.container.bind('lucid.db', () => db)
+
+    const dbAssertions = new DatabaseTestAssertions(app)
+
+    await assert.rejects(
+      () => dbAssertions.assertModelExists(user),
+      `Expected 'User' model with primary key ${user.$primaryKeyValue} to exist, but it was not found`
+    )
+  })
+
+  test('assertModelMissing should respect beforeFind hooks', async () => {
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    class User extends BaseModel {
+      static table = 'users'
+
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare username: string
+
+      @column()
+      declare email: string
+
+      @column()
+      declare points: number
+
+      @beforeFind()
+      static applyActiveFilter(query: any) {
+        query.where('points', '>', 0)
+      }
+    }
+
+    const user = new User()
+    user.fill({ username: 'jul', email: 'jul@adonisjs.com', points: 0 })
+    await user.save()
 
     const app = new AppFactory().create(
       new URL('./', import.meta.url),

--- a/test/test_utils.spec.ts
+++ b/test/test_utils.spec.ts
@@ -862,12 +862,12 @@ if (process.env.DB === 'pg') {
     group.each.disableTimeout()
 
     test('assertHas should query the configured connection', async ({ assert, cleanup }) => {
+      const db = await getMultiConnectionDb()
       cleanup(async () => {
         await db.connection('primary').from('users').del()
         await db.connection('secondary').from('users').del()
       })
 
-      const db = await getMultiConnectionDb()
       await db
         .connection('primary')
         .table('users')

--- a/test/test_utils.spec.ts
+++ b/test/test_utils.spec.ts
@@ -469,407 +469,404 @@ test.group('Database Test Utils', (group) => {
   }).skip(!supportsSchemaDump, 'Schema dumps are not supported for the current database dialect')
 })
 
-if (process.env.DB === 'pg') {
-  test.group('Database Test Assertions', (group) => {
-    group.each.disableTimeout()
-    group.each.setup(async () => {
-      await setup()
-      return async () => await resetTables()
-    })
-
-    test('assertHas should pass when matching rows exist', async () => {
-      const db = getDb()
-      await db.table('users').insert({ username: 'jul', email: 'jul@adonisjs.com' })
-
-      const app = new AppFactory().create(
-        new URL('./', import.meta.url),
-        () => {}
-      ) as ApplicationService
-      await app.init()
-      app.container.bind('lucid.db', () => db)
-
-      const dbAssertions = new DatabaseTestAssertions(app)
-      await dbAssertions.assertHas('users', { username: 'jul' })
-    })
-
-    test('assertHas should fail when no matching rows exist', async () => {
-      const db = getDb()
-      const app = new AppFactory().create(
-        new URL('./', import.meta.url),
-        () => {}
-      ) as ApplicationService
-      await app.init()
-      app.container.bind('lucid.db', () => db)
-
-      const dbAssertions = new DatabaseTestAssertions(app)
-      await dbAssertions.assertHas('users', { username: 'nonexistent' })
-    }).throws(
-      `Expected table 'users' to have rows matching {"username":"nonexistent"}, but none were found`
-    )
-
-    test('assertHas should pass when matching exact count', async () => {
-      const db = getDb()
-      await db.table('users').multiInsert([
-        { username: 'jul', email: 'jul@adonisjs.com', points: 10 },
-        { username: 'romain', email: 'romain@adonisjs.com', points: 10 },
-      ])
-
-      const app = new AppFactory().create(
-        new URL('./', import.meta.url),
-        () => {}
-      ) as ApplicationService
-      await app.init()
-      app.container.bind('lucid.db', () => db)
-
-      const dbAssertions = new DatabaseTestAssertions(app)
-      await dbAssertions.assertHas('users', { points: 10 }, 2)
-    })
-
-    test('assertHas should fail when count does not match', async () => {
-      const db = getDb()
-      await db.table('users').insert({ username: 'jul', email: 'jul@adonisjs.com', points: 10 })
-
-      const app = new AppFactory().create(
-        new URL('./', import.meta.url),
-        () => {}
-      ) as ApplicationService
-      await app.init()
-      app.container.bind('lucid.db', () => db)
-
-      const dbAssertions = new DatabaseTestAssertions(app)
-      await dbAssertions.assertHas('users', { points: 10 }, 5)
-    }).throws(`Expected table 'users' to have 5 rows matching {"points":10}, but found 1`)
-
-    test('assertMissing should pass when no matching rows exist', async () => {
-      const db = getDb()
-      const app = new AppFactory().create(
-        new URL('./', import.meta.url),
-        () => {}
-      ) as ApplicationService
-      await app.init()
-      app.container.bind('lucid.db', () => db)
-
-      const dbAssertions = new DatabaseTestAssertions(app)
-      await dbAssertions.assertMissing('users', { username: 'jul' })
-    })
-
-    test('assertMissing should fail when matching rows exist', async () => {
-      const db = getDb()
-      await db.table('users').insert({ username: 'jul', email: 'jul@adonisjs.com' })
-
-      const app = new AppFactory().create(
-        new URL('./', import.meta.url),
-        () => {}
-      ) as ApplicationService
-      await app.init()
-      app.container.bind('lucid.db', () => db)
-
-      const dbAssertions = new DatabaseTestAssertions(app)
-      await dbAssertions.assertMissing('users', { username: 'jul' })
-    }).throws(`Expected table 'users' to have no rows matching {"username":"jul"}, but found 1`)
-
-    test('assertCount should pass with correct count', async () => {
-      const db = getDb()
-      await db.table('users').multiInsert([
-        { username: 'jul', email: 'jul@adonisjs.com' },
-        { username: 'romain', email: 'romain@adonisjs.com' },
-      ])
-
-      const app = new AppFactory().create(
-        new URL('./', import.meta.url),
-        () => {}
-      ) as ApplicationService
-      await app.init()
-      app.container.bind('lucid.db', () => db)
-
-      const dbAssertions = new DatabaseTestAssertions(app)
-      await dbAssertions.assertCount('users', 2)
-    })
-
-    test('assertCount should fail with incorrect count', async () => {
-      const db = getDb()
-      await db.table('users').insert({ username: 'jul', email: 'jul@adonisjs.com' })
-
-      const app = new AppFactory().create(
-        new URL('./', import.meta.url),
-        () => {}
-      ) as ApplicationService
-      await app.init()
-      app.container.bind('lucid.db', () => db)
-
-      const dbAssertions = new DatabaseTestAssertions(app)
-      await dbAssertions.assertCount('users', 5)
-    }).throws("Expected table 'users' to have 5 rows, but found 1")
-
-    test('assertEmpty should pass on empty table', async () => {
-      const db = getDb()
-      const app = new AppFactory().create(
-        new URL('./', import.meta.url),
-        () => {}
-      ) as ApplicationService
-      await app.init()
-      app.container.bind('lucid.db', () => db)
-
-      const dbAssertions = new DatabaseTestAssertions(app)
-      await dbAssertions.assertEmpty('users')
-    })
-
-    test('assertEmpty should fail on non-empty table', async () => {
-      const db = getDb()
-      await db.table('users').insert({ username: 'jul', email: 'jul@adonisjs.com' })
-
-      const app = new AppFactory().create(
-        new URL('./', import.meta.url),
-        () => {}
-      ) as ApplicationService
-      await app.init()
-      app.container.bind('lucid.db', () => db)
-
-      const dbAssertions = new DatabaseTestAssertions(app)
-      await dbAssertions.assertEmpty('users')
-    }).throws("Expected table 'users' to have 0 rows, but found 1")
-
-    test('assertModelExists should pass when model exists in db', async () => {
-      const db = getDb()
-      const adapter = ormAdapter(db)
-      const BaseModel = getBaseModel(adapter)
-
-      class User extends BaseModel {
-        static table = 'users'
-
-        @column({ isPrimary: true })
-        declare id: number
-
-        @column()
-        declare username: string
-
-        @column()
-        declare email: string
-      }
-
-      const user = new User()
-      user.fill({ username: 'jul', email: 'jul@adonisjs.com' })
-      await user.save()
-
-      const app = new AppFactory().create(
-        new URL('./', import.meta.url),
-        () => {}
-      ) as ApplicationService
-      await app.init()
-      app.container.bind('lucid.db', () => db)
-
-      const dbAssertions = new DatabaseTestAssertions(app)
-      await dbAssertions.assertModelExists(user)
-    })
-
-    test('assertModelExists should fail when model does not exist in db', async ({ assert }) => {
-      const db = getDb()
-      const adapter = ormAdapter(db)
-      const BaseModel = getBaseModel(adapter)
-
-      class User extends BaseModel {
-        static table = 'users'
-
-        @column({ isPrimary: true })
-        declare id: number
-
-        @column()
-        declare username: string
-
-        @column()
-        declare email: string
-      }
-
-      const user = new User()
-      user.fill({ username: 'jul', email: 'jul@adonisjs.com' })
-      await user.save()
-
-      const primaryKey = user.$primaryKeyValue
-      await user.delete()
-
-      const app = new AppFactory().create(
-        new URL('./', import.meta.url),
-        () => {}
-      ) as ApplicationService
-      await app.init()
-      app.container.bind('lucid.db', () => db)
-
-      const dbAssertions = new DatabaseTestAssertions(app)
-      await assert.rejects(
-        () => dbAssertions.assertModelExists(user),
-        `Expected 'User' model with primary key ${primaryKey} to exist, but it was not found`
-      )
-    })
-
-    test('assertModelMissing should pass when model does not exist in db', async () => {
-      const db = getDb()
-      const adapter = ormAdapter(db)
-      const BaseModel = getBaseModel(adapter)
-
-      class User extends BaseModel {
-        static table = 'users'
-
-        @column({ isPrimary: true })
-        declare id: number
-
-        @column()
-        declare username: string
-
-        @column()
-        declare email: string
-      }
-
-      const user = new User()
-      user.fill({ username: 'jul', email: 'jul@adonisjs.com' })
-      await user.save()
-      await user.delete()
-
-      const app = new AppFactory().create(
-        new URL('./', import.meta.url),
-        () => {}
-      ) as ApplicationService
-      await app.init()
-      app.container.bind('lucid.db', () => db)
-
-      const dbAssertions = new DatabaseTestAssertions(app)
-      await dbAssertions.assertModelMissing(user)
-    })
-
-    test('assertModelExists should respect beforeFind hooks', async ({ assert }) => {
-      const db = getDb()
-      const adapter = ormAdapter(db)
-      const BaseModel = getBaseModel(adapter)
-
-      class User extends BaseModel {
-        static table = 'users'
-
-        @column({ isPrimary: true })
-        declare id: number
-
-        @column()
-        declare username: string
-
-        @column()
-        declare email: string
-
-        @column()
-        declare points: number
-
-        @beforeFind()
-        static applyActiveFilter(query: any) {
-          query.where('points', '>', 0)
-        }
-      }
-
-      const user = new User()
-      user.fill({ username: 'jul', email: 'jul@adonisjs.com', points: 0 })
-      await user.save()
-
-      const app = new AppFactory().create(
-        new URL('./', import.meta.url),
-        () => {}
-      ) as ApplicationService
-      await app.init()
-      app.container.bind('lucid.db', () => db)
-
-      const dbAssertions = new DatabaseTestAssertions(app)
-
-      await assert.rejects(
-        () => dbAssertions.assertModelExists(user),
-        `Expected 'User' model with primary key ${user.$primaryKeyValue} to exist, but it was not found`
-      )
-    })
-
-    test('assertModelMissing should respect beforeFind hooks', async () => {
-      const db = getDb()
-      const adapter = ormAdapter(db)
-      const BaseModel = getBaseModel(adapter)
-
-      class User extends BaseModel {
-        static table = 'users'
-
-        @column({ isPrimary: true })
-        declare id: number
-
-        @column()
-        declare username: string
-
-        @column()
-        declare email: string
-
-        @column()
-        declare points: number
-
-        @beforeFind()
-        static applyActiveFilter(query: any) {
-          query.where('points', '>', 0)
-        }
-      }
-
-      const user = new User()
-      user.fill({ username: 'jul', email: 'jul@adonisjs.com', points: 0 })
-      await user.save()
-
-      const app = new AppFactory().create(
-        new URL('./', import.meta.url),
-        () => {}
-      ) as ApplicationService
-      await app.init()
-      app.container.bind('lucid.db', () => db)
-
-      const dbAssertions = new DatabaseTestAssertions(app)
-      await dbAssertions.assertModelMissing(user)
-    })
-
-    test('assertModelMissing should fail when model still exists in db', async ({ assert }) => {
-      const db = getDb()
-      const adapter = ormAdapter(db)
-      const BaseModel = getBaseModel(adapter)
-
-      class User extends BaseModel {
-        static table = 'users'
-
-        @column({ isPrimary: true })
-        declare id: number
-
-        @column()
-        declare username: string
-
-        @column()
-        declare email: string
-      }
-
-      const user = new User()
-      user.fill({ username: 'jul', email: 'jul@adonisjs.com' })
-      await user.save()
-
-      const app = new AppFactory().create(
-        new URL('./', import.meta.url),
-        () => {}
-      ) as ApplicationService
-      await app.init()
-      app.container.bind('lucid.db', () => db)
-
-      const dbAssertions = new DatabaseTestAssertions(app)
-      await assert.rejects(
-        () => dbAssertions.assertModelMissing(user),
-        `Expected 'User' model with primary key ${user.$primaryKeyValue} to not exist, but it was found`
-      )
-    })
+test.group('Database Test Assertions', (group) => {
+  group.each.disableTimeout()
+  group.each.setup(async () => {
+    await setup()
+    return async () => await resetTables()
   })
 
+  test('assertHas should pass when matching rows exist', async () => {
+    const db = getDb()
+    await db.table('users').insert({ username: 'jul', email: 'jul@adonisjs.com' })
+
+    const app = new AppFactory().create(
+      new URL('./', import.meta.url),
+      () => {}
+    ) as ApplicationService
+    await app.init()
+    app.container.bind('lucid.db', () => db)
+
+    const dbAssertions = new DatabaseTestAssertions(app)
+    await dbAssertions.assertHas('users', { username: 'jul' })
+  })
+
+  test('assertHas should fail when no matching rows exist', async () => {
+    const db = getDb()
+    const app = new AppFactory().create(
+      new URL('./', import.meta.url),
+      () => {}
+    ) as ApplicationService
+    await app.init()
+    app.container.bind('lucid.db', () => db)
+
+    const dbAssertions = new DatabaseTestAssertions(app)
+    await dbAssertions.assertHas('users', { username: 'nonexistent' })
+  }).throws(
+    `Expected table 'users' to have rows matching {"username":"nonexistent"}, but none were found`
+  )
+
+  test('assertHas should pass when matching exact count', async () => {
+    const db = getDb()
+    await db.table('users').multiInsert([
+      { username: 'jul', email: 'jul@adonisjs.com', points: 10 },
+      { username: 'romain', email: 'romain@adonisjs.com', points: 10 },
+    ])
+
+    const app = new AppFactory().create(
+      new URL('./', import.meta.url),
+      () => {}
+    ) as ApplicationService
+    await app.init()
+    app.container.bind('lucid.db', () => db)
+
+    const dbAssertions = new DatabaseTestAssertions(app)
+    await dbAssertions.assertHas('users', { points: 10 }, 2)
+  })
+
+  test('assertHas should fail when count does not match', async () => {
+    const db = getDb()
+    await db.table('users').insert({ username: 'jul', email: 'jul@adonisjs.com', points: 10 })
+
+    const app = new AppFactory().create(
+      new URL('./', import.meta.url),
+      () => {}
+    ) as ApplicationService
+    await app.init()
+    app.container.bind('lucid.db', () => db)
+
+    const dbAssertions = new DatabaseTestAssertions(app)
+    await dbAssertions.assertHas('users', { points: 10 }, 5)
+  }).throws(`Expected table 'users' to have 5 rows matching {"points":10}, but found 1`)
+
+  test('assertMissing should pass when no matching rows exist', async () => {
+    const db = getDb()
+    const app = new AppFactory().create(
+      new URL('./', import.meta.url),
+      () => {}
+    ) as ApplicationService
+    await app.init()
+    app.container.bind('lucid.db', () => db)
+
+    const dbAssertions = new DatabaseTestAssertions(app)
+    await dbAssertions.assertMissing('users', { username: 'jul' })
+  })
+
+  test('assertMissing should fail when matching rows exist', async () => {
+    const db = getDb()
+    await db.table('users').insert({ username: 'jul', email: 'jul@adonisjs.com' })
+
+    const app = new AppFactory().create(
+      new URL('./', import.meta.url),
+      () => {}
+    ) as ApplicationService
+    await app.init()
+    app.container.bind('lucid.db', () => db)
+
+    const dbAssertions = new DatabaseTestAssertions(app)
+    await dbAssertions.assertMissing('users', { username: 'jul' })
+  }).throws(`Expected table 'users' to have no rows matching {"username":"jul"}, but found 1`)
+
+  test('assertCount should pass with correct count', async () => {
+    const db = getDb()
+    await db.table('users').multiInsert([
+      { username: 'jul', email: 'jul@adonisjs.com' },
+      { username: 'romain', email: 'romain@adonisjs.com' },
+    ])
+
+    const app = new AppFactory().create(
+      new URL('./', import.meta.url),
+      () => {}
+    ) as ApplicationService
+    await app.init()
+    app.container.bind('lucid.db', () => db)
+
+    const dbAssertions = new DatabaseTestAssertions(app)
+    await dbAssertions.assertCount('users', 2)
+  })
+
+  test('assertCount should fail with incorrect count', async () => {
+    const db = getDb()
+    await db.table('users').insert({ username: 'jul', email: 'jul@adonisjs.com' })
+
+    const app = new AppFactory().create(
+      new URL('./', import.meta.url),
+      () => {}
+    ) as ApplicationService
+    await app.init()
+    app.container.bind('lucid.db', () => db)
+
+    const dbAssertions = new DatabaseTestAssertions(app)
+    await dbAssertions.assertCount('users', 5)
+  }).throws("Expected table 'users' to have 5 rows, but found 1")
+
+  test('assertEmpty should pass on empty table', async () => {
+    const db = getDb()
+    const app = new AppFactory().create(
+      new URL('./', import.meta.url),
+      () => {}
+    ) as ApplicationService
+    await app.init()
+    app.container.bind('lucid.db', () => db)
+
+    const dbAssertions = new DatabaseTestAssertions(app)
+    await dbAssertions.assertEmpty('users')
+  })
+
+  test('assertEmpty should fail on non-empty table', async () => {
+    const db = getDb()
+    await db.table('users').insert({ username: 'jul', email: 'jul@adonisjs.com' })
+
+    const app = new AppFactory().create(
+      new URL('./', import.meta.url),
+      () => {}
+    ) as ApplicationService
+    await app.init()
+    app.container.bind('lucid.db', () => db)
+
+    const dbAssertions = new DatabaseTestAssertions(app)
+    await dbAssertions.assertEmpty('users')
+  }).throws("Expected table 'users' to have 0 rows, but found 1")
+
+  test('assertModelExists should pass when model exists in db', async () => {
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    class User extends BaseModel {
+      static table = 'users'
+
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare username: string
+
+      @column()
+      declare email: string
+    }
+
+    const user = new User()
+    user.fill({ username: 'jul', email: 'jul@adonisjs.com' })
+    await user.save()
+
+    const app = new AppFactory().create(
+      new URL('./', import.meta.url),
+      () => {}
+    ) as ApplicationService
+    await app.init()
+    app.container.bind('lucid.db', () => db)
+
+    const dbAssertions = new DatabaseTestAssertions(app)
+    await dbAssertions.assertModelExists(user)
+  })
+
+  test('assertModelExists should fail when model does not exist in db', async ({ assert }) => {
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    class User extends BaseModel {
+      static table = 'users'
+
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare username: string
+
+      @column()
+      declare email: string
+    }
+
+    const user = new User()
+    user.fill({ username: 'jul', email: 'jul@adonisjs.com' })
+    await user.save()
+
+    const primaryKey = user.$primaryKeyValue
+    await user.delete()
+
+    const app = new AppFactory().create(
+      new URL('./', import.meta.url),
+      () => {}
+    ) as ApplicationService
+    await app.init()
+    app.container.bind('lucid.db', () => db)
+
+    const dbAssertions = new DatabaseTestAssertions(app)
+    await assert.rejects(
+      () => dbAssertions.assertModelExists(user),
+      `Expected 'User' model with primary key ${primaryKey} to exist, but it was not found`
+    )
+  })
+
+  test('assertModelMissing should pass when model does not exist in db', async () => {
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    class User extends BaseModel {
+      static table = 'users'
+
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare username: string
+
+      @column()
+      declare email: string
+    }
+
+    const user = new User()
+    user.fill({ username: 'jul', email: 'jul@adonisjs.com' })
+    await user.save()
+    await user.delete()
+
+    const app = new AppFactory().create(
+      new URL('./', import.meta.url),
+      () => {}
+    ) as ApplicationService
+    await app.init()
+    app.container.bind('lucid.db', () => db)
+
+    const dbAssertions = new DatabaseTestAssertions(app)
+    await dbAssertions.assertModelMissing(user)
+  })
+
+  test('assertModelExists should respect beforeFind hooks', async ({ assert }) => {
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    class User extends BaseModel {
+      static table = 'users'
+
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare username: string
+
+      @column()
+      declare email: string
+
+      @column()
+      declare points: number
+
+      @beforeFind()
+      static applyActiveFilter(query: any) {
+        query.where('points', '>', 0)
+      }
+    }
+
+    const user = new User()
+    user.fill({ username: 'jul', email: 'jul@adonisjs.com', points: 0 })
+    await user.save()
+
+    const app = new AppFactory().create(
+      new URL('./', import.meta.url),
+      () => {}
+    ) as ApplicationService
+    await app.init()
+    app.container.bind('lucid.db', () => db)
+
+    const dbAssertions = new DatabaseTestAssertions(app)
+
+    await assert.rejects(
+      () => dbAssertions.assertModelExists(user),
+      `Expected 'User' model with primary key ${user.$primaryKeyValue} to exist, but it was not found`
+    )
+  })
+
+  test('assertModelMissing should respect beforeFind hooks', async () => {
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    class User extends BaseModel {
+      static table = 'users'
+
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare username: string
+
+      @column()
+      declare email: string
+
+      @column()
+      declare points: number
+
+      @beforeFind()
+      static applyActiveFilter(query: any) {
+        query.where('points', '>', 0)
+      }
+    }
+
+    const user = new User()
+    user.fill({ username: 'jul', email: 'jul@adonisjs.com', points: 0 })
+    await user.save()
+
+    const app = new AppFactory().create(
+      new URL('./', import.meta.url),
+      () => {}
+    ) as ApplicationService
+    await app.init()
+    app.container.bind('lucid.db', () => db)
+
+    const dbAssertions = new DatabaseTestAssertions(app)
+    await dbAssertions.assertModelMissing(user)
+  })
+
+  test('assertModelMissing should fail when model still exists in db', async ({ assert }) => {
+    const db = getDb()
+    const adapter = ormAdapter(db)
+    const BaseModel = getBaseModel(adapter)
+
+    class User extends BaseModel {
+      static table = 'users'
+
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare username: string
+
+      @column()
+      declare email: string
+    }
+
+    const user = new User()
+    user.fill({ username: 'jul', email: 'jul@adonisjs.com' })
+    await user.save()
+
+    const app = new AppFactory().create(
+      new URL('./', import.meta.url),
+      () => {}
+    ) as ApplicationService
+    await app.init()
+    app.container.bind('lucid.db', () => db)
+
+    const dbAssertions = new DatabaseTestAssertions(app)
+    await assert.rejects(
+      () => dbAssertions.assertModelMissing(user),
+      `Expected 'User' model with primary key ${user.$primaryKeyValue} to not exist, but it was found`
+    )
+  })
+})
+
+if (process.env.DB === 'pg') {
   test.group('Database Test Assertions | connection', (group) => {
     group.each.disableTimeout()
 
-    group.each.setup(async () => {
-      const db = await getMultiConnectionDb()
-      return async () => {
+    test('assertHas should query the configured connection', async ({ assert, cleanup }) => {
+      cleanup(async () => {
         await db.connection('primary').from('users').del()
         await db.connection('secondary').from('users').del()
-      }
-    })
+      })
 
-    test('assertHas should query the configured connection', async ({ assert }) => {
       const db = await getMultiConnectionDb()
       await db
         .connection('primary')
@@ -892,8 +889,13 @@ if (process.env.DB === 'pg') {
       )
     })
 
-    test('assertMissing should query the configured connection', async () => {
+    test('assertMissing should query the configured connection', async ({ cleanup }) => {
       const db = await getMultiConnectionDb()
+      cleanup(async () => {
+        await db.connection('primary').from('users').del()
+        await db.connection('secondary').from('users').del()
+      })
+
       await db
         .connection('primary')
         .table('users')
@@ -910,8 +912,13 @@ if (process.env.DB === 'pg') {
       await dbAssertions.connection('secondary').assertMissing('users', { username: 'jul' })
     })
 
-    test('assertCount should query the configured connection', async () => {
+    test('assertCount should query the configured connection', async ({ cleanup }) => {
       const db = await getMultiConnectionDb()
+      cleanup(async () => {
+        await db.connection('primary').from('users').del()
+        await db.connection('secondary').from('users').del()
+      })
+
       await db
         .connection('primary')
         .table('users')
@@ -929,8 +936,16 @@ if (process.env.DB === 'pg') {
       await dbAssertions.connection('secondary').assertCount('users', 0)
     })
 
-    test('assertModelExists should query the configured connection', async ({ assert }) => {
+    test('assertModelExists should query the configured connection', async ({
+      assert,
+      cleanup,
+    }) => {
       const db = await getMultiConnectionDb()
+      cleanup(async () => {
+        await db.connection('primary').from('users').del()
+        await db.connection('secondary').from('users').del()
+      })
+
       const adapter = ormAdapter(db)
       const BaseModel = getBaseModel(adapter)
 
@@ -967,8 +982,16 @@ if (process.env.DB === 'pg') {
       )
     })
 
-    test('assertModelMissing should query the configured connection', async ({ assert }) => {
+    test('assertModelMissing should query the configured connection', async ({
+      assert,
+      cleanup,
+    }) => {
       const db = await getMultiConnectionDb()
+      cleanup(async () => {
+        await db.connection('primary').from('users').del()
+        await db.connection('secondary').from('users').del()
+      })
+
       const adapter = ormAdapter(db)
       const BaseModel = getBaseModel(adapter)
 


### PR DESCRIPTION
Added database assertion methods via a new `DatabaseTestAssertions` class and a japa plugin to expose them on the test context:

- `assertHas(table, data, count?)` => checks rows matching data exist
- `assertMissing(table, data)` => checks no rows match
- `assertCount(table, count)` => checks total row count
- `assertEmpty(table)` => checks table has no rows
- `assertModelExists(model)` => checks model instance exists in db by pk
- `assertModelMissing(model)` => checks model instance is gone

assertions live in their own class (`DatabaseTestAssertions`) separate from the lifecycle utils (`DatabaseTestUtils`). the two have different concerns:

- **`DatabaseTestUtils`** - migrate, truncate, seed, transaction wrapping. used in `group.each.setup()` via `testUtils.db()`
- **`DatabaseTestAssertions`** - assertHas, assertMissing, etc. used inside test bodies via `({ db }) =>`

the assertions are exposed via a Japa Plugin (`@adonisjs/lucid/plugins/db`)

## Setup

add the plugin to `tests/bootstrap.ts`:

```ts
import { dbAssertions } from '@adonisjs/lucid/plugins/db'

export const plugins: Config['plugins'] = [
  assert(),
  pluginAdonisJS(app),
  apiClient(),
  dbAssertions(app),
]
```

## Usage

```ts
import User from '#models/user'
import { test } from '@japa/runner'
import testUtils from '@adonisjs/core/services/test_utils'

test.group('Users', (group) => {
  group.each.setup(() => testUtils.db().truncate())

  test('registers a new user', async ({ client, db }) => {
    await client.post('/register').json({
      email: 'jul@test.com',
      password: 'secret123',
    })

    await db.assertHas('users', { email: 'jul@test.com' })
    await db.assertCount('users', 1)
  })

  test('promotes multiple users to admin', async ({ client, db }) => {
    await User.createMany([
      { email: 'a@test.com', password: 's', role: 'user' },
      { email: 'b@test.com', password: 's', role: 'user' },
    ])

    await client.post('/admin/promote-all')

    await db.assertHas('users', { role: 'admin' }, 2)
    await db.assertMissing('users', { role: 'user' })
  })

  test('deletes a user and cleans up tokens', async ({ client, db }) => {
    const user = await User.create({
      email: 'jul@test.com',
      password: 'secret123',
    })

    await client.delete(`/users/${user.id}`)

    await db.assertModelMissing(user)
    await db.assertEmpty('auth_access_tokens')
  })
})
```
