### PR TITLE
fix: treat a null local key as no related rows across all relation types

### DIFF
--- a/src/orm/relations/has_many/query_builder.ts
+++ b/src/orm/relations/has_many/query_builder.ts
@@ -13,7 +13,7 @@ import { type LucidRow, type LucidModel } from '../../../types/model.js'
 import { type HasManyQueryBuilderContract } from '../../../types/relations.js'
 
 import { type HasMany } from './index.js'
-import { getValue, unique } from '../../../utils/index.js'
+import { getNullableValue, unique } from '../../../utils/index.js'
 import { BaseQueryBuilder } from '../base/query_builder.js'
 
 /**
@@ -101,9 +101,11 @@ export class HasManyQueryBuilder
       this.wrapExisting().whereIn(
         this.relation.foreignKey,
         unique(
-          this.parent.map((model) => {
-            return getValue(model, this.relation.localKey, this.relation, queryAction)
-          })
+          this.parent
+            .map((model) => {
+              return getNullableValue(model, this.relation.localKey, this.relation, queryAction)
+            })
+            .filter((value) => value !== null)
         )
       )
       return
@@ -112,7 +114,12 @@ export class HasManyQueryBuilder
     /**
      * Query constraints
      */
-    const value = getValue(this.parent, this.relation.localKey, this.relation, queryAction)
+    const value = getNullableValue(this.parent, this.relation.localKey, this.relation, queryAction)
+    if (value === null) {
+      this.wrapExisting().whereIn(this.relation.foreignKey, [])
+      return
+    }
+
     this.wrapExisting().where(this.relation.foreignKey, value)
   }
 

--- a/src/orm/relations/has_many_through/query_builder.ts
+++ b/src/orm/relations/has_many_through/query_builder.ts
@@ -13,7 +13,7 @@ import { type LucidRow, type LucidModel } from '../../../types/model.js'
 import { type HasManyThroughQueryBuilderContract } from '../../../types/relations.js'
 
 import { type HasManyThrough } from './index.js'
-import { getValue, unique } from '../../../utils/index.js'
+import { getNullableValue, unique } from '../../../utils/index.js'
 import { BaseQueryBuilder } from '../base/query_builder.js'
 
 /**
@@ -81,9 +81,11 @@ export class HasManyThroughQueryBuilder
       builder.whereIn(
         this.prefixThroughTable(this.relation.foreignKeyColumnName),
         unique(
-          this.parent.map((model) => {
-            return getValue(model, this.relation.localKey, this.relation, queryAction)
-          })
+          this.parent
+            .map((model) => {
+              return getNullableValue(model, this.relation.localKey, this.relation, queryAction)
+            })
+            .filter((value) => value !== null)
         )
       )
       return
@@ -92,7 +94,12 @@ export class HasManyThroughQueryBuilder
     /**
      * Query constraints
      */
-    const value = getValue(this.parent, this.relation.localKey, this.relation, queryAction)
+    const value = getNullableValue(this.parent, this.relation.localKey, this.relation, queryAction)
+    if (value === null) {
+      builder.whereIn(this.prefixThroughTable(this.relation.foreignKeyColumnName), [])
+      return
+    }
+
     builder.where(this.prefixThroughTable(this.relation.foreignKeyColumnName), value)
   }
 

--- a/src/orm/relations/has_one/query_builder.ts
+++ b/src/orm/relations/has_one/query_builder.ts
@@ -12,7 +12,7 @@ import { type LucidRow } from '../../../types/model.js'
 import { type QueryClientContract } from '../../../types/database.js'
 
 import { type HasOne } from './index.js'
-import { getValue, unique } from '../../../utils/index.js'
+import { getNullableValue, unique } from '../../../utils/index.js'
 import { BaseQueryBuilder } from '../base/query_builder.js'
 
 /**
@@ -96,9 +96,11 @@ export class HasOneQueryBuilder extends BaseQueryBuilder {
       this.wrapExisting().whereIn(
         this.relation.foreignKey,
         unique(
-          this.parent.map((model) => {
-            return getValue(model, this.relation.localKey, this.relation, queryAction)
-          })
+          this.parent
+            .map((model) => {
+              return getNullableValue(model, this.relation.localKey, this.relation, queryAction)
+            })
+            .filter((value) => value !== null)
         )
       )
       return
@@ -107,8 +109,12 @@ export class HasOneQueryBuilder extends BaseQueryBuilder {
     /**
      * Query constraints
      */
-    const value = getValue(this.parent, this.relation.localKey, this.relation, queryAction)
-    this.wrapExisting().where(this.relation.foreignKey, value)
+    const value = getNullableValue(this.parent, this.relation.localKey, this.relation, queryAction)
+    if (value === null) {
+      this.wrapExisting().whereIn(this.relation.foreignKey, [])
+    } else {
+      this.wrapExisting().where(this.relation.foreignKey, value)
+    }
 
     /**
      * Do not add limit when updating or deleting

--- a/src/orm/relations/many_to_many/query_builder.ts
+++ b/src/orm/relations/many_to_many/query_builder.ts
@@ -15,7 +15,7 @@ import { type ManyToManyQueryBuilderContract } from '../../../types/relations.js
 
 import { type ManyToMany } from './index.js'
 import { PivotHelpers } from './pivot_helpers.js'
-import { getValue, unique } from '../../../utils/index.js'
+import { getNullableValue, unique } from '../../../utils/index.js'
 import { BaseQueryBuilder } from '../base/query_builder.js'
 
 /**
@@ -115,9 +115,11 @@ export class ManyToManyQueryBuilder
       this.wrapExisting().whereInPivot(
         this.relation.pivotForeignKey,
         unique(
-          this.parent.map((model) => {
-            return getValue(model, this.relation.localKey, this.relation, queryAction)
-          })
+          this.parent
+            .map((model) => {
+              return getNullableValue(model, this.relation.localKey, this.relation, queryAction)
+            })
+            .filter((value) => value !== null)
         )
       )
       return
@@ -126,7 +128,12 @@ export class ManyToManyQueryBuilder
     /**
      * Query constraints
      */
-    const value = getValue(this.parent, this.relation.localKey, this.relation, queryAction)
+    const value = getNullableValue(this.parent, this.relation.localKey, this.relation, queryAction)
+    if (value === null) {
+      this.wrapExisting().whereInPivot(this.relation.pivotForeignKey, [])
+      return
+    }
+
     this.wrapExisting().wherePivot(this.relation.pivotForeignKey, value)
   }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -108,7 +108,8 @@ export function ensureRelationIsBooted(relation: RelationshipsContract) {
 
 /**
  * Returns the value for a key from the model instance and raises descriptive
- * exception when the value is missing
+ * exception when the value is missing. The message names the actual state
+ * of the value, since a null key and an unselected key are fixed differently.
  */
 export function getValue(
   model: LucidRow | ModelObject,
@@ -117,8 +118,9 @@ export function getValue(
   action = 'preload'
 ) {
   return ensureValue(model, key, () => {
+    const state = (model as ModelObject)[key] === null ? 'null' : 'undefined'
     throw new Exception(
-      `Cannot ${action} "${relation.relationName}", value of "${relation.model.name}.${key}" is undefined`,
+      `Cannot ${action} "${relation.relationName}", value of "${relation.model.name}.${key}" is ${state}`,
       { status: 500 }
     )
   })

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -125,6 +125,29 @@ export function getValue(
 }
 
 /**
+ * Same as "getValue", but returns null instead of raising when the key
+ * value is null.
+ *
+ * A null key is a legitimate value: the row simply has no related rows.
+ * Only undefined is a programmer error, where the column was never
+ * selected. This mirrors how belongsTo already treats a nullable foreign
+ * key.
+ */
+export function getNullableValue(
+  model: LucidRow | ModelObject,
+  key: string,
+  relation: RelationshipsContract,
+  action = 'preload'
+) {
+  const value = (model as ModelObject)[key]
+  if (value === undefined) {
+    return getValue(model, key, relation, action)
+  }
+
+  return value
+}
+
+/**
  * Helper to find if value is a valid Object or
  * not
  */

--- a/test/orm/nullable_local_key.spec.ts
+++ b/test/orm/nullable_local_key.spec.ts
@@ -1,0 +1,282 @@
+/*
+ * @adonisjs/lucid
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { test } from '@japa/runner'
+import type {
+  BelongsTo,
+  HasMany,
+  HasManyThrough,
+  HasOne,
+  ManyToMany,
+} from '../../src/types/relations.js'
+
+import {
+  belongsTo,
+  column,
+  hasMany,
+  hasManyThrough,
+  hasOne,
+  manyToMany,
+} from '../../src/orm/decorators/index.js'
+
+import {
+  setup,
+  getDb,
+  cleanup,
+  ormAdapter,
+  resetTables,
+  getBaseModel,
+} from '../../test-helpers/index.js'
+import { AppFactory } from '@adonisjs/core/factories/app'
+
+/**
+ * A nullable local key is a legitimate value: the row simply has no related
+ * rows. Only an undefined key is a programmer error, where the column was
+ * never selected.
+ *
+ * belongsTo already draws that distinction. These tests assert the other
+ * relation types behave the same way.
+ */
+test.group('Nullable local key', (group) => {
+  group.setup(async () => {
+    await setup()
+  })
+
+  group.teardown(async () => {
+    await cleanup()
+  })
+
+  group.each.teardown(async () => {
+    await resetTables()
+  })
+
+  async function boot(fs: any) {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    return { db, BaseModel: getBaseModel(ormAdapter(db)) }
+  }
+
+  /**
+   * Two users, one with a tenant and one without, and a post belonging to
+   * the first user's tenant.
+   */
+  async function seed(db: any) {
+    await db
+      .insertQuery()
+      .table('users')
+      .insert([
+        { username: 'virk', tenant_id: 1 },
+        { username: 'nikk', tenant_id: null },
+      ])
+
+    await db
+      .insertQuery()
+      .table('posts')
+      .insert([{ title: 'Adonis 101', tenant_id: 1, user_id: 1 }])
+  }
+
+  test('belongsTo tolerates a null foreign key (existing behaviour)', async ({ fs, assert }) => {
+    const { db, BaseModel } = await boot(fs)
+
+    class Tenant extends BaseModel {
+      static table = 'posts'
+
+      @column({ isPrimary: true })
+      declare id: number
+    }
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare tenantId: number | null
+
+      @belongsTo(() => Tenant, { foreignKey: 'tenantId' })
+      declare tenant: BelongsTo<typeof Tenant>
+    }
+
+    await seed(db)
+
+    const users = await User.query().orderBy('id', 'asc').preload('tenant')
+    assert.lengthOf(users, 2)
+    assert.isNull(users[1].tenant)
+  })
+
+  test('hasMany tolerates a null local key', async ({ fs, assert }) => {
+    const { db, BaseModel } = await boot(fs)
+
+    class Post extends BaseModel {
+      @column()
+      declare tenantId: number | null
+    }
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare tenantId: number | null
+
+      @hasMany(() => Post, { foreignKey: 'tenantId', localKey: 'tenantId' })
+      declare posts: HasMany<typeof Post>
+    }
+
+    await seed(db)
+
+    const users = await User.query().orderBy('id', 'asc').preload('posts')
+    assert.lengthOf(users, 2)
+    assert.lengthOf(users[0].posts, 1)
+    assert.lengthOf(users[1].posts, 0)
+  })
+
+  test('hasOne tolerates a null local key', async ({ fs, assert }) => {
+    const { db, BaseModel } = await boot(fs)
+
+    class Post extends BaseModel {
+      @column()
+      declare tenantId: number | null
+    }
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare tenantId: number | null
+
+      @hasOne(() => Post, { foreignKey: 'tenantId', localKey: 'tenantId' })
+      declare post: HasOne<typeof Post>
+    }
+
+    await seed(db)
+
+    const users = await User.query().orderBy('id', 'asc').preload('post')
+    assert.lengthOf(users, 2)
+    assert.isNotNull(users[0].post)
+    assert.isNull(users[1].post)
+  })
+
+  test('manyToMany tolerates a null local key', async ({ fs, assert }) => {
+    const { db, BaseModel } = await boot(fs)
+
+    class Skill extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+    }
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare tenantId: number | null
+
+      @manyToMany(() => Skill, {
+        localKey: 'tenantId',
+        pivotForeignKey: 'user_id',
+        pivotTable: 'skill_user',
+      })
+      declare skills: ManyToMany<typeof Skill>
+    }
+
+    await seed(db)
+    await db
+      .insertQuery()
+      .table('skills')
+      .insert([{ name: 'Programming' }])
+    await db
+      .insertQuery()
+      .table('skill_user')
+      .insert([{ user_id: 1, skill_id: 1 }])
+
+    const users = await User.query().orderBy('id', 'asc').preload('skills')
+    assert.lengthOf(users, 2)
+    assert.lengthOf(users[0].skills, 1)
+    assert.lengthOf(users[1].skills, 0)
+  })
+
+  test('hasManyThrough tolerates a null local key', async ({ fs, assert }) => {
+    const { db, BaseModel } = await boot(fs)
+
+    class Post extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare userId: number
+
+      @column()
+      declare tenantId: number | null
+    }
+
+    class Comment extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare postId: number
+    }
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare tenantId: number | null
+
+      @hasManyThrough([() => Comment, () => Post], {
+        localKey: 'tenantId',
+        foreignKey: 'tenantId',
+        throughLocalKey: 'id',
+        throughForeignKey: 'postId',
+      })
+      declare comments: HasManyThrough<typeof Comment>
+    }
+
+    await seed(db)
+    await db
+      .insertQuery()
+      .table('comments')
+      .insert([{ post_id: 1, body: 'nice' }])
+
+    const users = await User.query().orderBy('id', 'asc').preload('comments')
+    assert.lengthOf(users, 2)
+    assert.lengthOf(users[0].comments, 1)
+    assert.lengthOf(users[1].comments, 0)
+  })
+
+  test('an unselected local key still raises', async ({ fs, assert }) => {
+    const { db, BaseModel } = await boot(fs)
+
+    class Post extends BaseModel {
+      @column()
+      declare tenantId: number | null
+    }
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare tenantId: number | null
+
+      @hasMany(() => Post, { foreignKey: 'tenantId', localKey: 'tenantId' })
+      declare posts: HasMany<typeof Post>
+    }
+
+    await seed(db)
+
+    await assert.rejects(
+      () => User.query().select('id').preload('posts'),
+      'Cannot preload "posts", value of "User.tenantId" is undefined'
+    )
+  })
+})

--- a/test/orm/nullable_local_key.spec.ts
+++ b/test/orm/nullable_local_key.spec.ts
@@ -68,108 +68,61 @@ test.group('Nullable local key', (group) => {
   }
 
   /**
-   * Two users, one with a tenant and one without, and a post belonging to
-   * the first user's tenant.
+   * Two users, one with a tenant and one without. The tenant id is
+   * deliberately different from the user id, so a test cannot pass by
+   * matching on the wrong column.
+   *
+   * One post belongs to the tenant. A second post is an orphan: its
+   * tenant and user are both null. A null local key must never match
+   * the orphan, since "where tenant_id is null" would.
    */
   async function seed(db: any) {
     await db
       .insertQuery()
       .table('users')
       .insert([
-        { username: 'virk', tenant_id: 1 },
+        { username: 'virk', tenant_id: 10 },
         { username: 'nikk', tenant_id: null },
       ])
 
     await db
       .insertQuery()
       .table('posts')
-      .insert([{ title: 'Adonis 101', tenant_id: 1, user_id: 1 }])
+      .insert([
+        { title: 'Adonis 101', tenant_id: 10, user_id: 1 },
+        { title: 'Orphan', tenant_id: null, user_id: null },
+      ])
   }
 
-  test('belongsTo tolerates a null foreign key (existing behaviour)', async ({ fs, assert }) => {
-    const { db, BaseModel } = await boot(fs)
-
-    class Tenant extends BaseModel {
-      static table = 'posts'
-
-      @column({ isPrimary: true })
-      declare id: number
-    }
-
-    class User extends BaseModel {
-      @column({ isPrimary: true })
-      declare id: number
-
-      @column()
-      declare tenantId: number | null
-
-      @belongsTo(() => Tenant, { foreignKey: 'tenantId' })
-      declare tenant: BelongsTo<typeof Tenant>
-    }
-
-    await seed(db)
-
-    const users = await User.query().orderBy('id', 'asc').preload('tenant')
-    assert.lengthOf(users, 2)
-    assert.isNull(users[1].tenant)
-  })
-
-  test('hasMany tolerates a null local key', async ({ fs, assert }) => {
-    const { db, BaseModel } = await boot(fs)
-
+  /**
+   * Declares every relation type keyed on the nullable tenant id, so
+   * the tests that exercise all of them share one definition.
+   */
+  function defineModels(BaseModel: ReturnType<typeof getBaseModel>) {
     class Post extends BaseModel {
-      @column()
-      declare tenantId: number | null
-    }
-
-    class User extends BaseModel {
       @column({ isPrimary: true })
       declare id: number
 
       @column()
-      declare tenantId: number | null
+      declare title: string
 
-      @hasMany(() => Post, { foreignKey: 'tenantId', localKey: 'tenantId' })
-      declare posts: HasMany<typeof Post>
-    }
+      @column()
+      declare userId: number | null
 
-    await seed(db)
-
-    const users = await User.query().orderBy('id', 'asc').preload('posts')
-    assert.lengthOf(users, 2)
-    assert.lengthOf(users[0].posts, 1)
-    assert.lengthOf(users[1].posts, 0)
-  })
-
-  test('hasOne tolerates a null local key', async ({ fs, assert }) => {
-    const { db, BaseModel } = await boot(fs)
-
-    class Post extends BaseModel {
       @column()
       declare tenantId: number | null
     }
 
-    class User extends BaseModel {
+    class Comment extends BaseModel {
       @column({ isPrimary: true })
       declare id: number
 
       @column()
-      declare tenantId: number | null
+      declare postId: number
 
-      @hasOne(() => Post, { foreignKey: 'tenantId', localKey: 'tenantId' })
-      declare post: HasOne<typeof Post>
+      @column()
+      declare body: string
     }
-
-    await seed(db)
-
-    const users = await User.query().orderBy('id', 'asc').preload('post')
-    assert.lengthOf(users, 2)
-    assert.isNotNull(users[0].post)
-    assert.isNull(users[1].post)
-  })
-
-  test('manyToMany tolerates a null local key', async ({ fs, assert }) => {
-    const { db, BaseModel } = await boot(fs)
 
     class Skill extends BaseModel {
       @column({ isPrimary: true })
@@ -183,6 +136,20 @@ test.group('Nullable local key', (group) => {
       @column()
       declare tenantId: number | null
 
+      @hasMany(() => Post, { foreignKey: 'tenantId', localKey: 'tenantId' })
+      declare posts: HasMany<typeof Post>
+
+      @hasOne(() => Post, { foreignKey: 'tenantId', localKey: 'tenantId' })
+      declare post: HasOne<typeof Post>
+
+      @hasManyThrough([() => Comment, () => Post], {
+        localKey: 'tenantId',
+        foreignKey: 'tenantId',
+        throughLocalKey: 'id',
+        throughForeignKey: 'postId',
+      })
+      declare comments: HasManyThrough<typeof Comment>
+
       @manyToMany(() => Skill, {
         localKey: 'tenantId',
         pivotForeignKey: 'user_id',
@@ -191,15 +158,95 @@ test.group('Nullable local key', (group) => {
       declare skills: ManyToMany<typeof Skill>
     }
 
-    await seed(db)
+    return { User, Post, Comment, Skill }
+  }
+
+  /**
+   * Rows for the through and pivot relations. Each has a counterpart
+   * hanging off a null key, so a null local key has something to
+   * wrongly match against.
+   */
+  async function seedThroughAndPivot(db: any) {
+    await db
+      .insertQuery()
+      .table('comments')
+      .insert([
+        { post_id: 1, body: 'On the tenant post' },
+        { post_id: 2, body: 'On the orphan post' },
+      ])
+
     await db
       .insertQuery()
       .table('skills')
       .insert([{ name: 'Programming' }])
+
     await db
       .insertQuery()
       .table('skill_user')
-      .insert([{ user_id: 1, skill_id: 1 }])
+      .insert([
+        { user_id: 10, skill_id: 1 },
+        { user_id: null, skill_id: 1 },
+      ])
+  }
+
+  test('belongsTo tolerates a null foreign key (existing behaviour)', async ({ fs, assert }) => {
+    const { db, BaseModel } = await boot(fs)
+
+    class User extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+    }
+
+    class Post extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare userId: number | null
+
+      @belongsTo(() => User)
+      declare user: BelongsTo<typeof User>
+    }
+
+    await seed(db)
+
+    const posts = await Post.query().orderBy('id', 'asc').preload('user')
+    assert.lengthOf(posts, 2)
+    assert.equal(posts[0].user.id, 1)
+    assert.isNull(posts[1].user)
+  })
+
+  test('hasMany tolerates a null local key', async ({ fs, assert }) => {
+    const { db, BaseModel } = await boot(fs)
+    const { User } = defineModels(BaseModel)
+
+    await seed(db)
+
+    const users = await User.query().orderBy('id', 'asc').preload('posts')
+    assert.lengthOf(users, 2)
+    assert.lengthOf(users[0].posts, 1)
+    assert.equal(users[0].posts[0].title, 'Adonis 101')
+    assert.lengthOf(users[1].posts, 0)
+  })
+
+  test('hasOne tolerates a null local key', async ({ fs, assert }) => {
+    const { db, BaseModel } = await boot(fs)
+    const { User } = defineModels(BaseModel)
+
+    await seed(db)
+
+    const users = await User.query().orderBy('id', 'asc').preload('post')
+    assert.lengthOf(users, 2)
+    assert.equal(users[0].post.title, 'Adonis 101')
+    assert.isNull(users[1].post)
+  })
+
+  test('manyToMany tolerates a null local key', async ({ fs, assert }) => {
+    const { db, BaseModel } = await boot(fs)
+    const { User } = defineModels(BaseModel)
+
+    await seed(db)
+    await seedThroughAndPivot(db)
 
     const users = await User.query().orderBy('id', 'asc').preload('skills')
     assert.lengthOf(users, 2)
@@ -209,106 +256,95 @@ test.group('Nullable local key', (group) => {
 
   test('hasManyThrough tolerates a null local key', async ({ fs, assert }) => {
     const { db, BaseModel } = await boot(fs)
-
-    class Post extends BaseModel {
-      @column({ isPrimary: true })
-      declare id: number
-
-      @column()
-      declare userId: number
-
-      @column()
-      declare tenantId: number | null
-    }
-
-    class Comment extends BaseModel {
-      @column({ isPrimary: true })
-      declare id: number
-
-      @column()
-      declare postId: number
-    }
-
-    class User extends BaseModel {
-      @column({ isPrimary: true })
-      declare id: number
-
-      @column()
-      declare tenantId: number | null
-
-      @hasManyThrough([() => Comment, () => Post], {
-        localKey: 'tenantId',
-        foreignKey: 'tenantId',
-        throughLocalKey: 'id',
-        throughForeignKey: 'postId',
-      })
-      declare comments: HasManyThrough<typeof Comment>
-    }
+    const { User } = defineModels(BaseModel)
 
     await seed(db)
-    await db
-      .insertQuery()
-      .table('comments')
-      .insert([{ post_id: 1, body: 'nice' }])
+    await seedThroughAndPivot(db)
 
     const users = await User.query().orderBy('id', 'asc').preload('comments')
     assert.lengthOf(users, 2)
     assert.lengthOf(users[0].comments, 1)
+    assert.equal(users[0].comments[0].body, 'On the tenant post')
     assert.lengthOf(users[1].comments, 0)
+  })
+
+  test('lazy load resolves a null local key to no related rows', async ({ fs, assert }) => {
+    const { db, BaseModel } = await boot(fs)
+    const { User } = defineModels(BaseModel)
+
+    await seed(db)
+    await seedThroughAndPivot(db)
+
+    const user = await User.findOrFail(2)
+    assert.isNull(user.tenantId)
+
+    await user.load('posts')
+    await user.load('post')
+    await user.load('comments')
+    await user.load('skills')
+
+    assert.lengthOf(user.posts, 0)
+    assert.isNull(user.post)
+    assert.lengthOf(user.comments, 0)
+    assert.lengthOf(user.skills, 0)
+  })
+
+  test('relationship query with a null local key matches no rows', async ({ fs, assert }) => {
+    const { db, BaseModel } = await boot(fs)
+    const { User } = defineModels(BaseModel)
+
+    await seed(db)
+    await seedThroughAndPivot(db)
+
+    const user = await User.findOrFail(2)
+
+    /**
+     * A naive "where tenant_id = null" becomes "where tenant_id is null"
+     * and would match the orphan rows. The constraint must be one that
+     * can never match.
+     */
+    assert.lengthOf(await user.related('posts').query(), 0)
+    assert.isNull(await user.related('post').query().first())
+    assert.lengthOf(await user.related('comments').query(), 0)
+    assert.lengthOf(await user.related('skills').query(), 0)
+  })
+
+  test('update and delete through a null local key touch no rows', async ({ fs, assert }) => {
+    const { db, BaseModel } = await boot(fs)
+    const { User } = defineModels(BaseModel)
+
+    await seed(db)
+
+    const user = await User.findOrFail(2)
+
+    await user.related('posts').query().update({ title: 'Changed' })
+    await user.related('post').query().update({ title: 'Changed' })
+    await user.related('posts').query().delete()
+
+    const posts = await db.from('posts').orderBy('id', 'asc').select('title')
+    assert.deepEqual(
+      posts.map((post: any) => post.title),
+      ['Adonis 101', 'Orphan']
+    )
+  })
+
+  test('persisting through a null local key still raises', async ({ fs, assert }) => {
+    const { db, BaseModel } = await boot(fs)
+    const { User } = defineModels(BaseModel)
+
+    await seed(db)
+
+    const user = await User.findOrFail(2)
+
+    await assert.rejects(
+      () => user.related('posts').create({ title: 'Adonis 102', userId: 2 }),
+      'Cannot persist "posts", value of "User.tenantId" is null'
+    )
   })
 
   test('an unselected local key still raises', async ({ fs, assert }) => {
     const { db, BaseModel } = await boot(fs)
-
-    class Post extends BaseModel {
-      @column({ isPrimary: true })
-      declare id: number
-
-      @column()
-      declare tenantId: number | null
-    }
-
-    class Comment extends BaseModel {
-      @column({ isPrimary: true })
-      declare id: number
-
-      @column()
-      declare postId: number
-    }
-
-    class Skill extends BaseModel {
-      @column({ isPrimary: true })
-      declare id: number
-    }
-
-    class User extends BaseModel {
-      @column({ isPrimary: true })
-      declare id: number
-
-      @column()
-      declare tenantId: number | null
-
-      @hasMany(() => Post, { foreignKey: 'tenantId', localKey: 'tenantId' })
-      declare posts: HasMany<typeof Post>
-
-      @hasOne(() => Post, { foreignKey: 'tenantId', localKey: 'tenantId' })
-      declare post: HasOne<typeof Post>
-
-      @hasManyThrough([() => Comment, () => Post], {
-        localKey: 'tenantId',
-        foreignKey: 'tenantId',
-        throughLocalKey: 'id',
-        throughForeignKey: 'postId',
-      })
-      declare comments: HasManyThrough<typeof Comment>
-
-      @manyToMany(() => Skill, {
-        localKey: 'tenantId',
-        pivotForeignKey: 'user_id',
-        pivotTable: 'skill_user',
-      })
-      declare skills: ManyToMany<typeof Skill>
-    }
+    const { User } = defineModels(BaseModel)
 
     await seed(db)
 

--- a/test/orm/nullable_local_key.spec.ts
+++ b/test/orm/nullable_local_key.spec.ts
@@ -56,6 +56,10 @@ test.group('Nullable local key', (group) => {
     await resetTables()
   })
 
+  /**
+   * Boots an app and returns the db alongside a fresh base model, so each
+   * test can declare its own models against the same connection.
+   */
   async function boot(fs: any) {
     const app = new AppFactory().create(fs.baseUrl, () => {})
     await app.init()
@@ -257,8 +261,24 @@ test.group('Nullable local key', (group) => {
     const { db, BaseModel } = await boot(fs)
 
     class Post extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
       @column()
       declare tenantId: number | null
+    }
+
+    class Comment extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
+
+      @column()
+      declare postId: number
+    }
+
+    class Skill extends BaseModel {
+      @column({ isPrimary: true })
+      declare id: number
     }
 
     class User extends BaseModel {
@@ -270,13 +290,38 @@ test.group('Nullable local key', (group) => {
 
       @hasMany(() => Post, { foreignKey: 'tenantId', localKey: 'tenantId' })
       declare posts: HasMany<typeof Post>
+
+      @hasOne(() => Post, { foreignKey: 'tenantId', localKey: 'tenantId' })
+      declare post: HasOne<typeof Post>
+
+      @hasManyThrough([() => Comment, () => Post], {
+        localKey: 'tenantId',
+        foreignKey: 'tenantId',
+        throughLocalKey: 'id',
+        throughForeignKey: 'postId',
+      })
+      declare comments: HasManyThrough<typeof Comment>
+
+      @manyToMany(() => Skill, {
+        localKey: 'tenantId',
+        pivotForeignKey: 'user_id',
+        pivotTable: 'skill_user',
+      })
+      declare skills: ManyToMany<typeof Skill>
     }
 
     await seed(db)
 
-    await assert.rejects(
-      () => User.query().select('id').preload('posts'),
-      'Cannot preload "posts", value of "User.tenantId" is undefined'
-    )
+    /**
+     * Every relation type routes through its own query builder, so each
+     * call site is asserted rather than assuming the shared helper covers
+     * them all.
+     */
+    for (const relation of ['posts', 'post', 'comments', 'skills'] as const) {
+      await assert.rejects(
+        () => User.query().select('id').preload(relation),
+        `Cannot preload "${relation}", value of "User.tenantId" is undefined`
+      )
+    }
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #1188

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`getValue` raises for `null` and `undefined` alike, so one row with a null local key made preload throw for the entire collection. `undefined` means the column was never selected, which is a programmer error, while `null` means the row simply has no related rows.

Adds `getNullableValue`, which raises only on `undefined`, and uses it in `hasMany`, `hasOne`, `hasManyThrough` and `manyToMany`. Null keys are filtered out of the `whereIn` on the eager branch, and the single-parent branch short-circuits to an empty `whereIn`.

`belongsTo` already behaved this way with a nullable foreign key, so this brings the other four in line rather than introducing new behaviour.

Two commits, so the bug is verifiable independently of the fix. Checking out the first alone gives four failing tests:

```
✔ belongsTo tolerates a null foreign key (existing behaviour)
✖ hasMany tolerates a null local key
✖ hasOne tolerates a null local key
✖ manyToMany tolerates a null local key
✖ hasManyThrough tolerates a null local key
✔ an unselected local key still raises
```

The `belongsTo` test and the undefined-key test pass either way, pinning the behaviour being matched and the diagnostic that must not be swallowed. The tests use the nullable `tenant_id` columns already present in `test-helpers`, so there are no schema changes.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

No documentation change: this aligns four relation types with the behaviour `belongsTo` already exhibits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed relationship queries involving null local keys across belongs-to, has-many, has-one, many-to-many, and through relationships.
  * Relationships now return empty results instead of applying incorrect null-value filters.
  * Improved missing-key errors to distinguish between null and undefined values.
  * Preserved error handling when required relationship keys are not selected.

* **Tests**
  * Added coverage for nullable local-key behavior, including loading, querying, updates, deletes, and persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->