### PR TITLE
fix: exclude $columns from ModelAttributes inferred type

### DIFF
--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -93,12 +93,11 @@ export type OptionalTypedDecorator<PropType> = <
 /**
  * A complex type that filters out functions and relationships from the
  * model attributes and consider all other properties as database
- * columns. Alternatively, the user can self define a `$columns`
- * property.
+ * columns.
  */
 export type ModelAttributes<Model extends LucidRow> = {
   [Filtered in {
-    [P in keyof Model]: P extends keyof LucidRow | 'serializeExtras'
+    [P in keyof Model]: P extends keyof LucidRow | 'serializeExtras' | '$columns'
       ? never
       : Model[P] extends Function | ModelRelationTypes
         ? never


### PR DESCRIPTION
### 🔗 Linked issue
Closes #1175

### ❓ Type of change
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description
`$columns` was leaking into `ModelAttributes` because it is an instance property generated by the schema builder but was not excluded from the  inferred type.

This caused `$columns` to appear as a valid key in methods like `fill()`,  `merge()`, `create()`, etc.

The fix adds `'$columns'` to the exclusion condition in `ModelAttributes` (`src/types/model.ts`), the same way other `LucidRow` properties are excluded.

### 📝 Checklist
- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.