### PR TITLE
feat: expose Adapter db attribute and export SeedsRunner

### DIFF
--- a/src/orm/adapter/index.ts
+++ b/src/orm/adapter/index.ts
@@ -22,7 +22,7 @@ import {
  * model instances from it.
  */
 export class Adapter implements AdapterContract {
-  constructor(private db: Database) {}
+  constructor(protected db: Database) {}
 
   private getPrimaryKeyColumnName(Model: LucidModel) {
     return Model.$keys.attributesToColumns.get(Model.primaryKey, Model.primaryKey)

--- a/src/seeders/main.ts
+++ b/src/seeders/main.ts
@@ -8,3 +8,4 @@
  */
 
 export { BaseSeeder } from './base_seeder.js'
+export { SeedsRunner } from './runner.js'


### PR DESCRIPTION
### Description

This PR exposes the database instance in the adapter and exports `SeedsRunner` as part of the public API.

These changes are useful for extending Lucid, for example to support multi-tenancy use cases.