### PR TITLE
fix: resolve real column names before table-qualified aliases during hydration

### DIFF
--- a/src/orm/base_model/index.ts
+++ b/src/orm/base_model/index.ts
@@ -1798,13 +1798,17 @@ class BaseModelImpl implements LucidRow {
          * Pull the attribute name from the column name, since adapter
          * results always holds the column names.
          *
-         * Try three lookups in order:
-         * 1. Table-qualified alias (e.g., "users_id")
-         * 2. Direct column name (e.g., "id") - for backward compatibility
-         * 3. Fallback to undefined
+         * Try two lookups in order:
+         * 1. Direct column name (e.g., "id")
+         * 2. Table-qualified alias (e.g., "users_id") - for aliased selections
+         *    made via "columnsForSelect"
+         *
+         * The real column name must win, otherwise a column literally named
+         * like another column's alias (e.g. "users_id" alongside "id") gets
+         * hydrated into the wrong attribute.
          */
         let attributeName =
-          Model.$keys.columnAliasesToAttributes.get(key) || Model.$keys.columnsToAttributes.get(key)
+          Model.$keys.columnsToAttributes.get(key) || Model.$keys.columnAliasesToAttributes.get(key)
 
         if (attributeName) {
           const attribute = Model.$getColumn(attributeName)!

--- a/test/orm/base_model.spec.ts
+++ b/test/orm/base_model.spec.ts
@@ -1842,6 +1842,56 @@ test.group('Base Model | create from adapter results', (group) => {
     assert.isTrue(user!.$isDirty)
     assert.deepEqual(user!.$dirty, { user: { username: 'nikk' } })
   })
+
+  test('hydrate table qualified column aliases', async ({ fs, assert }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const adapter = new FakeAdapter()
+
+    const BaseModel = getBaseModel(adapter)
+
+    class User extends BaseModel {
+      static table = 'users'
+
+      @column()
+      declare id: number
+
+      @column({ columnName: 'full_name' })
+      declare fullName: string
+    }
+
+    const user = User.$createFromAdapterResult({ users_id: 1, users_full_name: 'virk' })
+
+    assert.deepEqual(user!.$attributes, { id: 1, fullName: 'virk' })
+  })
+
+  test('give real column names precedence over column aliases', async ({ fs, assert }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const adapter = new FakeAdapter()
+
+    const BaseModel = getBaseModel(adapter)
+
+    class Semafor extends BaseModel {
+      static table = 'semafor'
+
+      @column()
+      declare url: string
+
+      @column({ columnName: 'semafor_url' })
+      declare semaforUrl: string
+    }
+
+    const semafor = Semafor.$createFromAdapterResult({
+      url: 'https://foo.com',
+      semafor_url: 'https://bar.com',
+    })
+
+    assert.deepEqual(semafor!.$attributes, {
+      url: 'https://foo.com',
+      semaforUrl: 'https://bar.com',
+    })
+  })
 })
 
 test.group('Base Model | delete', (group) => {


### PR DESCRIPTION
## Summary

Fixes #1191.

During `consumeAdapterResult`, the attribute lookup consulted `columnAliasesToAttributes` before `columnsToAttributes`. Alias keys are `${table}_${columnName}`, so any model with a column whose **real** name equals another column's alias collides: the alias entry wins and the value lands on the wrong attribute.

Concrete case: table `semafor` with columns `url` and `semafor_url`. The alias of `url` is `semafor_url`, so the `semafor_url` result key resolved to the `url` attribute, `semaforUrl` was never set, and both reads returned one value.

## Change

One-line ordering swap in `src/orm/base_model/index.ts` so the real column name resolves first:

```ts
let attributeName =
  Model.$keys.columnsToAttributes.get(key) || Model.$keys.columnAliasesToAttributes.get(key)
```

Un-aliased result keys — the overwhelming majority — must resolve to their own column, and an alias can never be the real name of the column it aliases, so nothing that relied on alias resolution regresses. Alias resolution still applies to genuinely aliased joined selections made via `columnsForSelect()`. The adjacent comment was updated to match the new order.

## Tests

Two tests added to the `Base Model | create from adapter results` group in `test/orm/base_model.spec.ts`:

- `hydrate table qualified column aliases` — guards the alias path, which had no coverage before; passes on both orderings.
- `give real column names precedence over column aliases` — the regression; fails on `22.x` with `{ url: 'https://bar.com' }` and passes with this change.

Run locally on Node 24: `npm run test:sqlite` (1494 passed, 6 skipped) and `npm run test:better_sqlite` (1492 passed, 6 skipped), plus `npm run lint`, `npm run typecheck`, and prettier over the changed files — all clean. The Docker-backed pg/mysql/mssql suites were not run locally (port conflict with another local database); the change is driver-agnostic in-memory attribute mapping, so CI coverage there should be sufficient.

This exact swap has been running in a production monorepo as a pnpm patch, with its full suite of 6,000+ tests green over it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved data loading when database columns and table-qualified aliases have conflicting names.
  - Ensures actual column values take precedence, preventing incorrect hydrated results.

- **Tests**
  - Added coverage for table-qualified aliases and column-name precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->