### PR TITLE
feat(schema): add foreignId helper

### DIFF
--- a/docs/AI-REFERENCE-MIGRATIONS.md
+++ b/docs/AI-REFERENCE-MIGRATIONS.md
@@ -375,6 +375,22 @@ async up() {
 
 ## Foreign Keys
 
+### Foreign ID
+
+Use `foreignId` to create a non-nullable unsigned big integer and its foreign key in one
+chain. Calling `constrained()` without arguments removes the `_id` suffix, pluralizes the
+remaining name, and references `id`. For example, `user_id` references `users.id`.
+
+```typescript
+table.foreignId('user_id').constrained().onDelete('CASCADE')
+
+// Override the inferred table, referenced column, and foreign key name
+table
+  .foreignId('author_id')
+  .nullable()
+  .constrained('members', 'member_id', 'posts_author_id_foreign')
+```
+
 ### Basic Foreign Key
 
 ```typescript

--- a/src/schema/main.ts
+++ b/src/schema/main.ts
@@ -26,8 +26,13 @@ knex.TableBuilder.extend<Knex.TableBuilder, ForeignIdColumnBuilder>(
     const column = this.bigInteger(columnName).unsigned().notNullable() as ForeignIdColumnBuilder
 
     column.constrained = (tableName, referencedColumn = 'id', foreignKeyName) => {
-      const suffixIndex = columnName.lastIndexOf(`_${referencedColumn}`)
-      const relatedName = suffixIndex === -1 ? columnName : columnName.slice(0, suffixIndex)
+      const referencedColumnSuffix = `_${referencedColumn}`
+      const suffix = columnName.endsWith(referencedColumnSuffix)
+        ? referencedColumnSuffix
+        : columnName.endsWith('_id')
+          ? '_id'
+          : ''
+      const relatedName = suffix ? columnName.slice(0, -suffix.length) : columnName
 
       return this.foreign(columnName, foreignKeyName)
         .references(referencedColumn)

--- a/src/schema/main.ts
+++ b/src/schema/main.ts
@@ -7,13 +7,36 @@
  * file that was distributed with this source code.
  */
 
-import type { Knex } from 'knex'
+import knex, { type Knex } from 'knex'
+import string from '@poppinss/utils/string'
 import { Exception } from '@poppinss/utils/exception'
 import { getDDLMethod } from '../utils/index.js'
-import type { DeferCallback } from '../types/schema.js'
+import type { DeferCallback, ForeignIdColumnBuilder } from '../types/schema.js'
 import { QueryReporter } from '../query_reporter/index.js'
 import type { QueryClientContract } from '../types/database.js'
 import type { RawQueryBindings } from '../types/querybuilder.js'
+
+/**
+ * Add a non-nullable unsigned big integer column that may be constrained
+ * using the conventional table name inferred from the column name.
+ */
+knex.TableBuilder.extend<Knex.TableBuilder, ForeignIdColumnBuilder>(
+  'foreignId',
+  function (columnName: string) {
+    const column = this.bigInteger(columnName).unsigned().notNullable() as ForeignIdColumnBuilder
+
+    column.constrained = (tableName, referencedColumn = 'id', foreignKeyName) => {
+      const suffixIndex = columnName.lastIndexOf(`_${referencedColumn}`)
+      const relatedName = suffixIndex === -1 ? columnName : columnName.slice(0, suffixIndex)
+
+      return this.foreign(columnName, foreignKeyName)
+        .references(referencedColumn)
+        .inTable(tableName ?? string.pluralize(relatedName))
+    }
+
+    return column
+  }
+)
 
 /**
  * Exposes the API to define table schema using deferred database

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -7,7 +7,30 @@
  * file that was distributed with this source code.
  */
 
+import type { Knex } from 'knex'
 import { type QueryClientContract } from './database.js'
+
+/**
+ * Column builder returned by the foreignId helper
+ */
+export interface ForeignIdColumnBuilder extends Knex.ColumnBuilder {
+  nullable(): ForeignIdColumnBuilder
+  notNullable(): ForeignIdColumnBuilder
+  unsigned(): ForeignIdColumnBuilder
+  constrained(
+    tableName?: string,
+    referencedColumnName?: string,
+    foreignKeyName?: string
+  ): Knex.ReferencingColumnBuilder
+}
+
+declare module 'knex' {
+  namespace Knex {
+    interface TableBuilder {
+      foreignId(columnName: string): ForeignIdColumnBuilder
+    }
+  }
+}
 
 /**
  * Shape of callback to defer database calls

--- a/test/migrations/schema.spec.ts
+++ b/test/migrations/schema.spec.ts
@@ -293,6 +293,7 @@ test.group('Schema', (group) => {
       .connection()
       .schema.createTable('posts', (table) => {
         table.foreignId('person_id').constrained().onDelete('CASCADE')
+        table.foreignId('user_id').constrained(undefined, 'uuid')
         table
           .foreignId('author_id')
           .nullable()
@@ -311,6 +312,7 @@ test.group('Schema', (group) => {
           .references('id')
           .inTable('people')
           .onDelete('CASCADE')
+        table.bigInteger('user_id').unsigned().notNullable().references('uuid').inTable('users')
         table.bigInteger('author_id').unsigned().nullable()
         table
           .foreign('author_id', 'posts_author_id_foreign')

--- a/test/migrations/schema.spec.ts
+++ b/test/migrations/schema.spec.ts
@@ -283,6 +283,46 @@ test.group('Schema', (group) => {
     assert.deepEqual(queries, [knexSchema])
   })
 
+  test('define conventional and explicit foreign IDs', async ({ assert, fs, cleanup }) => {
+    const app = new AppFactory().create(fs.baseUrl, () => {})
+    await app.init()
+    const db = getDb()
+    cleanup(() => db.manager.closeAll())
+
+    const foreignIdSchema = db
+      .connection()
+      .schema.createTable('posts', (table) => {
+        table.foreignId('person_id').constrained().onDelete('CASCADE')
+        table
+          .foreignId('author_id')
+          .nullable()
+          .constrained('members', 'member_id', 'posts_author_id_foreign')
+          .onUpdate('CASCADE')
+      })
+      .toSQL()
+
+    const knexSchema = db
+      .connection()
+      .schema.createTable('posts', (table) => {
+        table
+          .bigInteger('person_id')
+          .unsigned()
+          .notNullable()
+          .references('id')
+          .inTable('people')
+          .onDelete('CASCADE')
+        table.bigInteger('author_id').unsigned().nullable()
+        table
+          .foreign('author_id', 'posts_author_id_foreign')
+          .references('member_id')
+          .inTable('members')
+          .onUpdate('CASCADE')
+      })
+      .toSQL()
+
+    assert.deepEqual(foreignIdSchema, knexSchema)
+  })
+
   test('emit db:query event when schema instructions are executed', async ({
     assert,
     fs,


### PR DESCRIPTION
## Summary

- add `table.foreignId()` for non-nullable unsigned big integer columns
- add `constrained()` with conventional table-name inference
- support nullable columns and explicit table, referenced column, and constraint names
- include schema tests, TypeScript declarations, and AI reference documentation

## Testing

- `npm run lint`
- `npm run typecheck`
- `npm run test:sqlite -- --files test/migrations/schema.spec.ts`
- verified generated SQL parity with the expanded Knex chain for PostgreSQL, MySQL, SQLite, and MSSQL

Closes #1193


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `foreignId()` schema helper for creating unsigned, non-nullable foreign key columns.
  - Supports inferred or explicitly configured referenced tables, columns, and constraint names.
  - Supports nullable columns and cascading-delete configurations.

- **Documentation**
  - Added reference documentation with usage examples and configuration details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->