### PR TITLE
Fix: Refactor table query to use pg_class and pg_namespace

### DIFF
--- a/src/dialects/pg.ts
+++ b/src/dialects/pg.ts
@@ -56,11 +56,14 @@ export class PgDialect implements DialectContract {
   #compileGetAllTables(schemas: string[]) {
     return this.client
       .query()
-      .from('pg_catalog.pg_tables')
-      .select(['tablename as name', 'schemaname as schema'])
-      .whereNotIn('schemaname', ['pg_catalog', 'information_schema'])
-      .whereIn('schemaname', schemas)
-      .orderBy('tablename', 'asc')
+      .from('pg_catalog.pg_class as c')
+      .join('pg_catalog.pg_namespace as n', 'n.oid', 'c.relnamespace')
+      .select(['c.relname as name', 'n.nspname as schema'])
+      .whereIn('c.relkind', ['r', 'p'])
+      .where('c.relispartition', false)
+      .whereNotIn('n.nspname', ['pg_catalog', 'information_schema'])
+      .whereIn('n.nspname', schemas)
+      .orderBy('c.relname', 'asc')
   }
 
   /**


### PR DESCRIPTION
### 🔗 Linked issue

Discussion: https://github.com/orgs/adonisjs/discussions/5114

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR fixes an issue where PostgreSQL partitions were being incorrectly returned as individual standalone tables when fetching schema definitions.

Previously, `#compileGetAllTables` queried `pg_catalog.pg_tables`, which inherently lists all child partitions as standard tables. 

The query was refactored to use `pg_catalog.pg_class` joined with `pg_catalog.pg_namespace`. By filtering the relation kind for standard and partitioned tables (`c.relkind IN ('r', 'p')`) and explicitly excluding the child partitions themselves (`c.relispartition = false`), the method now correctly returns only the parent table.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PostgreSQL table discovery to better handle partitioned tables and schema filtering, ensuring more accurate table identification across your databases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->