### PR TITLE
feat: add db:create and db:drop commands

### DIFF
--- a/commands/db_create.ts
+++ b/commands/db_create.ts
@@ -1,0 +1,108 @@
+/*
+ * @adonisjs/lucid
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { BaseCommand, flags } from '@adonisjs/core/ace'
+import { type CommandOptions } from '@adonisjs/core/types/ace'
+import { DatabaseAdministrator } from '../src/database_administrator/index.js'
+
+export default class DbCreate extends BaseCommand {
+  static commandName = 'db:create'
+  static description = 'Create the database of the given connection'
+  static options: CommandOptions = {
+    startApp: true,
+  }
+
+  /**
+   * Choose a custom pre-defined connection. Otherwise, we use the
+   * default connection
+   */
+  @flags.string({ description: 'Define a custom database connection', alias: 'c' })
+  declare connection: string
+
+  /**
+   * Not a valid connection
+   */
+  private printNotAValidConnection(connection: string) {
+    this.logger.error(
+      `"${connection}" is not a valid connection name. Double check "config/database" file`
+    )
+  }
+
+  /**
+   * Run as a subcommand. Never close database connections or exit
+   * process inside this method
+   */
+  private async runAsSubCommand() {
+    const db = await this.app.container.make('lucid.db')
+    this.connection = this.connection || db.primaryConnectionName
+
+    /**
+     * Invalid database connection
+     */
+    const managerConnection = db.manager.get(this.connection)
+    if (!managerConnection) {
+      this.printNotAValidConnection(this.connection)
+      this.exitCode = 1
+      return
+    }
+
+    /**
+     * The database to create does not exist yet, therefore we cannot
+     * use the lucid connection and instead connect to the dialect
+     * maintenance database
+     */
+    const administrator = new DatabaseAdministrator(managerConnection.config)
+
+    try {
+      const databaseName = administrator.databaseName
+
+      if (await administrator.databaseExists()) {
+        this.logger.info(`Database "${databaseName}" already exists`)
+        return
+      }
+
+      await administrator.createDatabase()
+      this.logger.success(`Created database "${databaseName}"`)
+    } finally {
+      await administrator.disconnect()
+    }
+  }
+
+  /**
+   * Branching out, so that if required we can implement
+   * "runAsMain" separately from "runAsSubCommand".
+   *
+   * For now, they both are the same
+   */
+  private async runAsMain() {
+    await this.runAsSubCommand()
+  }
+
+  /**
+   * Handle command
+   */
+  async run(): Promise<void> {
+    if (this.isMain) {
+      await this.runAsMain()
+    } else {
+      await this.runAsSubCommand()
+    }
+  }
+
+  /**
+   * Lifecycle method invoked by ace after the "run"
+   * method.
+   */
+  async completed() {
+    if (this.isMain) {
+      const db = await this.app.container.make('lucid.db')
+      await db.manager.closeAll(true)
+    }
+  }
+}

--- a/commands/db_drop.ts
+++ b/commands/db_drop.ts
@@ -1,0 +1,142 @@
+/*
+ * @adonisjs/lucid
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { BaseCommand, flags } from '@adonisjs/core/ace'
+import { type CommandOptions } from '@adonisjs/core/types/ace'
+import { DatabaseAdministrator } from '../src/database_administrator/index.js'
+
+export default class DbDrop extends BaseCommand {
+  static commandName = 'db:drop'
+  static description = 'Drop the database of the given connection'
+  static options: CommandOptions = {
+    startApp: true,
+  }
+
+  /**
+   * Choose a custom pre-defined connection. Otherwise, we use the
+   * default connection
+   */
+  @flags.string({ description: 'Define a custom database connection', alias: 'c' })
+  declare connection: string
+
+  /**
+   * Force command execution in production
+   */
+  @flags.boolean({ description: 'Explicitly force command to run in production' })
+  declare force: boolean
+
+  /**
+   * Not a valid connection
+   */
+  private printNotAValidConnection(connection: string) {
+    this.logger.error(
+      `"${connection}" is not a valid connection name. Double check "config/database" file`
+    )
+  }
+
+  /**
+   * Prompts to take consent when dropping the database in production
+   */
+  private async takeProductionConsent(): Promise<boolean> {
+    const question = 'You are in production environment. Want to continue dropping the database?'
+    try {
+      return await this.prompt.confirm(question)
+    } catch (error) {
+      return false
+    }
+  }
+
+  /**
+   * Run as a subcommand. Never close database connections or exit
+   * process inside this method
+   */
+  private async runAsSubCommand() {
+    const db = await this.app.container.make('lucid.db')
+    this.connection = this.connection || db.primaryConnectionName
+
+    /**
+     * Continue with dropping the database when not in production
+     * or force flag is passed
+     */
+    let continueDrop = !this.app.inProduction || this.force
+    if (!continueDrop) {
+      continueDrop = await this.takeProductionConsent()
+    }
+
+    /**
+     * Do not continue when in prod and the prompt was cancelled
+     */
+    if (!continueDrop) {
+      return
+    }
+
+    /**
+     * Invalid database connection
+     */
+    const managerConnection = db.manager.get(this.connection)
+    if (!managerConnection) {
+      this.printNotAValidConnection(this.connection)
+      this.exitCode = 1
+      return
+    }
+
+    /**
+     * We cannot drop a database over a connection attached to it,
+     * therefore we do not use the lucid connection and instead
+     * connect to the dialect maintenance database
+     */
+    const administrator = new DatabaseAdministrator(managerConnection.config)
+
+    try {
+      const databaseName = administrator.databaseName
+
+      if (!(await administrator.databaseExists())) {
+        this.logger.info(`Database "${databaseName}" does not exist`)
+        return
+      }
+
+      await administrator.dropDatabase()
+      this.logger.success(`Dropped database "${databaseName}"`)
+    } finally {
+      await administrator.disconnect()
+    }
+  }
+
+  /**
+   * Branching out, so that if required we can implement
+   * "runAsMain" separately from "runAsSubCommand".
+   *
+   * For now, they both are the same
+   */
+  private async runAsMain() {
+    await this.runAsSubCommand()
+  }
+
+  /**
+   * Handle command
+   */
+  async run(): Promise<void> {
+    if (this.isMain) {
+      await this.runAsMain()
+    } else {
+      await this.runAsSubCommand()
+    }
+  }
+
+  /**
+   * Lifecycle method invoked by ace after the "run"
+   * method.
+   */
+  async completed() {
+    if (this.isMain) {
+      const db = await this.app.container.make('lucid.db')
+      await db.manager.closeAll(true)
+    }
+  }
+}

--- a/src/database_administrator/index.ts
+++ b/src/database_administrator/index.ts
@@ -1,0 +1,273 @@
+/*
+ * @adonisjs/lucid
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import knex, { Knex } from 'knex'
+import { existsSync } from 'node:fs'
+import { dirname } from 'node:path'
+import { mkdir, unlink } from 'node:fs/promises'
+
+import * as errors from '../errors.js'
+import LibSQLClient from '../clients/libsql.cjs'
+import type { ConnectionConfig } from '../types/database.js'
+
+/**
+ * The list of clients on which the administrator can create and
+ * drop databases
+ */
+const SUPPORTED_CLIENTS = [
+  'sqlite',
+  'sqlite3',
+  'better-sqlite3',
+  'libsql',
+  'mysql',
+  'mysql2',
+  'pg',
+  'postgres',
+  'postgresql',
+  'redshift',
+  'mssql',
+]
+
+/**
+ * The list of clients using a file backed database
+ */
+const FILE_BACKED_CLIENTS = ['sqlite', 'sqlite3', 'better-sqlite3', 'libsql']
+
+/**
+ * The list of clients speaking the PostgreSQL dialect
+ */
+const PG_CLIENTS = ['pg', 'postgres', 'postgresql', 'redshift']
+
+/**
+ * The list of clients speaking the MySQL dialect
+ */
+const MYSQL_CLIENTS = ['mysql', 'mysql2']
+
+/**
+ * Database administrator performs database level operations like creating
+ * or dropping a database.
+ *
+ * Since the database in question may not exist yet, we cannot use the
+ * regular lucid connections that are bound to the database defined
+ * inside the config file. Instead, we create a standalone knex
+ * connection to the maintenance database of the dialect
+ * ("postgres" for PostgreSQL, "master" for MSSQL and
+ * no database at all for MySQL).
+ */
+export class DatabaseAdministrator {
+  #config: ConnectionConfig
+
+  /**
+   * Reference to knex. The instance is lazily created when performing
+   * the first database level operation
+   */
+  #client?: Knex
+
+  constructor(config: ConnectionConfig) {
+    if (!SUPPORTED_CLIENTS.includes(config.client)) {
+      throw new errors.E_UNSUPPORTED_DB_ADMINISTRATION([config.client])
+    }
+
+    this.#config = config
+  }
+
+  /**
+   * A boolean to know if the connection uses a file backed
+   * database like sqlite or libsql
+   */
+  private usesFileDatabase(): boolean {
+    return FILE_BACKED_CLIENTS.includes(this.#config.client)
+  }
+
+  /**
+   * Returns the connection node after giving preference to the
+   * write replica connection (when replicas are in use)
+   */
+  private resolveConnectionNode() {
+    const { replicas, connection } = this.#config
+
+    if (!replicas) {
+      return connection
+    }
+
+    if (typeof replicas.write.connection === 'string' || typeof connection === 'string') {
+      return replicas.write.connection
+    }
+
+    return Object.assign({}, connection, replicas.write.connection)
+  }
+
+  /**
+   * Returns the path to the database file for file backed databases
+   */
+  private fileDatabasePath(): string {
+    return this.databaseName
+  }
+
+  /**
+   * Returns the connection node pointing to the maintenance database
+   * of the dialect. "CREATE DATABASE" and "DROP DATABASE" queries
+   * cannot run over a connection attached to the database in
+   * question
+   */
+  private getMaintenanceConnection() {
+    const connection = this.resolveConnectionNode()
+
+    if (PG_CLIENTS.includes(this.#config.client)) {
+      if (typeof connection === 'string') {
+        const url = new URL(connection)
+        url.pathname = '/postgres'
+        return url.toString()
+      }
+      return Object.assign({}, connection, { database: 'postgres' })
+    }
+
+    if (MYSQL_CLIENTS.includes(this.#config.client)) {
+      return Object.assign({}, connection, { database: undefined })
+    }
+
+    if (this.#config.client === 'mssql') {
+      return Object.assign({}, connection, { database: 'master' })
+    }
+
+    return connection
+  }
+
+  /**
+   * Lazily instantiates the knex connection to the maintenance
+   * database. For file backed databases, the connection points
+   * to the database file itself
+   */
+  private getClient(): Knex {
+    if (!this.#client) {
+      this.#client = knex.knex({
+        client: this.#config.client === 'libsql' ? (LibSQLClient as any) : this.#config.client,
+        connection: this.usesFileDatabase()
+          ? { filename: (this.resolveConnectionNode() as { filename: string }).filename }
+          : (this.getMaintenanceConnection() as Knex.Config['connection']),
+        useNullAsDefault: true,
+        debug: false,
+      })
+    }
+
+    return this.#client
+  }
+
+  /**
+   * Quotes the database name as per the dialect rules to avoid
+   * SQL injection via the database name
+   */
+  private quoteIdentifier(name: string): string {
+    if (MYSQL_CLIENTS.includes(this.#config.client)) {
+      return '`' + name.replace(/`/g, '``') + '`'
+    }
+
+    if (this.#config.client === 'mssql') {
+      return '[' + name.replace(/]/g, ']]') + ']'
+    }
+
+    return '"' + name.replace(/"/g, '""') + '"'
+  }
+
+  /**
+   * Returns the database name (the file path for file backed databases)
+   * resolved from the connection config
+   */
+  get databaseName(): string {
+    const connection = this.resolveConnectionNode()
+
+    if (typeof connection === 'string') {
+      return new URL(connection).pathname.slice(1)
+    }
+
+    if (connection && 'filename' in connection && connection.filename) {
+      return connection.filename.replace(/^file:/, '')
+    }
+
+    if (connection && 'database' in connection && connection.database) {
+      return connection.database
+    }
+
+    if (connection && 'connectionString' in connection && connection.connectionString) {
+      return new URL(connection.connectionString).pathname.slice(1)
+    }
+
+    throw new errors.E_MISSING_DATABASE_NAME([this.#config.client])
+  }
+
+  /**
+   * Returns a boolean to know if the database already exists
+   */
+  async databaseExists(): Promise<boolean> {
+    if (this.usesFileDatabase()) {
+      return existsSync(this.fileDatabasePath())
+    }
+
+    const client = this.getClient()
+    const databaseName = this.databaseName
+
+    if (MYSQL_CLIENTS.includes(this.#config.client)) {
+      const rows = await client
+        .from('information_schema.schemata')
+        .where('schema_name', databaseName)
+      return rows.length > 0
+    }
+
+    if (this.#config.client === 'mssql') {
+      const rows = await client.from('sys.databases').where('name', databaseName)
+      return rows.length > 0
+    }
+
+    const rows = await client.from('pg_database').where('datname', databaseName)
+    return rows.length > 0
+  }
+
+  /**
+   * Creates the database. For file backed databases, the database
+   * file is created (alongside missing intermediate directories)
+   */
+  async createDatabase(): Promise<void> {
+    if (this.usesFileDatabase()) {
+      await mkdir(dirname(this.fileDatabasePath()), { recursive: true })
+      await this.getClient().raw('SELECT 1')
+      return
+    }
+
+    await this.getClient().raw(`CREATE DATABASE ${this.quoteIdentifier(this.databaseName)}`)
+  }
+
+  /**
+   * Drops the database. For file backed databases, the database
+   * file is removed from the disk
+   */
+  async dropDatabase(): Promise<void> {
+    if (this.usesFileDatabase()) {
+      await this.disconnect()
+
+      const filePath = this.fileDatabasePath()
+      if (existsSync(filePath)) {
+        await unlink(filePath)
+      }
+      return
+    }
+
+    await this.getClient().raw(`DROP DATABASE ${this.quoteIdentifier(this.databaseName)}`)
+  }
+
+  /**
+   * Closes the connection to the maintenance database. The instance
+   * cannot be used after calling this method
+   */
+  async disconnect(): Promise<void> {
+    if (this.#client) {
+      await this.#client.destroy()
+      this.#client = undefined
+    }
+  }
+}

--- a/src/database_administrator/index.ts
+++ b/src/database_administrator/index.ts
@@ -7,47 +7,17 @@
  * file that was distributed with this source code.
  */
 
-import knex, { Knex } from 'knex'
+import knex, { type Knex } from 'knex'
 import { existsSync } from 'node:fs'
 import { dirname } from 'node:path'
 import { mkdir, unlink } from 'node:fs/promises'
+// @ts-expect-error
+import { resolveClientNameWithAliases } from 'knex/lib/util/helpers.js'
 
 import * as errors from '../errors.js'
 import LibSQLClient from '../clients/libsql.cjs'
-import type { ConnectionConfig } from '../types/database.js'
-
-/**
- * The list of clients on which the administrator can create and
- * drop databases
- */
-const SUPPORTED_CLIENTS = [
-  'sqlite',
-  'sqlite3',
-  'better-sqlite3',
-  'libsql',
-  'mysql',
-  'mysql2',
-  'pg',
-  'postgres',
-  'postgresql',
-  'redshift',
-  'mssql',
-]
-
-/**
- * The list of clients using a file backed database
- */
-const FILE_BACKED_CLIENTS = ['sqlite', 'sqlite3', 'better-sqlite3', 'libsql']
-
-/**
- * The list of clients speaking the PostgreSQL dialect
- */
-const PG_CLIENTS = ['pg', 'postgres', 'postgresql', 'redshift']
-
-/**
- * The list of clients speaking the MySQL dialect
- */
-const MYSQL_CLIENTS = ['mysql', 'mysql2']
+import { clientsToDialectsMapping } from '../dialects/index.js'
+import type { ConnectionConfig, DialectAdministrationContract } from '../types/database.js'
 
 /**
  * Database administrator performs database level operations like creating
@@ -56,12 +26,17 @@ const MYSQL_CLIENTS = ['mysql', 'mysql2']
  * Since the database in question may not exist yet, we cannot use the
  * regular lucid connections that are bound to the database defined
  * inside the config file. Instead, we create a standalone knex
- * connection to the maintenance database of the dialect
- * ("postgres" for PostgreSQL, "master" for MSSQL and
- * no database at all for MySQL).
+ * connection to the maintenance database of the dialect and
+ * delegate the dialect specific bits to the dialect
+ * "administration" implementation.
  */
 export class DatabaseAdministrator {
   #config: ConnectionConfig
+
+  /**
+   * Dialect specific implementation of the administration operations
+   */
+  #administration: DialectAdministrationContract
 
   /**
    * Reference to knex. The instance is lazily created when performing
@@ -70,11 +45,17 @@ export class DatabaseAdministrator {
   #client?: Knex
 
   constructor(config: ConnectionConfig) {
-    if (!SUPPORTED_CLIENTS.includes(config.client)) {
+    const clientName = resolveClientNameWithAliases(
+      config.client
+    ) as keyof typeof clientsToDialectsMapping
+
+    const administration = clientsToDialectsMapping[clientName]?.administration
+    if (!administration) {
       throw new errors.E_UNSUPPORTED_DB_ADMINISTRATION([config.client])
     }
 
     this.#config = config
+    this.#administration = administration
   }
 
   /**
@@ -82,7 +63,7 @@ export class DatabaseAdministrator {
    * database like sqlite or libsql
    */
   private usesFileDatabase(): boolean {
-    return FILE_BACKED_CLIENTS.includes(this.#config.client)
+    return this.#administration.usesFileDatabase === true
   }
 
   /**
@@ -117,26 +98,20 @@ export class DatabaseAdministrator {
    * question
    */
   private getMaintenanceConnection() {
+    if (this.#administration.usesFileDatabase) {
+      return this.resolveConnectionNode()
+    }
+
     const connection = this.resolveConnectionNode()
+    const { maintenanceDatabase } = this.#administration
 
-    if (PG_CLIENTS.includes(this.#config.client)) {
-      if (typeof connection === 'string') {
-        const url = new URL(connection)
-        url.pathname = '/postgres'
-        return url.toString()
-      }
-      return Object.assign({}, connection, { database: 'postgres' })
+    if (typeof connection === 'string') {
+      const url = new URL(connection)
+      url.pathname = maintenanceDatabase ? `/${maintenanceDatabase}` : '/'
+      return url.toString()
     }
 
-    if (MYSQL_CLIENTS.includes(this.#config.client)) {
-      return Object.assign({}, connection, { database: undefined })
-    }
-
-    if (this.#config.client === 'mssql') {
-      return Object.assign({}, connection, { database: 'master' })
-    }
-
-    return connection
+    return Object.assign({}, connection, { database: maintenanceDatabase ?? undefined })
   }
 
   /**
@@ -152,27 +127,16 @@ export class DatabaseAdministrator {
           ? { filename: (this.resolveConnectionNode() as { filename: string }).filename }
           : (this.getMaintenanceConnection() as Knex.Config['connection']),
         useNullAsDefault: true,
+        /**
+         * Debug is disabled like lucid does for its own knex instances,
+         * since this standalone connection does not go through the
+         * QueryClient instrumentation emitting "db:query" events
+         */
         debug: false,
       })
     }
 
     return this.#client
-  }
-
-  /**
-   * Quotes the database name as per the dialect rules to avoid
-   * SQL injection via the database name
-   */
-  private quoteIdentifier(name: string): string {
-    if (MYSQL_CLIENTS.includes(this.#config.client)) {
-      return '`' + name.replace(/`/g, '``') + '`'
-    }
-
-    if (this.#config.client === 'mssql') {
-      return '[' + name.replace(/]/g, ']]') + ']'
-    }
-
-    return '"' + name.replace(/"/g, '""') + '"'
   }
 
   /**
@@ -205,27 +169,11 @@ export class DatabaseAdministrator {
    * Returns a boolean to know if the database already exists
    */
   async databaseExists(): Promise<boolean> {
-    if (this.usesFileDatabase()) {
+    if (this.#administration.usesFileDatabase) {
       return existsSync(this.fileDatabasePath())
     }
 
-    const client = this.getClient()
-    const databaseName = this.databaseName
-
-    if (MYSQL_CLIENTS.includes(this.#config.client)) {
-      const rows = await client
-        .from('information_schema.schemata')
-        .where('schema_name', databaseName)
-      return rows.length > 0
-    }
-
-    if (this.#config.client === 'mssql') {
-      const rows = await client.from('sys.databases').where('name', databaseName)
-      return rows.length > 0
-    }
-
-    const rows = await client.from('pg_database').where('datname', databaseName)
-    return rows.length > 0
+    return this.#administration.databaseExists(this.getClient(), this.databaseName)
   }
 
   /**
@@ -239,7 +187,8 @@ export class DatabaseAdministrator {
       return
     }
 
-    await this.getClient().raw(`CREATE DATABASE ${this.quoteIdentifier(this.databaseName)}`)
+    const client = this.getClient()
+    await client.raw(`CREATE DATABASE ${client.ref(this.databaseName).toSQL().sql}`)
   }
 
   /**
@@ -257,7 +206,8 @@ export class DatabaseAdministrator {
       return
     }
 
-    await this.getClient().raw(`DROP DATABASE ${this.quoteIdentifier(this.databaseName)}`)
+    const client = this.getClient()
+    await client.raw(`DROP DATABASE ${client.ref(this.databaseName).toSQL().sql}`)
   }
 
   /**

--- a/src/dialects/base_sqlite.ts
+++ b/src/dialects/base_sqlite.ts
@@ -7,9 +7,23 @@
  * file that was distributed with this source code.
  */
 
-import type { DialectContract, QueryClientContract, SharedConfigNode } from '../types/database.js'
+import type {
+  DialectContract,
+  QueryClientContract,
+  SharedConfigNode,
+  DialectAdministrationContract,
+} from '../types/database.js'
 
 export abstract class BaseSqliteDialect implements DialectContract {
+  /**
+   * Database level administration operations for the dialect.
+   * The database lives inside a file on disk, created and
+   * removed from the filesystem directly
+   */
+  static administration: DialectAdministrationContract = {
+    usesFileDatabase: true,
+  }
+
   abstract readonly name: 'sqlite3' | 'better-sqlite3' | 'libsql'
   readonly supportsAdvisoryLocks = false
   readonly supportsViews = true

--- a/src/dialects/index.ts
+++ b/src/dialects/index.ts
@@ -20,11 +20,18 @@ import {
   type SharedConfigNode,
   type QueryClientContract,
   type ConnectionContract,
+  type DialectAdministrationContract,
 } from '../types/database.js'
 
 export const clientsToDialectsMapping: {
   [K in ConnectionContract['clientName']]: {
     new (client: QueryClientContract, config: SharedConfigNode): DialectContract
+
+    /**
+     * Database level administration operations. Not defined when the
+     * dialect does not support creating or dropping databases
+     */
+    administration?: DialectAdministrationContract
   }
 } = {
   'mssql': MssqlDialect,

--- a/src/dialects/mssql.ts
+++ b/src/dialects/mssql.ts
@@ -11,9 +11,21 @@ import {
   type DialectContract,
   type SharedConfigNode,
   type QueryClientContract,
+  type DialectAdministrationContract,
 } from '../types/database.js'
 
 export class MssqlDialect implements DialectContract {
+  /**
+   * Database level administration operations for the dialect
+   */
+  static administration: DialectAdministrationContract = {
+    maintenanceDatabase: 'master',
+    async databaseExists(client, databaseName) {
+      const rows = await client.from('sys.databases').where('name', databaseName)
+      return rows.length > 0
+    },
+  }
+
   readonly name = 'mssql'
   readonly supportsAdvisoryLocks = false
   readonly supportsViews = false

--- a/src/dialects/mysql.ts
+++ b/src/dialects/mysql.ts
@@ -12,9 +12,25 @@ import {
   type DialectContract,
   type SharedConfigNode,
   type QueryClientContract,
+  type DialectAdministrationContract,
 } from '../types/database.js'
 
 export class MysqlDialect implements DialectContract {
+  /**
+   * Database level administration operations for the dialect.
+   * MySQL accepts connections without a selected database,
+   * hence no maintenance database is needed
+   */
+  static administration: DialectAdministrationContract = {
+    maintenanceDatabase: null,
+    async databaseExists(client, databaseName) {
+      const rows = await client
+        .from('information_schema.schemata')
+        .where('schema_name', databaseName)
+      return rows.length > 0
+    },
+  }
+
   readonly name = 'mysql'
   readonly supportsAdvisoryLocks = true
   readonly supportsViews = true

--- a/src/dialects/pg.ts
+++ b/src/dialects/pg.ts
@@ -11,9 +11,21 @@ import {
   type DialectContract,
   type SharedConfigNode,
   type QueryClientContract,
+  type DialectAdministrationContract,
 } from '../types/database.js'
 
 export class PgDialect implements DialectContract {
+  /**
+   * Database level administration operations for the dialect
+   */
+  static administration: DialectAdministrationContract = {
+    maintenanceDatabase: 'postgres',
+    async databaseExists(client, databaseName) {
+      const rows = await client.from('pg_database').where('datname', databaseName)
+      return rows.length > 0
+    },
+  }
+
   readonly name = 'postgres'
   readonly supportsAdvisoryLocks = true
   readonly supportsViews = true

--- a/src/dialects/red_shift.ts
+++ b/src/dialects/red_shift.ts
@@ -11,9 +11,23 @@ import {
   type DialectContract,
   type SharedConfigNode,
   type QueryClientContract,
+  type DialectAdministrationContract,
 } from '../types/database.js'
 
 export class RedshiftDialect implements DialectContract {
+  /**
+   * Database level administration operations for the dialect.
+   * Redshift clusters ship with a default "dev" database
+   * acting as the maintenance database
+   */
+  static administration: DialectAdministrationContract = {
+    maintenanceDatabase: 'dev',
+    async databaseExists(client, databaseName) {
+      const rows = await client.from('pg_database').where('datname', databaseName)
+      return rows.length > 0
+    },
+  }
+
   readonly name = 'redshift'
   readonly supportsAdvisoryLocks = false
   readonly supportsViews = true

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -104,3 +104,21 @@ export const E_UNSUPPORTED_CLIENT = createError<[string]>(
   'E_UNSUPPORTED_CLIENT',
   500
 )
+
+/**
+ * The client does not support creating or dropping databases
+ */
+export const E_UNSUPPORTED_DB_ADMINISTRATION = createError<[string]>(
+  'Cannot create or drop a database when using "%s" client',
+  'E_UNSUPPORTED_DB_ADMINISTRATION',
+  500
+)
+
+/**
+ * The database name cannot be resolved from the connection config
+ */
+export const E_MISSING_DATABASE_NAME = createError<[string]>(
+  'Cannot resolve database name from the "%s" connection config',
+  'E_MISSING_DATABASE_NAME',
+  500
+)

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -92,6 +92,39 @@ export interface DialectContract {
 }
 
 /**
+ * Dialect specific implementation of database level administration
+ * operations like creating or dropping a database.
+ *
+ * The methods are static (exposed on the dialect class) since the
+ * database in question may not exist yet and therefore no lucid
+ * connection can be established.
+ */
+export type DialectAdministrationContract =
+  | {
+      /**
+       * The dialect stores the database inside a file on
+       * disk (sqlite, libsql)
+       */
+      usesFileDatabase: true
+    }
+  | {
+      usesFileDatabase?: false
+
+      /**
+       * The database to connect to when running "CREATE DATABASE"
+       * and "DROP DATABASE" queries. Set to null when the dialect
+       * accepts connections without a selected database (MySQL)
+       */
+      maintenanceDatabase: string | null
+
+      /**
+       * Returns a boolean to know if the given database exists. The
+       * client is connected to the maintenance database
+       */
+      databaseExists(client: Knex, databaseName: string): Promise<boolean>
+    }
+
+/**
  * Shape of the transaction function to create a new transaction
  */
 export interface TransactionFn {

--- a/test-helpers/index.ts
+++ b/test-helpers/index.ts
@@ -157,6 +157,40 @@ export function getConfig(): ConnectionConfig {
 }
 
 /**
+ * Returns a connection config pointing to a database dedicated to the
+ * "db:create" and "db:drop" commands tests, so that the database used
+ * by the rest of the test suite is never touched.
+ *
+ * MySQL requires a user with global "CREATE" privileges to create
+ * databases, therefore we connect using the root user.
+ */
+export function getDbManagementConfig(): ConnectionConfig {
+  const config = getConfig()
+
+  if (typeof config.connection === 'object' && 'filename' in config.connection) {
+    return {
+      ...config,
+      connection: {
+        ...config.connection,
+        filename:
+          config.client === 'libsql'
+            ? `file:${join(SQLITE_BASE_PATH, 'db-management.sqlite')}`
+            : join(SQLITE_BASE_PATH, 'db-management.sqlite'),
+      },
+    } as ConnectionConfig
+  }
+
+  return {
+    ...config,
+    connection: {
+      ...(config.connection as object),
+      ...(['mysql', 'mysql2'].includes(config.client) ? { user: 'root' } : {}),
+      database: 'lucid_db_management',
+    },
+  } as ConnectionConfig
+}
+
+/**
  * Returns an instance of knex for testing
  */
 export function getKnex(config: Knex.Config): Knex {

--- a/test/commands/db_create.spec.ts
+++ b/test/commands/db_create.spec.ts
@@ -1,0 +1,88 @@
+/*
+ * @adonisjs/lucid
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import 'reflect-metadata'
+import { test } from '@japa/runner'
+import { AceFactory } from '@adonisjs/core/factories'
+
+import DbCreate from '../../commands/db_create.js'
+import { type DatabaseConfig } from '../../src/types/database.js'
+import { getDb, getDbManagementConfig } from '../../test-helpers/index.js'
+import { DatabaseAdministrator } from '../../src/database_administrator/index.js'
+
+function getDatabaseConfig(): DatabaseConfig {
+  return {
+    connection: 'primary',
+    connections: {
+      primary: getDbManagementConfig(),
+    },
+  }
+}
+
+test.group('db:create', (group) => {
+  group.each.teardown(async () => {
+    const administrator = new DatabaseAdministrator(getDbManagementConfig())
+    try {
+      if (await administrator.databaseExists()) {
+        await administrator.dropDatabase()
+      }
+    } finally {
+      await administrator.disconnect()
+    }
+  })
+
+  test('create database', async ({ fs, assert }) => {
+    const ace = await new AceFactory().make(fs.baseUrl, { importer: () => {} })
+    await ace.app.init()
+    ace.app.container.singleton('lucid.db', () => getDb(undefined, getDatabaseConfig()))
+    ace.ui.switchMode('raw')
+
+    const dbCreate = await ace.create(DbCreate, [])
+    await dbCreate.exec()
+
+    const administrator = new DatabaseAdministrator(getDbManagementConfig())
+    try {
+      assert.isTrue(await administrator.databaseExists())
+    } finally {
+      await administrator.disconnect()
+    }
+  })
+
+  test('report when database already exists', async ({ fs }) => {
+    const administrator = new DatabaseAdministrator(getDbManagementConfig())
+    try {
+      await administrator.createDatabase()
+    } finally {
+      await administrator.disconnect()
+    }
+
+    const ace = await new AceFactory().make(fs.baseUrl, { importer: () => {} })
+    await ace.app.init()
+    ace.app.container.singleton('lucid.db', () => getDb(undefined, getDatabaseConfig()))
+    ace.ui.switchMode('raw')
+
+    const dbCreate = await ace.create(DbCreate, [])
+    await dbCreate.exec()
+
+    dbCreate.assertLogMatches(/already exists/)
+  })
+
+  test('print error when using an invalid connection name', async ({ fs, assert }) => {
+    const ace = await new AceFactory().make(fs.baseUrl, { importer: () => {} })
+    await ace.app.init()
+    ace.app.container.singleton('lucid.db', () => getDb(undefined, getDatabaseConfig()))
+    ace.ui.switchMode('raw')
+
+    const dbCreate = await ace.create(DbCreate, ['--connection', 'foo'])
+    await dbCreate.exec()
+
+    assert.equal(dbCreate.exitCode, 1)
+    dbCreate.assertLogMatches(/is not a valid connection name/)
+  })
+})

--- a/test/commands/db_drop.spec.ts
+++ b/test/commands/db_drop.spec.ts
@@ -73,6 +73,112 @@ test.group('db:drop', (group) => {
     dbDrop.assertLogMatches(/does not exist/)
   })
 
+  test('do not drop database in production when prompt is rejected', async ({
+    fs,
+    assert,
+    cleanup,
+  }) => {
+    process.env.NODE_ENV = 'production'
+    cleanup(() => {
+      delete process.env.NODE_ENV
+    })
+
+    const administrator = new DatabaseAdministrator(getDbManagementConfig())
+    try {
+      await administrator.createDatabase()
+    } finally {
+      await administrator.disconnect()
+    }
+
+    const ace = await new AceFactory().make(fs.baseUrl, { importer: () => {} })
+    await ace.app.init()
+    await ace.app.boot()
+    ace.app.container.singleton('lucid.db', () => getDb(undefined, getDatabaseConfig()))
+    ace.ui.switchMode('raw')
+
+    const dbDrop = await ace.create(DbDrop, [])
+    dbDrop.prompt
+      .trap('You are in production environment. Want to continue dropping the database?')
+      .reject()
+
+    await dbDrop.exec()
+
+    const postDropAdministrator = new DatabaseAdministrator(getDbManagementConfig())
+    try {
+      assert.isTrue(await postDropAdministrator.databaseExists())
+    } finally {
+      await postDropAdministrator.disconnect()
+    }
+  })
+
+  test('drop database in production when prompt is accepted', async ({ fs, assert, cleanup }) => {
+    process.env.NODE_ENV = 'production'
+    cleanup(() => {
+      delete process.env.NODE_ENV
+    })
+
+    const administrator = new DatabaseAdministrator(getDbManagementConfig())
+    try {
+      await administrator.createDatabase()
+    } finally {
+      await administrator.disconnect()
+    }
+
+    const ace = await new AceFactory().make(fs.baseUrl, { importer: () => {} })
+    await ace.app.init()
+    await ace.app.boot()
+    ace.app.container.singleton('lucid.db', () => getDb(undefined, getDatabaseConfig()))
+    ace.ui.switchMode('raw')
+
+    const dbDrop = await ace.create(DbDrop, [])
+    dbDrop.prompt
+      .trap('You are in production environment. Want to continue dropping the database?')
+      .accept()
+
+    await dbDrop.exec()
+
+    const postDropAdministrator = new DatabaseAdministrator(getDbManagementConfig())
+    try {
+      assert.isFalse(await postDropAdministrator.databaseExists())
+    } finally {
+      await postDropAdministrator.disconnect()
+    }
+  })
+
+  test('drop database in production when --force flag is passed', async ({
+    fs,
+    assert,
+    cleanup,
+  }) => {
+    process.env.NODE_ENV = 'production'
+    cleanup(() => {
+      delete process.env.NODE_ENV
+    })
+
+    const administrator = new DatabaseAdministrator(getDbManagementConfig())
+    try {
+      await administrator.createDatabase()
+    } finally {
+      await administrator.disconnect()
+    }
+
+    const ace = await new AceFactory().make(fs.baseUrl, { importer: () => {} })
+    await ace.app.init()
+    await ace.app.boot()
+    ace.app.container.singleton('lucid.db', () => getDb(undefined, getDatabaseConfig()))
+    ace.ui.switchMode('raw')
+
+    const dbDrop = await ace.create(DbDrop, ['--force'])
+    await dbDrop.exec()
+
+    const postDropAdministrator = new DatabaseAdministrator(getDbManagementConfig())
+    try {
+      assert.isFalse(await postDropAdministrator.databaseExists())
+    } finally {
+      await postDropAdministrator.disconnect()
+    }
+  })
+
   test('print error when using an invalid connection name', async ({ fs, assert }) => {
     const ace = await new AceFactory().make(fs.baseUrl, { importer: () => {} })
     await ace.app.init()

--- a/test/commands/db_drop.spec.ts
+++ b/test/commands/db_drop.spec.ts
@@ -1,0 +1,88 @@
+/*
+ * @adonisjs/lucid
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import 'reflect-metadata'
+import { test } from '@japa/runner'
+import { AceFactory } from '@adonisjs/core/factories'
+
+import DbDrop from '../../commands/db_drop.js'
+import { type DatabaseConfig } from '../../src/types/database.js'
+import { getDb, getDbManagementConfig } from '../../test-helpers/index.js'
+import { DatabaseAdministrator } from '../../src/database_administrator/index.js'
+
+function getDatabaseConfig(): DatabaseConfig {
+  return {
+    connection: 'primary',
+    connections: {
+      primary: getDbManagementConfig(),
+    },
+  }
+}
+
+test.group('db:drop', (group) => {
+  group.each.teardown(async () => {
+    const administrator = new DatabaseAdministrator(getDbManagementConfig())
+    try {
+      if (await administrator.databaseExists()) {
+        await administrator.dropDatabase()
+      }
+    } finally {
+      await administrator.disconnect()
+    }
+  })
+
+  test('drop database', async ({ fs, assert }) => {
+    const administrator = new DatabaseAdministrator(getDbManagementConfig())
+    try {
+      await administrator.createDatabase()
+    } finally {
+      await administrator.disconnect()
+    }
+
+    const ace = await new AceFactory().make(fs.baseUrl, { importer: () => {} })
+    await ace.app.init()
+    ace.app.container.singleton('lucid.db', () => getDb(undefined, getDatabaseConfig()))
+    ace.ui.switchMode('raw')
+
+    const dbDrop = await ace.create(DbDrop, [])
+    await dbDrop.exec()
+
+    const postDropAdministrator = new DatabaseAdministrator(getDbManagementConfig())
+    try {
+      assert.isFalse(await postDropAdministrator.databaseExists())
+    } finally {
+      await postDropAdministrator.disconnect()
+    }
+  })
+
+  test('report when database does not exist', async ({ fs }) => {
+    const ace = await new AceFactory().make(fs.baseUrl, { importer: () => {} })
+    await ace.app.init()
+    ace.app.container.singleton('lucid.db', () => getDb(undefined, getDatabaseConfig()))
+    ace.ui.switchMode('raw')
+
+    const dbDrop = await ace.create(DbDrop, [])
+    await dbDrop.exec()
+
+    dbDrop.assertLogMatches(/does not exist/)
+  })
+
+  test('print error when using an invalid connection name', async ({ fs, assert }) => {
+    const ace = await new AceFactory().make(fs.baseUrl, { importer: () => {} })
+    await ace.app.init()
+    ace.app.container.singleton('lucid.db', () => getDb(undefined, getDatabaseConfig()))
+    ace.ui.switchMode('raw')
+
+    const dbDrop = await ace.create(DbDrop, ['--connection', 'foo'])
+    await dbDrop.exec()
+
+    assert.equal(dbDrop.exitCode, 1)
+    dbDrop.assertLogMatches(/is not a valid connection name/)
+  })
+})


### PR DESCRIPTION
### 🔗 Linked

https://github.com/orgs/adonisjs/discussions/5104

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds two new ace commands to create and drop the database of a given connection, without relying on external scripts or `docker exec`. This brings Lucid on par with Rails (`rails db:create` / `rails db:drop`) and completes the existing database lifecycle commands (`db:wipe`, `db:truncate`, `db:seed`). Typical use cases: project bootstrap (`db:create` then `migration:run`), CI pipelines, and resetting local environments.

```sh
node ace db:create              # uses the default connection
node ace db:create -c mysql     # uses a custom connection

node ace db:drop                # asks for consent in production
node ace db:drop --force        # skips the production prompt

- [x] I have linked an issue or discussion.

I will gladly handle the documentation part with a follow-up PR on lucid.adonisjs.com once the API is validated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `db:create` and `db:drop` commands for managing databases via the CLI.
  * You can now choose a connection with `--connection/-c`; `db:drop` supports `--force` for non-interactive drops.
  * Database management is now supported across multiple dialects, including file-based workflows.

* **Bug Fixes**
  * Improved error reporting for invalid connection names and missing database name resolution.
  * More reliable database existence checks and guaranteed cleanup/disconnect behavior.

* **Tests**
  * Added command test coverage for create/drop, including production prompting behavior and invalid connection handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->