### PR TITLE
fix: change alias for transformer flag from 'c' to 't'

### DIFF
--- a/commands/make_model.ts
+++ b/commands/make_model.ts
@@ -50,7 +50,7 @@ export default class MakeModel extends BaseCommand {
    */
   @flags.boolean({
     name: 'transformer',
-    alias: 'c',
+    alias: 't',
     description: 'Generate the transformer for the model',
   })
   declare transformer: boolean


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently `-c` flag is used for both `transformer` and `controller`. Since Transformer comes later in the ordering, that one is made instead.

Currently when running `node ace make:model  -mc Price` it generates Price model, migration and transformer, but no controller

This bug also makes it impossible to make controllers using full flag names:

<img width="776" height="506" alt="image" src="https://github.com/user-attachments/assets/752c62ab-c67f-442b-804a-28851b97862a" />

Flagged it as breaking change also, since someone might rely on `--controller` generating transformer instead (which I kinda doupt tho)

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the command-line flag shortcut for the transformer option from `-c` to `-t`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->