### PR TITLE
Feat: Add bigint and Array<bigint> to StrictValues type

### DIFF
--- a/src/types/querybuilder.ts
+++ b/src/types/querybuilder.ts
@@ -46,10 +46,12 @@ export type RawQuery =
 export type StrictValues =
   | string
   | number
+  | bigint
   | boolean
   | Date
   | Array<string>
   | Array<number>
+  | Array<bigint>
   | Array<Date>
   | Array<boolean>
   | Buffer

--- a/test/types/querybuilder_bigint.spec.ts
+++ b/test/types/querybuilder_bigint.spec.ts
@@ -1,0 +1,38 @@
+import { test } from '@japa/runner'
+import type { StrictValues, RawQueryBindings, RawQueryFn, ChainableContract } from '../../src/types/querybuilder.js'
+
+test.group('Types | QueryBuilder bigint', () => {
+  test('accept bigint in StrictValues/RawQueryBindings', ({ expectTypeOf }) => {
+    const v1: StrictValues = 1n
+    expectTypeOf(v1).toMatchTypeOf<bigint>()
+
+    const v2: StrictValues = [1n, 2n]
+    expectTypeOf(v2).toMatchTypeOf<bigint[]>()
+
+    const b1: RawQueryBindings = [1n]
+    expectTypeOf(b1).toMatchTypeOf<StrictValues[]>()
+
+    const b2: RawQueryBindings = { id: 1n }
+    expectTypeOf(b2).toMatchTypeOf<{ [key: string]: StrictValues }>()
+
+    type Builder = ChainableContract
+    const fn: RawQueryFn<Builder> = ((..._args: any[]) => ({} as Builder)) as any
+
+    fn('select ?', [1n])
+    fn('select :id', { id: 1n })
+  })
+
+  test('reject unsupported types', () => {
+    // @ts-expect-error
+    const v1: StrictValues = Symbol('nope')
+
+    // @ts-expect-error
+    const v2: StrictValues = [Symbol('nope')]
+
+    // @ts-expect-error
+    const b1: RawQueryBindings = [Symbol('nope')]
+
+    // @ts-expect-error
+    const b2: RawQueryBindings = { id: Symbol('nope') }
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Discussion: https://github.com/orgs/adonisjs/discussions/5115

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR fixes a TypeScript compilation error that occurs when passing `bigint` values to query builder methods (such as `.where()`).

Previously, using a `bigint` value resulted in the following type error:
`error TS2345: Argument of type 'number | bigint' is not assignable to parameter of type 'ChainableContract | StrictValues'.`

To resolve this, the `StrictValues` type definition in `src/types/querybuilder.ts` was updated to explicitly include `bigint`. It was added both as a primitive value and inside the `Array` type, ensuring that methods like `.whereIn()` also properly accept arrays containing `bigint` values.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `bigint` and `bigint` arrays in query value bindings and raw query parameters.

* **Tests**
  * Added type-level tests to verify `bigint` acceptance and to ensure unsupported types are rejected at compile time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->